### PR TITLE
Use Firebase Web REST auth

### DIFF
--- a/App/config/firebase.ts
+++ b/App/config/firebase.ts
@@ -1,5 +1,3 @@
-// firebase.ts
-
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
@@ -17,8 +15,6 @@ const firebaseConfig = {
 
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
 
-const auth = getAuth(app);
-const firestore = getFirestore(app);
-const storage = getStorage(app);
-
-export { auth, firestore, storage };
+export const auth = getAuth(app);
+export const firestore = getFirestore(app);
+export const storage = getStorage(app);

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -10,7 +10,6 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
 import { useUserStore } from "@/state/userStore";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { auth } from '@/config/firebase';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -23,11 +22,9 @@ export default function LoginScreen() {
   const handleLogin = async () => {
     setLoading(true);
     try {
-      await login(email, password);
-
-      const user = auth.currentUser;
-      if (user) {
-        await loadUser(user.uid);
+      const result = await login(email, password);
+      if (result.localId) {
+        await loadUser(result.localId);
       }
     } catch (err: any) {
       Alert.alert('Login Failed', err.message);

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -9,7 +9,6 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { auth } from '@/config/firebase';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -22,15 +21,13 @@ export default function SignupScreen() {
   const handleSignup = async () => {
     setLoading(true);
     try {
-      await signup(email, password);
-
-      const firebaseUser = auth.currentUser;
-      if (!firebaseUser) throw new Error('User creation failed.');
+      const result = await signup(email, password);
+      if (!result.localId) throw new Error('User creation failed.');
 
       await createUserProfile({
-        uid: firebaseUser.uid,
-        email: firebaseUser.email ?? '',
-        displayName: firebaseUser.displayName ?? '',
+        uid: result.localId,
+        email: result.email,
+        displayName: '',
       });
 
       // Navigation handled automatically after auth


### PR DESCRIPTION
## Summary
- standardize firebase initialization in `firebase.ts`
- switch auth service to Firebase REST API
- adjust login and signup screens to use REST auth results

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_684ed5fd0aec83308e7a908aeef464a5