### PR TITLE
Fix Expo config for Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ plugins: [
       android: {
         googleServicesFile: "./android/app/google-services.json"
       },
-      ios: {
-        googleServicesFile: "./ios/GoogleService-Info.plist"
-      }
     }
   ]
 ]

--- a/app.config.js
+++ b/app.config.js
@@ -11,6 +11,8 @@ export default ({ config }) => ({
 
   android: {
     package: "com.whippybuckle.onevineapp",
+    // Ensure Android build picks up Firebase config
+    googleServicesFile: "./android/app/google-services.json",
   },
 
   extra: {
@@ -31,9 +33,6 @@ export default ({ config }) => ({
       {
         android: {
           googleServicesFile: "./android/app/google-services.json",
-        },
-        ios: {
-          googleServicesFile: "./ios/GoogleService-Info.plist",
         },
       },
     ],


### PR DESCRIPTION
## Summary
- ensure android build uses `google-services.json`
- adjust README snippet for build properties

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ba7bfb2348330a408f9da99375cd8