### PR TITLE
Refactor auth initialization

### DIFF
--- a/App/hooks/useAuth.ts
+++ b/App/hooks/useAuth.ts
@@ -2,9 +2,8 @@ import { useEffect, useState } from 'react';
 import { User, onAuthStateChanged, getAuth } from 'firebase/auth';
 import { app } from '@/config/firebase';
 
-const auth = getAuth(app);
-
 export default function useAuth() {
+  const auth = getAuth(app);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/App/hooks/useUser.ts
+++ b/App/hooks/useUser.ts
@@ -2,9 +2,8 @@ import { useEffect, useState } from 'react';
 import { User, onAuthStateChanged, signInAnonymously, getAuth } from 'firebase/auth';
 import { app } from '@/config/firebase';
 
-const auth = getAuth(app);
-
 export function useUser(): { user: User | null; loading: boolean } {
+  const auth = getAuth(app);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/App/navigation/AppNavigator.tsx
+++ b/App/navigation/AppNavigator.tsx
@@ -6,8 +6,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { User, onAuthStateChanged, getAuth } from 'firebase/auth';
 import { app } from '@/config/firebase';
 
-const auth = getAuth(app);
-
 import AuthNavigator from './AuthNavigator';
 import MainTabNavigator from './MainTabNavigator';
 import OnboardingScreen from '@/screens/auth/OnboardingScreen';
@@ -16,6 +14,7 @@ import { theme } from '@/components/theme/theme';
 const Stack = createNativeStackNavigator();
 
 export default function AppNavigator() {
+  const auth = getAuth(app);
   const [user, setUser] = useState<User | null>(null);
   const [hasSeenOnboarding, setHasSeenOnboarding] = useState(false);
   const [loading, setLoading] = useState(true);

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -14,11 +14,10 @@ import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import { doc, getDoc, collection } from 'firebase/firestore';
 
 export default function ConfessionalScreen() {
+  const auth = getAuth(app);
   const [confession, setConfession] = useState('');
   const [response, setResponse] = useState('');
   const [loading, setLoading] = useState(false);

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -7,11 +7,10 @@ import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { app } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
 
-const auth = getAuth(app);
-
 type Props = NativeStackScreenProps<RootStackParamList, 'GiveBack'>;
 
 export default function GiveBackScreen({ navigation }: Props) {
+  const auth = getAuth(app);
   const [donating, setDonating] = useState(false);
 
   const handleDonation = async (amount: number) => {

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -15,11 +15,10 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_V2 } from "@/utils/constants";
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export default function ReligionAIScreen() {
+  const auth = getAuth(app);
   const [question, setQuestion] = useState('');
   const [messages, setMessages] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -13,11 +13,10 @@ import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { app } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
 
-const auth = getAuth(app);
-
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function LoginScreen() {
+  const auth = getAuth(app);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -12,11 +12,10 @@ import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { app } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
 
-const auth = getAuth(app);
-
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function SignupScreen() {
+  const auth = getAuth(app);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -14,11 +14,10 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export default function ChallengeScreen() {
+  const auth = getAuth(app);
   const [challenge, setChallenge] = useState('');
   const [loading, setLoading] = useState(false);
   const [canSkip, setCanSkip] = useState(true);

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -13,11 +13,10 @@ import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export default function StreakScreen() {
+  const auth = getAuth(app);
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(false);
   const [streak, setStreak] = useState(0);

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -11,14 +11,13 @@ import {
 } from 'react-native';
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { collection, doc, updateDoc, increment, setDoc } from 'firebase/firestore';
 
 export default function TriviaScreen() {
+  const auth = getAuth(app);
   const [story, setStory] = useState('');
   const [answer, setAnswer] = useState('');
   const [correctReligion, setCorrectReligion] = useState('');

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -7,11 +7,10 @@ import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { app } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
 
-const auth = getAuth(app);
-
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
 
 export default function UpgradeScreen({ navigation }: Props) {
+  const auth = getAuth(app);
   const [loading, setLoading] = useState(false);
 
   const handleUpgrade = async () => {

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -7,12 +7,11 @@ import {
   getAuth,
 } from 'firebase/auth';
 
-const auth = getAuth(app);
-
 /**
  * Sign up a new user with email and password
  */
 export async function signup(email: string, password: string): Promise<void> {
+  const auth = getAuth(app);
   try {
     await createUserWithEmailAndPassword(auth, email, password);
   } catch (error: any) {
@@ -24,6 +23,7 @@ export async function signup(email: string, password: string): Promise<void> {
  * Log in an existing user with email and password
  */
 export async function login(email: string, password: string): Promise<void> {
+  const auth = getAuth(app);
   try {
     await signInWithEmailAndPassword(auth, email, password);
   } catch (error: any) {
@@ -35,6 +35,7 @@ export async function login(email: string, password: string): Promise<void> {
  * Log out the currently signed-in user
  */
 export async function logout(): Promise<void> {
+  const auth = getAuth(app);
   try {
     await signOut(auth);
   } catch (error: any) {
@@ -46,6 +47,7 @@ export async function logout(): Promise<void> {
  * Send a password reset email
  */
 export async function resetPassword(email: string): Promise<void> {
+  const auth = getAuth(app);
   try {
     await sendPasswordResetEmail(auth, email);
   } catch (error: any) {

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import { doc, getDoc, setDoc, collection, serverTimestamp } from 'firebase/firestore';
 
 interface ChallengeStore {
@@ -33,6 +31,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
   },
 
   syncWithFirestore: async () => {
+    const auth = getAuth(app);
     const user = auth.currentUser;
     if (!user) return;
 
@@ -49,6 +48,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
   },
 
   updateStreakInFirestore: async () => {
+    const auth = getAuth(app);
     const user = auth.currentUser;
     if (!user) return;
 

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,10 +1,9 @@
 import { app, firestore } from '@/config/firebase';
 import { getAuth } from 'firebase/auth';
-
-const auth = getAuth(app);
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export const getTokenCount = async () => {
+  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return 0;
 
@@ -20,6 +19,7 @@ export const getTokenCount = async () => {
 };
 
 export const setTokenCount = async (count: number) => {
+  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return;
 
@@ -35,6 +35,7 @@ export const consumeToken = async () => {
 };
 
 export const canUseFreeAsk = async () => {
+  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return false;
 
@@ -55,6 +56,7 @@ export const canUseFreeAsk = async () => {
 };
 
 export const useFreeAsk = async () => {
+  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return;
 
@@ -63,6 +65,7 @@ export const useFreeAsk = async () => {
 };
 
 export const syncSubscriptionStatus = async () => {
+  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return;
 


### PR DESCRIPTION
## Summary
- use getAuth(app) lazily inside hooks and screens
- remove global auth variable across the app

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684e048f28a08330ae7d4d34a5c35f09