### PR TITLE
Fix Firebase modular setup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,8 +3,8 @@ import { View, ActivityIndicator } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { User, onAuthStateChanged, getAuth } from 'firebase/auth';
-import { app } from '@/config/firebase';
+import { User, onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 import { RootStackParamList } from './App/navigation/RootStackParamList';
 import { theme } from './App/components/theme/theme';
@@ -48,7 +48,6 @@ export default function App() {
 
   useEffect(() => {
     let unsubscribe: () => void;
-    const auth = getAuth(app);
 
     const initialize = async () => {
       try {

--- a/App/config/firebase.ts
+++ b/App/config/firebase.ts
@@ -17,8 +17,8 @@ const firebaseConfig = {
 
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
 
-export const auth = getAuth(app);
-export const firestore = getFirestore(app);
-export const storage = getStorage(app);
+const auth = getAuth(app);
+const firestore = getFirestore(app);
+const storage = getStorage(app);
 
-export { app };
+export { auth, firestore, storage };

--- a/App/hooks/useAuth.ts
+++ b/App/hooks/useAuth.ts
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react';
-import { User, onAuthStateChanged, getAuth } from 'firebase/auth';
-import { app } from '@/config/firebase';
+import { User, onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 export default function useAuth() {
-  const auth = getAuth(app);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/App/hooks/useUser.ts
+++ b/App/hooks/useUser.ts
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react';
-import { User, onAuthStateChanged, signInAnonymously, getAuth } from 'firebase/auth';
-import { app } from '@/config/firebase';
+import { User, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 export function useUser(): { user: User | null; loading: boolean } {
-  const auth = getAuth(app);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/App/navigation/AppNavigator.tsx
+++ b/App/navigation/AppNavigator.tsx
@@ -3,8 +3,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ActivityIndicator, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { User, onAuthStateChanged, getAuth } from 'firebase/auth';
-import { app } from '@/config/firebase';
+import { User, onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 import AuthNavigator from './AuthNavigator';
 import MainTabNavigator from './MainTabNavigator';
@@ -14,7 +14,6 @@ import { theme } from '@/components/theme/theme';
 const Stack = createNativeStackNavigator();
 
 export default function AppNavigator() {
-  const auth = getAuth(app);
   const [user, setUser] = useState<User | null>(null);
   const [hasSeenOnboarding, setHasSeenOnboarding] = useState(false);
   const [loading, setLoading] = useState(true);

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -12,12 +12,10 @@ import {
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import { doc, getDoc, collection } from 'firebase/firestore';
 
 export default function ConfessionalScreen() {
-  const auth = getAuth(app);
   const [confession, setConfession] = useState('');
   const [response, setResponse] = useState('');
   const [loading, setLoading] = useState(false);

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -4,13 +4,11 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { app } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'GiveBack'>;
 
 export default function GiveBackScreen({ navigation }: Props) {
-  const auth = getAuth(app);
   const [donating, setDonating] = useState(false);
 
   const handleDonation = async (amount: number) => {

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -13,12 +13,10 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_V2 } from "@/utils/constants";
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export default function ReligionAIScreen() {
-  const auth = getAuth(app);
   const [question, setQuestion] = useState('');
   const [messages, setMessages] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -10,13 +10,11 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
 import { useUserStore } from "@/state/userStore";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { app } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function LoginScreen() {
-  const auth = getAuth(app);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -9,13 +9,11 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { app } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function SignupScreen() {
-  const auth = getAuth(app);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -12,12 +12,10 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export default function ChallengeScreen() {
-  const auth = getAuth(app);
   const [challenge, setChallenge] = useState('');
   const [loading, setLoading] = useState(false);
   const [canSkip, setCanSkip] = useState(true);

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -11,12 +11,10 @@ import {
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export default function StreakScreen() {
-  const auth = getAuth(app);
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(false);
   const [streak, setStreak] = useState(0);

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -9,15 +9,13 @@ import {
   ActivityIndicator,
   ScrollView
 } from 'react-native';
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { collection, doc, updateDoc, increment, setDoc } from 'firebase/firestore';
 
 export default function TriviaScreen() {
-  const auth = getAuth(app);
   const [story, setStory] = useState('');
   const [answer, setAnswer] = useState('');
   const [correctReligion, setCorrectReligion] = useState('');

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -4,13 +4,11 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { app } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth } from '@/config/firebase';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
 
 export default function UpgradeScreen({ navigation }: Props) {
-  const auth = getAuth(app);
   const [loading, setLoading] = useState(false);
 
   const handleUpgrade = async () => {

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -1,17 +1,15 @@
-import { app } from '@/config/firebase';
+import { auth } from '@/config/firebase';
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   signOut,
   sendPasswordResetEmail,
-  getAuth,
 } from 'firebase/auth';
 
 /**
  * Sign up a new user with email and password
  */
 export async function signup(email: string, password: string): Promise<void> {
-  const auth = getAuth(app);
   try {
     await createUserWithEmailAndPassword(auth, email, password);
   } catch (error: any) {
@@ -23,7 +21,6 @@ export async function signup(email: string, password: string): Promise<void> {
  * Log in an existing user with email and password
  */
 export async function login(email: string, password: string): Promise<void> {
-  const auth = getAuth(app);
   try {
     await signInWithEmailAndPassword(auth, email, password);
   } catch (error: any) {
@@ -35,7 +32,6 @@ export async function login(email: string, password: string): Promise<void> {
  * Log out the currently signed-in user
  */
 export async function logout(): Promise<void> {
-  const auth = getAuth(app);
   try {
     await signOut(auth);
   } catch (error: any) {
@@ -47,7 +43,6 @@ export async function logout(): Promise<void> {
  * Send a password reset email
  */
 export async function resetPassword(email: string): Promise<void> {
-  const auth = getAuth(app);
   try {
     await sendPasswordResetEmail(auth, email);
   } catch (error: any) {

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection, serverTimestamp } from 'firebase/firestore';
 
 interface ChallengeStore {
@@ -31,7 +30,6 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
   },
 
   syncWithFirestore: async () => {
-    const auth = getAuth(app);
     const user = auth.currentUser;
     if (!user) return;
 
@@ -48,7 +46,6 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
   },
 
   updateStreakInFirestore: async () => {
-    const auth = getAuth(app);
     const user = auth.currentUser;
     if (!user) return;
 

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,9 +1,7 @@
-import { app, firestore } from '@/config/firebase';
-import { getAuth } from 'firebase/auth';
+import { auth, firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 
 export const getTokenCount = async () => {
-  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return 0;
 
@@ -19,7 +17,6 @@ export const getTokenCount = async () => {
 };
 
 export const setTokenCount = async (count: number) => {
-  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return;
 
@@ -35,7 +32,6 @@ export const consumeToken = async () => {
 };
 
 export const canUseFreeAsk = async () => {
-  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return false;
 
@@ -56,7 +52,6 @@ export const canUseFreeAsk = async () => {
 };
 
 export const useFreeAsk = async () => {
-  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return;
 
@@ -65,7 +60,6 @@ export const useFreeAsk = async () => {
 };
 
 export const syncSubscriptionStatus = async () => {
-  const auth = getAuth(app);
   const user = auth.currentUser;
   if (!user) return;
 


### PR DESCRIPTION
## Summary
- clean up Firebase initialization and exports
- use shared `auth` from firebase config across the app
- remove inline `getAuth(app)` usage

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'react-native', expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec4c1137c8330a2de75c0c5b8c2e2