### PR TITLE
Fix Firebase initialization for RN

### DIFF
--- a/App/config/firebase.ts
+++ b/App/config/firebase.ts
@@ -1,3 +1,6 @@
+// Ensure the Firebase native app is initialized
+import '@react-native-firebase/app';
+
 import auth from '@react-native-firebase/auth';
 import firestore from '@react-native-firebase/firestore';
 import storage from '@react-native-firebase/storage';


### PR DESCRIPTION
## Summary
- ensure `@react-native-firebase/app` is imported before using Auth, Firestore and Storage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d95e3c48330a3f9f3667d916604