### PR TITLE
Fix email regex

### DIFF
--- a/App/utils/validateEmail.ts
+++ b/App/utils/validateEmail.ts
@@ -2,6 +2,6 @@
  * Validates whether a string is a valid email address.
  */
 export function validateEmail(email: string): boolean {
-  const regex = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/
+  const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
   return regex.test(email.toLowerCase())
 }


### PR DESCRIPTION
## Summary
- correct the regular expression used to validate email addresses

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*


------
https://chatgpt.com/codex/tasks/task_e_6845da19f9cc8330bea4c08eb4356495