### PR TITLE
Fix Firestore snapshot.exists usages

### DIFF
--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -30,7 +30,7 @@ export async function loadUser(uid: string): Promise<void> {
   const ref = doc(collection(firestore, 'users'), uid);
   const snapshot = await getDoc(ref);
 
-  if (snapshot.exists) {
+  if (snapshot.exists()) {
     const user = snapshot.data() as FirestoreUser;
     useUserStore.getState().setUser({
       uid: user.uid,

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -38,7 +38,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
     const ref = doc(collection(firestore, 'completedChallenges'), user.uid);
     const snap = await getDoc(ref);
 
-    if (snap.exists) {
+    if (snap.exists()) {
       const data = snap.data();
       set({
         lastCompleted: data?.lastCompleted?.toDate?.().getTime() || null,

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -10,7 +10,7 @@ export const getTokenCount = async () => {
   const tokenRef = doc(collection(firestore, 'tokens'), user.uid);
   const tokenSnap = await getDoc(tokenRef);
 
-  if (tokenSnap.exists) {
+  if (tokenSnap.exists()) {
     const data = tokenSnap.data()!;
     return data.count || 0;
   } else {
@@ -42,7 +42,7 @@ export const canUseFreeAsk = async () => {
   const docRef = doc(collection(firestore, 'freeAsk'), user.uid);
   const docSnap = await getDoc(docRef);
 
-  if (!docSnap.exists) return true;
+  if (!docSnap.exists()) return true;
 
   const data = docSnap.data()!;
   const lastUsed = data.date?.toDate?.();
@@ -72,11 +72,11 @@ export const syncSubscriptionStatus = async () => {
   const subRef = doc(collection(firestore, 'subscriptions'), user.uid);
   const subSnap = await getDoc(subRef);
 
-  const isSubscribed = subSnap.exists && subSnap.data()!.active === true;
+  const isSubscribed = subSnap.exists() && subSnap.data()!.active === true;
 
   const tokenRef = doc(collection(firestore, 'tokens'), user.uid);
   if (isSubscribed) {
-    await tokenRef.set({ count: 9999 }, { merge: true });
+    await setDoc(tokenRef, { count: 9999 }, { merge: true });
   }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
       ]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "functions"]
 }


### PR DESCRIPTION
## Summary
- call `exists()` instead of `.exists` on Firestore snapshots
- switch to modular Firestore `setDoc` API
- exclude the Cloud Functions folder from the main TypeScript build

## Testing
- `npm install --ignore-scripts`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684e1b5fe0b8833083ca35f3a0e5bf88