### PR TITLE
Disable hermes JS engine

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,6 +4,7 @@ export default ({ config }) => ({
   slug: "onevine-app",
   version: "1.0.0",
   runtimeVersion: "1.0.0",
+  jsEngine: "jsc",
 
   updates: {
     url: "https://u.expo.dev/bbf209be-1b48-4f76-a496-9d4fcd8339fd",
@@ -29,6 +30,10 @@ export default ({ config }) => ({
       {
         android: {
           // ✅ No need to configure Google Services or Firebase here anymore
+          jsEngine: "jsc",
+        },
+        ios: {
+          jsEngine: "jsc",
         },
       },
     ],


### PR DESCRIPTION
## Summary
- disable Hermes by setting jsEngine to JSC in app configuration
- force JSC engine in expo-build-properties plugin

## Testing
- `npm test` *(fails: Missing script "test" as no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ebc2d5fa48330be91152d0ecc8310