### PR TITLE
Rename AskJesus to ReligionAI; expand onboarding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -33,7 +33,7 @@ import JoinOrganizationScreen from './App/screens/profile/JoinOrganizationScreen
 
 // Root-Level Screens
 import QuoteScreen from './App/screens/QuoteScreen';
-import AskJesusScreen from './App/screens/AskJesusScreen';
+import ReligionAIScreen from './App/screens/ReligionAIScreen';
 import JournalScreen from './App/screens/JournalScreen';
 import ConfessionalScreen from './App/screens/ConfessionalScreen';
 import BuyTokensScreen from './App/screens/BuyTokensScreen';
@@ -119,13 +119,13 @@ export default function App() {
             <Stack.Screen name="Quote" component={QuoteScreen} options={{ headerShown: false }} />
             <Stack.Screen name="SelectReligion" component={SelectReligionScreen} options={{ title: 'Select Religion' }} />
             <Stack.Screen name="Home" component={HomeScreen} />
-            <Stack.Screen name="WWJD" component={AskJesusScreen} options={{ title: 'WWJD' }} />
+            <Stack.Screen name="ReligionAI" component={ReligionAIScreen} options={{ title: 'Religion AI' }} />
             <Stack.Screen name="Journal" component={JournalScreen} options={{ title: 'Quiet Journal' }} />
             <Stack.Screen name="Streak" component={StreakScreen} options={{ title: 'Grace Streak' }} />
             <Stack.Screen name="Challenge" component={ChallengeScreen} options={{ title: 'Daily Challenge' }} />
             <Stack.Screen name="Confessional" component={ConfessionalScreen} options={{ title: 'Confessional' }} />
             <Stack.Screen name="BuyTokens" component={BuyTokensScreen} options={{ title: 'Buy Tokens' }} />
-            <Stack.Screen name="Upgrade" component={UpgradeScreen} options={{ title: 'Upgrade to WWJD+' }} />
+            <Stack.Screen name="Upgrade" component={UpgradeScreen} options={{ title: 'Upgrade to OneVine+' }} />
             <Stack.Screen name="GiveBack" component={GiveBackScreen} options={{ title: 'Give Back' }} />
             <Stack.Screen name="Profile" component={ProfileScreen} />
             <Stack.Screen name="Settings" component={SettingsScreen} />

--- a/App/navigation/MainTabNavigator.tsx
+++ b/App/navigation/MainTabNavigator.tsx
@@ -5,7 +5,7 @@ import { theme } from "@/components/theme/theme";
 
 // Screens
 import HomeScreen from "@/screens/dashboard/HomeScreen";
-import AskJesusScreen from "@/screens/AskJesusScreen";
+import ReligionAIScreen from "@/screens/ReligionAIScreen";
 import JournalScreen from "@/screens/JournalScreen";
 import ChallengeScreen from "@/screens/dashboard/ChallengeScreen";
 import ConfessionalScreen from "@/screens/ConfessionalScreen";
@@ -33,7 +33,7 @@ export default function MainTabNavigator() {
           switch (route.name) {
             case 'Home':
               return <Ionicons name="home-outline" size={size} color={color} />;
-            case 'WWJD':
+            case 'ReligionAI':
               return <MaterialCommunityIcons name="cross" size={size} color={color} />;
             case 'Journal':
               return <Ionicons name="book-outline" size={size} color={color} />;
@@ -56,7 +56,7 @@ export default function MainTabNavigator() {
       })}
     >
       <Tab.Screen name="Home" component={HomeScreen as React.ComponentType<any>} />
-      <Tab.Screen name="WWJD" component={AskJesusScreen as React.ComponentType<any>} />
+      <Tab.Screen name="ReligionAI" component={ReligionAIScreen as React.ComponentType<any>} />
       <Tab.Screen name="Journal" component={JournalScreen as React.ComponentType<any>} />
       <Tab.Screen name="Challenge" component={ChallengeScreen as React.ComponentType<any>} />
       <Tab.Screen name="Confessional" component={ConfessionalScreen as React.ComponentType<any>} />

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -19,7 +19,7 @@ export type RootStackParamList = {
 
   // Main app screens
   Home: undefined;
-  WWJD: undefined;
+  ReligionAI: undefined;
   Journal: undefined;
   Streak: undefined;
   Challenge: undefined;

--- a/App/navigation/screens.ts
+++ b/App/navigation/screens.ts
@@ -9,7 +9,7 @@ export const SCREENS = {
 
   MAIN: {
     HOME: 'Home',
-    WWJD: 'WWJD',
+    RELIGION_AI: 'ReligionAI',
     JOURNAL: 'Journal',
     CHALLENGE: 'Challenge',
     CONFESSIONAL: 'Confessional',

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -12,7 +12,7 @@ import {
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import { firebaseAuth } from "@/config/firebaseConfig"; // ✅ fixed import
+import { firebaseAuth, db } from "@/config/firebaseConfig"; // ✅ fixed import
 
 export default function ConfessionalScreen() {
   const [confession, setConfession] = useState('');
@@ -30,6 +30,17 @@ export default function ConfessionalScreen() {
       const user = firebaseAuth.currentUser;
       if (!user) return;
 
+      const userRef = db.collection('users').doc(user.uid);
+      const userSnap = await userRef.get();
+      const userData = userSnap.data() || {};
+      const religion = userData.religion || 'Spiritual Guide';
+      const role = religion === 'Christianity' ? 'Pastor' :
+                   religion === 'Islam' ? 'Imam' :
+                   religion === 'Hinduism' ? 'Guru' :
+                   religion === 'Buddhism' ? 'Teacher' :
+                   religion === 'Judaism' ? 'Rabbi' :
+                   'Spiritual Guide';
+
       const idToken = await user.getIdToken();
       const res = await fetch(ASK_GEMINI_SIMPLE, {
         method: 'POST',
@@ -38,7 +49,7 @@ export default function ConfessionalScreen() {
           Authorization: `Bearer ${idToken}`,
         },
         body: JSON.stringify({
-          prompt: `User confession: ${confession}\nJesus:`,
+          prompt: `User confession: ${confession}\n${role}:`,
         }),
       });
 

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -15,7 +15,7 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_V2 } from "@/utils/constants";
 import { firebaseAuth, db } from "@/config/firebaseConfig";
 
-export default function AskJesusScreen() {
+export default function ReligionAIScreen() {
   const [question, setQuestion] = useState('');
   const [messages, setMessages] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
@@ -96,7 +96,9 @@ export default function AskJesusScreen() {
           Authorization: `Bearer ${idToken}`,
         },
         body: JSON.stringify({
-          prompt: `${conversationContext}\nUser: ${question}\n${promptRole}:`,
+          prompt: `You are a ${promptRole} of the ${religion} faith. ` +
+            `Answer the user using teachings from that tradition and cite any ` +
+            `relevant scriptures.\n${conversationContext}\nUser: ${question}\n${promptRole}:`,
         }),
       });
 
@@ -111,7 +113,7 @@ export default function AskJesusScreen() {
 
       setQuestion('');
     } catch (err) {
-      console.error('❌ AskJesus error:', err);
+      console.error('❌ ReligionAI error:', err);
       Alert.alert('Error', 'Could not get a response. Please try again later.');
     } finally {
       setLoading(false);
@@ -132,7 +134,7 @@ export default function AskJesusScreen() {
 
         {isSubscribed && (
           <View style={styles.subscriptionBanner}>
-            <Text style={styles.subscriptionText}>💎 WWJD+ Unlimited Chat Enabled</Text>
+            <Text style={styles.subscriptionText}>💎 OneVine+ Unlimited Chat Enabled</Text>
             <Button title="Clear Conversation" onPress={handleClear} color={theme.colors.accent} />
           </View>
         )}

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet, Alert, TextInput } from 'react-native';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from "@/components/common/Button";
 import { useNavigation, CommonActions } from '@react-navigation/native';
@@ -19,6 +19,9 @@ export default function OnboardingScreen() {
   const user = useUserStore((state: any) => state.user);
   const navigation = useNavigation<OnboardingScreenProps['navigation']>();
   const [religion, setReligion] = useState(user?.religion ?? 'Christian');
+  const [username, setUsername] = useState(user?.displayName ?? '');
+  const [region, setRegion] = useState('');
+  const [organization, setOrganization] = useState('');
   const [loading, setLoading] = useState(false);
 
   const handleContinue = async () => {
@@ -27,10 +30,20 @@ export default function OnboardingScreen() {
       return;
     }
 
+    if (!username.trim() || !region.trim()) {
+      Alert.alert('Missing Info', 'Username and region are required.');
+      return;
+    }
+
     setLoading(true);
     try {
       if (user.uid) {
-        await updateUserFields(user.uid, { religion });
+        await updateUserFields(user.uid, {
+          religion,
+          displayName: username,
+          region,
+          organizationId: organization || undefined,
+        });
         await completeOnboarding(user.uid);
 
         navigation.reset({
@@ -51,6 +64,22 @@ export default function OnboardingScreen() {
   return (
     <ScreenContainer>
       <Text style={styles.title}>Welcome to OneVine 🌿</Text>
+      <Text style={styles.subtitle}>Tell us about yourself:</Text>
+
+      <TextInput
+        style={styles.input}
+        placeholder="Username"
+        value={username}
+        onChangeText={setUsername}
+      />
+
+      <TextInput
+        style={styles.input}
+        placeholder="Region"
+        value={region}
+        onChangeText={setRegion}
+      />
+
       <Text style={styles.subtitle}>Choose your spiritual lens:</Text>
 
       <View style={styles.pickerWrapper}>
@@ -64,6 +93,13 @@ export default function OnboardingScreen() {
           ))}
         </Picker>
       </View>
+
+      <TextInput
+        style={styles.input}
+        placeholder="Organization (optional)"
+        value={organization}
+        onChangeText={setOrganization}
+      />
 
       <Button title="Continue" onPress={handleContinue} loading={loading} />
     </ScreenContainer>
@@ -95,6 +131,15 @@ const styles = StyleSheet.create({
     height: 50,
     color: theme.colors.text,
     backgroundColor: theme.colors.inputBackground || theme.colors.surface,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+    backgroundColor: theme.colors.surface,
+    color: theme.colors.text,
   },
 });
 

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -17,7 +17,7 @@ export default function HomeScreen({ navigation }: Props) {
       const t = await getTokenCount();
       await syncSubscriptionStatus(); // updates Firestore token state
       setTokens(t);
-      setSubscribed(t >= 9999); // 9999 token cap implies WWJD+ sub
+      setSubscribed(t >= 9999); // 9999 token cap implies OneVine+ sub
     };
     loadData();
   }, []);
@@ -25,19 +25,19 @@ export default function HomeScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <Text style={styles.title}>Welcome to WWJD</Text>
-        <Text style={styles.subtitle}>Walk With Jesus Daily</Text>
+        <Text style={styles.title}>Welcome to OneVine</Text>
+        <Text style={styles.subtitle}>Grow in Faith Daily</Text>
 
         <View style={styles.statusBox}>
           {subscribed ? (
-            <Text style={styles.subscribed}>🌟 WWJD+ Active</Text>
+            <Text style={styles.subscribed}>🌟 OneVine+ Active</Text>
           ) : (
             <Text style={styles.tokenInfo}>🎟️ Tokens: {tokens}</Text>
           )}
         </View>
 
         <View style={styles.buttonContainer}>
-          <Button title="WWJD" onPress={() => navigation.navigate('WWJD')} />
+          <Button title="Religion AI" onPress={() => navigation.navigate('ReligionAI')} />
           <View style={styles.spacer} />
           <Button title="Journal" onPress={() => navigation.navigate('Journal')} />
           <View style={styles.spacer} />
@@ -49,7 +49,7 @@ export default function HomeScreen({ navigation }: Props) {
           <View style={styles.spacer} />
           <Button title="Buy Tokens" onPress={() => navigation.navigate('BuyTokens')} />
           <View style={styles.spacer} />
-          <Button title="Upgrade to WWJD+" onPress={() => navigation.navigate('Upgrade')} />
+          <Button title="Upgrade to OneVine+" onPress={() => navigation.navigate('Upgrade')} />
           <View style={styles.spacer} />
           <Button title="Give Back" onPress={() => navigation.navigate('GiveBack')} />
           <View style={styles.spacer} />

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -42,6 +42,17 @@ export default function StreakScreen() {
         return;
       }
 
+      const userRef = db.collection('users').doc(user.uid);
+      const userSnap = await userRef.get();
+      const userData = userSnap.data() || {};
+      const religion = userData.religion || 'Spiritual Guide';
+      const role = religion === 'Christianity' ? 'Pastor' :
+                   religion === 'Islam' ? 'Imam' :
+                   religion === 'Hinduism' ? 'Guru' :
+                   religion === 'Buddhism' ? 'Teacher' :
+                   religion === 'Judaism' ? 'Rabbi' :
+                   'Spiritual Guide';
+
       const idToken = await user.getIdToken();
 
       const response = await fetch(ASK_GEMINI_SIMPLE, {
@@ -51,7 +62,7 @@ export default function StreakScreen() {
           Authorization: `Bearer ${idToken}`,
         },
         body: JSON.stringify({
-          prompt: `The user has completed ${streakData?.streakCount || 0} daily challenges in a row. Give them a short motivational message from Jesus that acknowledges their consistency and encourages them to continue.`,
+          prompt: `The user has completed ${streakData?.streakCount || 0} daily challenges in a row. Give them a short motivational message from a ${role} encouraging continued devotion.`,
         }),
       });
 

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -36,7 +36,7 @@ export default function UpgradeScreen({ navigation }: Props) {
       );
 
       const rawText = await res.text();
-      console.log('🔥 WWJD+ raw response:', rawText);
+      console.log('🔥 OneVine+ raw response:', rawText);
       const data = JSON.parse(rawText);
 
       if (data.url) {
@@ -45,7 +45,7 @@ export default function UpgradeScreen({ navigation }: Props) {
         Alert.alert('Error', 'Something went wrong. Please try again.');
       }
     } catch (err) {
-      console.error('WWJD+ Subscription Error:', err);
+      console.error('OneVine+ Subscription Error:', err);
       Alert.alert('Subscription Failed', 'We could not start the upgrade. Please try again.');
     } finally {
       setLoading(false);
@@ -55,11 +55,11 @@ export default function UpgradeScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <Text style={styles.title}>WWJD+ Membership</Text>
+        <Text style={styles.title}>OneVine+ Membership</Text>
         <Text style={styles.subtitle}>Experience the full blessing</Text>
 
         <View style={styles.benefitsBox}>
-          <Text style={styles.benefit}>✅ Unlimited daily WWJD questions</Text>
+          <Text style={styles.benefit}>✅ Unlimited Religion AI questions</Text>
           <Text style={styles.benefit}>✅ Full Confessional access</Text>
           <Text style={styles.benefit}>✅ Personalized journaling prompts</Text>
           <Text style={styles.benefit}>✅ Early access to new features</Text>
@@ -68,7 +68,7 @@ export default function UpgradeScreen({ navigation }: Props) {
         <Text style={styles.price}>$9.99 / month</Text>
 
         <View style={styles.buttonWrap}>
-          <Button title="Join WWJD+" onPress={handleUpgrade} disabled={loading} />
+          <Button title="Join OneVine+" onPress={handleUpgrade} disabled={loading} />
         </View>
 
         <View style={styles.buttonWrap}>

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -9,6 +9,8 @@ export interface FirestoreUser {
   email: string;
   displayName?: string;
   religion: string;
+  region?: string;
+  organizationId?: string;
   isSubscribed: boolean;
   onboardingComplete: boolean;
   createdAt: number;
@@ -29,6 +31,8 @@ export async function loadUser(uid: string): Promise<void> {
       displayName: user.displayName ?? '',
       isSubscribed: user.isSubscribed,
       religion: user.religion,
+      region: user.region ?? '',
+      organizationId: user.organizationId,
       tokens: 0, // placeholder
     });
   } else {
@@ -44,11 +48,15 @@ export async function createUserProfile({
   email,
   displayName,
   religion = 'Christian',
+  region = '',
+  organizationId,
 }: {
   uid: string;
   email: string;
   displayName?: string;
   religion?: string;
+  region?: string;
+  organizationId?: string;
 }) {
   const ref = db.collection('users').doc(uid);
   const now = Date.now();
@@ -58,6 +66,8 @@ export async function createUserProfile({
     email,
     displayName,
     religion,
+    region,
+    organizationId,
     isSubscribed: false,
     onboardingComplete: false,
     createdAt: now,
@@ -79,9 +89,9 @@ export async function completeOnboarding(uid: string) {
  */
 export async function updateUserFields(
   uid: string,
-  updates: Partial<Pick<FirestoreUser, 'religion' | 'isSubscribed'>>
+  updates: Partial<FirestoreUser>
 ) {
   const ref = db.collection('users').doc(uid);
-  await ref.update(updates);
+  await ref.set(updates, { merge: true });
 }
 

--- a/App/state/userStore.ts
+++ b/App/state/userStore.ts
@@ -5,6 +5,8 @@ interface UserData {
   email: string
   displayName: string
   religion: string
+  region: string
+  organizationId?: string
   isSubscribed: boolean
   tokens: number
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project uses **React Native (via Expo)** and is powered by **Firebase** for
 - **Google Gemini / OpenAI GPT**
   - Faith-aligned reflection prompts
 - **Stripe**
-  - WWJD+ / OneVine+ subscription handling
+  - OneVine+ subscription handling
 - **Firebase Cloud Functions**
   - (Planned) server-side token logic and analytics
 
@@ -106,7 +106,7 @@ Additional uses cost tokens
 
 Daily streak bonuses
 
-💳 OneVine+ (WWJD+) Subscription
+💳 OneVine+ Subscription
 Unlimited access + priority reflections
 
 🏆 Leaderboards


### PR DESCRIPTION
## Summary
- rename AskJesusScreen to ReligionAIScreen and update navigation
- generalize prompts to respect chosen religion
- update home UI and upgrade screen for new OneVine branding
- add username/region/organization fields during onboarding
- extend user service and store with region and organization info

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_6845ddb22600833097d763e217f34159