### PR TITLE
Fix organization signup and add password reset

### DIFF
--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, Alert } from 'react-native';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
-import { login } from "@/services/authService";
+import { login, resetPassword } from "@/services/authService";
 import { loadUser } from "@/services/userService";
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -32,6 +32,19 @@ export default function LoginScreen() {
       setLoading(false);
     }
   };
+  const handleForgotPassword = async () => {
+    if (!email) {
+      Alert.alert("Password Reset", "Please enter your email first.");
+      return;
+    }
+    try {
+      await resetPassword(email);
+      Alert.alert("Password Reset", "If this email is registered, a reset link has been sent.");
+    } catch (err:any) {
+      Alert.alert("Error", err.message);
+    }
+  };
+
 
   return (
     <ScreenContainer>
@@ -53,6 +66,13 @@ export default function LoginScreen() {
       />
 
       <Button title="Log In" onPress={handleLogin} loading={loading} />
+      <Text
+        style={styles.link}
+        onPress={handleForgotPassword}
+      >
+        Forgot Password?
+      </Text>
+
 
       <Text
         style={styles.link}

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -74,11 +74,14 @@ export async function createUserProfile({
     displayName,
     religion,
     region,
-    organizationId,
     isSubscribed: false,
     onboardingComplete: false,
     createdAt: now,
   };
+
+  if (organizationId) {
+    (userData as any).organizationId = organizationId;
+  }
 
   await setDoc(ref, userData);
 }
@@ -99,6 +102,9 @@ export async function updateUserFields(
   updates: Partial<FirestoreUser>
 ) {
   const ref = doc(collection(firestore, 'users'), uid);
-  await setDoc(ref, updates, { merge: true });
+  const filtered = Object.fromEntries(
+    Object.entries(updates).filter(([_, v]) => v !== undefined)
+  );
+  await setDoc(ref, filtered, { merge: true });
 }
 


### PR DESCRIPTION
## Summary
- avoid setting undefined organizationId in user records
- filter undefined fields in `updateUserFields`
- add forgot password link on login screen
- support sending password reset email

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f025b4ef483309c3647025476aa41