### PR TITLE
Refactor Firebase imports to use shared config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,10 +3,8 @@ import { View, ActivityIndicator } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import auth, { FirebaseAuthTypes } from '@react-native-firebase/auth';
-import './App/config/firebaseApp'; // ✅ Ensure Firebase is initialized first
-
-const firebaseAuth = auth();
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 import { RootStackParamList } from './App/navigation/RootStackParamList';
 import { theme } from './App/components/theme/theme';

--- a/App/config/firebaseConfig.ts
+++ b/App/config/firebaseConfig.ts
@@ -1,0 +1,7 @@
+import auth from '@react-native-firebase/auth';
+import firestore from '@react-native-firebase/firestore';
+import storage from '@react-native-firebase/storage';
+
+export const firebaseAuth = auth();
+export const db = firestore();
+export const storageRef = storage();

--- a/App/hooks/useAuth.ts
+++ b/App/hooks/useAuth.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import auth, { FirebaseAuthTypes } from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 export default function useAuth() {
   const [user, setUser] = useState<FirebaseAuthTypes.User | null>(null);

--- a/App/hooks/useUser.ts
+++ b/App/hooks/useUser.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import auth, { FirebaseAuthTypes } from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 export function useUser(): { user: FirebaseAuthTypes.User | null; loading: boolean } {
   const [user, setUser] = useState<FirebaseAuthTypes.User | null>(null);

--- a/App/navigation/AppNavigator.tsx
+++ b/App/navigation/AppNavigator.tsx
@@ -3,13 +3,13 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ActivityIndicator, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import auth, { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 import AuthNavigator from './AuthNavigator';
 import MainTabNavigator from './MainTabNavigator';
 import OnboardingScreen from '@/screens/auth/OnboardingScreen';
 import { theme } from '@/components/theme/theme';
-const firebaseAuth = auth();
 
 const Stack = createNativeStackNavigator();
 

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -12,11 +12,7 @@ import {
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
-const db = firestore();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export default function ConfessionalScreen() {
   const [confession, setConfession] = useState('');

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -4,9 +4,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import auth from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'GiveBack'>;
 

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -16,11 +16,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import * as LocalAuthentication from 'expo-local-authentication';
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
-const db = firestore();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export default function JournalScreen() {
   const [entry, setEntry] = useState('');

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -13,11 +13,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_V2 } from "@/utils/constants";
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
-const db = firestore();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export default function ReligionAIScreen() {
   const [question, setQuestion] = useState('');

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -10,9 +10,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
 import { useUserStore } from "@/state/userStore";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import auth from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 

--- a/App/screens/auth/OrganizationSignupScreen.tsx
+++ b/App/screens/auth/OrganizationSignupScreen.tsx
@@ -7,9 +7,7 @@ import {
   StyleSheet,
   Alert
 } from 'react-native';
-import firestore from '@react-native-firebase/firestore';
-
-const db = firestore();
+import { db } from '@/config/firebaseConfig';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -11,9 +11,7 @@ import {
 import { theme } from "@/components/theme/theme";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useUser } from "@/hooks/useUser";
-import firestore from '@react-native-firebase/firestore';
-
-const db = firestore();
+import { db } from '@/config/firebaseConfig';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -9,9 +9,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import auth from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -12,11 +12,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
-const db = firestore();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export default function ChallengeScreen() {
   const [challenge, setChallenge] = useState('');

--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -6,9 +6,7 @@ import {
   ActivityIndicator,
   ScrollView
 } from 'react-native';
-import firestore from '@react-native-firebase/firestore';
-
-const db = firestore();
+import { db } from '@/config/firebaseConfig';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -11,11 +11,7 @@ import {
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
-const db = firestore();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export default function StreakScreen() {
   const [message, setMessage] = useState('');

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -8,13 +8,7 @@ import {
   Alert
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-import storage from '@react-native-firebase/storage';
-
-const firebaseAuth = auth();
-const db = firestore();
-const storageRef = storage();
+import { firebaseAuth, db, storageRef } from '@/config/firebaseConfig';
 import { useUser } from "@/hooks/useUser";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -13,9 +13,7 @@ import firestore from '@react-native-firebase/firestore';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
-import auth from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export default function TriviaScreen() {
   const [story, setStory] = useState('');
@@ -74,14 +72,14 @@ export default function TriviaScreen() {
       correctReligion && answer.toLowerCase().includes(correctReligion.toLowerCase());
 
     try {
-      const userRef = firestore().collection('users').doc(user.uid);
+      const userRef = db.collection('users').doc(user.uid);
 
       if (isCorrect) {
         await userRef.update({
           individualPoints: firestore.FieldValue.increment(10) // ✅ React Native Firebase version
         });
 
-        await firestore()
+        await db
           .collection('completedChallenges')
           .doc(user.uid)
           .set(

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -4,9 +4,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import auth from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
 

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -12,6 +12,7 @@ import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
 import firestore from '@react-native-firebase/firestore';
+import { db } from '@/config/firebaseConfig';
 
 export default function JoinOrganizationScreen() {
   const { user } = useUser();
@@ -25,7 +26,7 @@ export default function JoinOrganizationScreen() {
 
   const fetchOrgs = async () => {
     try {
-      const snap = await firestore().collection('organizations').get();
+      const snap = await db.collection('organizations').get();
       const all = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
       setOrgs(all);
       setFiltered(all);
@@ -51,8 +52,8 @@ export default function JoinOrganizationScreen() {
     }
 
     try {
-      const userRef = firestore().collection('users').doc(user.uid);
-      const orgRef = firestore().collection('organizations').doc(org.id);
+      const userRef = db.collection('users').doc(user.uid);
+      const orgRef = db.collection('organizations').doc(org.id);
 
       await userRef.update({
         organizationId: org.id

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -9,6 +9,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import firestore from '@react-native-firebase/firestore';
+import { db } from '@/config/firebaseConfig';
 import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
@@ -26,11 +27,11 @@ export default function OrganizationManagementScreen() {
     if (!user) return;
     setLoading(true);
     try {
-      const userSnap = await firestore().collection('users').doc(user.uid).get();
+      const userSnap = await db.collection('users').doc(user.uid).get();
       const orgId = userSnap.data()?.organizationId;
       if (!orgId) throw new Error('No organization found');
 
-      const orgSnap = await firestore().collection('organizations').doc(orgId).get();
+      const orgSnap = await db.collection('organizations').doc(orgId).get();
       setOrg({ id: orgId, ...orgSnap.data() });
     } catch (err) {
       console.error('❌ Failed to load org:', err);
@@ -44,7 +45,7 @@ export default function OrganizationManagementScreen() {
     if (!org?.id) return;
 
     try {
-      await firestore()
+      await db
         .collection('organizations')
         .doc(org.id)
         .update({

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -1,6 +1,4 @@
-import auth from '@react-native-firebase/auth';
-
-const firebaseAuth = auth();
+import { firebaseAuth } from '@/config/firebaseConfig';
 
 /**
  * Sign up a new user with email and password

--- a/App/services/storageService.ts
+++ b/App/services/storageService.ts
@@ -1,6 +1,4 @@
-import storage from '@react-native-firebase/storage';
-
-const storageRef = storage();
+import { storageRef } from '@/config/firebaseConfig';
 
 export async function uploadImage(fileUri: string, path: string): Promise<string> {
   const response = await fetch(fileUri);

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -1,6 +1,4 @@
-import firestore from '@react-native-firebase/firestore';
-
-const db = firestore();
+import { db } from '@/config/firebaseConfig';
 import { useUserStore } from "@/state/userStore";
 
 /**

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
-import auth from '@react-native-firebase/auth';
 import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 interface ChallengeStore {
   lastCompleted: number | null;
@@ -35,7 +33,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
     const user = firebaseAuth.currentUser;
     if (!user) return;
 
-    const ref = firestore().collection('completedChallenges').doc(user.uid);
+    const ref = db.collection('completedChallenges').doc(user.uid);
     const snap = await ref.get();
 
     if (snap.exists) {
@@ -52,7 +50,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
     if (!user) return;
 
     const { lastCompleted, streak } = get();
-    const ref = firestore().collection('completedChallenges').doc(user.uid);
+    const ref = db.collection('completedChallenges').doc(user.uid);
 
     await ref.set({
       lastCompleted: lastCompleted ? new Date(lastCompleted) : firestore.FieldValue.serverTimestamp(),

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,8 +1,4 @@
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
-
-const firebaseAuth = auth();
-const db = firestore();
+import { firebaseAuth, db } from '@/config/firebaseConfig';
 
 export const getTokenCount = async () => {
   const user = firebaseAuth.currentUser;


### PR DESCRIPTION
## Summary
- centralize Firebase instances in `firebaseConfig.ts`
- remove `firebaseApp` initialization import
- refactor screens and utilities to pull `firebaseAuth`, `db`, and `storageRef` from shared config

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6847a714672083308bc638592059d81a