### PR TITLE
Add auth guard for Firestore queries

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -16,6 +16,7 @@ import { firestore } from '@/config/firebase';
 import { doc, getDoc, collection } from 'firebase/firestore';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function ConfessionalScreen() {
   const [confession, setConfession] = useState('');
@@ -31,9 +32,13 @@ export default function ConfessionalScreen() {
 
     setLoading(true);
     try {
-      if (!user) return;
+      const uid = await ensureAuth(user?.uid);
+      if (!uid) {
+        setLoading(false);
+        return;
+      }
 
-      const userRef = doc(collection(firestore, 'users'), user.uid);
+      const userRef = doc(collection(firestore, 'users'), uid);
       const userSnap = await getDoc(userRef);
       const userData = userSnap.data() || {};
       const religion = userData.religion || 'Spiritual Guide';

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -17,6 +17,7 @@ import { theme } from "@/components/theme/theme";
 import * as LocalAuthentication from 'expo-local-authentication';
 import { firestore } from '@/config/firebase';
 import { collection, getDocs, addDoc, orderBy, query } from 'firebase/firestore';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function JournalScreen() {
   const [entry, setEntry] = useState('');
@@ -40,6 +41,9 @@ export default function JournalScreen() {
             return;
           }
         }
+
+        const uid = await ensureAuth();
+        if (!uid) return;
 
         const q = query(
           collection(firestore, 'journalEntries'),
@@ -66,6 +70,9 @@ export default function JournalScreen() {
     if (!entry.trim()) return;
     setSaving(true);
     try {
+      const uid = await ensureAuth();
+      if (!uid) throw new Error('Not authenticated');
+
       await addDoc(collection(firestore, 'journalEntries'), {
         text: entry,
         createdAt: new Date(), // ✅ replaces serverTimestamp()

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -17,6 +17,7 @@ import { firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function ReligionAIScreen() {
   const [question, setQuestion] = useState('');
@@ -34,9 +35,13 @@ export default function ReligionAIScreen() {
     setLoading(true);
 
     try {
-      if (!user) return;
+      const uid = await ensureAuth(user?.uid);
+      if (!uid) {
+        setLoading(false);
+        return;
+      }
 
-      const userRef = doc(collection(firestore, 'users'), user.uid);
+      const userRef = doc(collection(firestore, 'users'), uid);
       const userSnap = await getDoc(userRef);
       const userData = userSnap.data() || {};
       const lastAsk = userData.lastFreeAsk?.toDate?.();

--- a/App/screens/auth/OrganizationSignupScreen.tsx
+++ b/App/screens/auth/OrganizationSignupScreen.tsx
@@ -13,6 +13,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
+import { ensureAuth } from '@/utils/authGuard';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'OrganizationSignup'>;
 
@@ -29,6 +30,9 @@ export default function OrganizationSignupScreen({ navigation }: Props) {
 
     setSubmitting(true);
     try {
+      const uid = await ensureAuth();
+      if (!uid) throw new Error('Not authenticated');
+
       const seatLimit = tier === 'enterprise-plus' ? 50 : 25;
       const subscribedSeats = tier === 'enterprise-plus' ? 50 : 0;
 

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -15,6 +15,7 @@ import { firestore } from '@/config/firebase';
 import { doc, setDoc, collection } from 'firebase/firestore';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
+import { ensureAuth } from '@/utils/authGuard';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SelectReligion'>;
 
@@ -38,10 +39,12 @@ export default function SelectReligionScreen({ navigation }: Props) {
     }
 
     if (!user) return;
+    const uid = await ensureAuth(user.uid);
+    if (!uid) return;
 
     try {
       await setDoc(
-        doc(collection(firestore, 'users'), user.uid),
+        doc(collection(firestore, 'users'), uid),
         { religion: selected },
         { merge: true }
       );

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -16,6 +16,7 @@ import { firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function ChallengeScreen() {
   const [challenge, setChallenge] = useState('');
@@ -25,11 +26,12 @@ export default function ChallengeScreen() {
 
   const fetchChallenge = async () => {
     try {
-      if (!user) return;
+      const uid = await ensureAuth(user?.uid);
+      if (!uid) return;
 
       setLoading(true);
 
-      const userRef = doc(collection(firestore, 'users'), user.uid);
+      const userRef = doc(collection(firestore, 'users'), uid);
       const userSnap = await getDoc(userRef);
       const userData = userSnap.data() || {};
       const lastChallenge = userData.lastChallenge?.toDate?.();

--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -10,6 +10,7 @@ import { firestore } from '@/config/firebase';
 import { collection, getDocs, query, orderBy } from 'firebase/firestore';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function LeaderboardsScreen() {
   const [individuals, setIndividuals] = useState<any[]>([]);
@@ -24,6 +25,12 @@ export default function LeaderboardsScreen() {
   const fetchData = async () => {
     setLoading(true);
     try {
+      const uid = await ensureAuth();
+      if (!uid) {
+        setLoading(false);
+        return;
+      }
+
       const userSnap = await getDocs(
         query(collection(firestore, 'users'), orderBy('individualPoints', 'desc'))
       );

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -15,6 +15,7 @@ import { firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function StreakScreen() {
   const [message, setMessage] = useState('');
@@ -28,11 +29,12 @@ export default function StreakScreen() {
 
   const fetchStreakMessage = async () => {
     try {
-      if (!user) return;
+      const uid = await ensureAuth(user?.uid);
+      if (!uid) return;
 
       setLoading(true);
 
-      const streakRef = doc(collection(firestore, 'completedChallenges'), user.uid);
+      const streakRef = doc(collection(firestore, 'completedChallenges'), uid);
       const streakSnap = await getDoc(streakRef);
       const streakData = streakSnap.data();
 
@@ -45,7 +47,7 @@ export default function StreakScreen() {
         return;
       }
 
-      const userRef = doc(collection(firestore, 'users'), user.uid);
+      const userRef = doc(collection(firestore, 'users'), uid);
       const userSnap = await getDoc(userRef);
       const userData = userSnap.data() || {};
       const religion = userData.religion || 'Spiritual Guide';

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -14,6 +14,7 @@ import { collection, addDoc } from 'firebase/firestore';
 import { useUser } from "@/hooks/useUser";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function SubmitProofScreen() {
   const { user } = useUser();
@@ -39,9 +40,12 @@ export default function SubmitProofScreen() {
       return;
     }
 
+    const uid = await ensureAuth(user.uid);
+    if (!uid) return;
+
     setUploading(true);
     try {
-      const refPath = `proofs/${user.uid}/${Date.now()}`;
+      const refPath = `proofs/${uid}/${Date.now()}`;
       const imgRef = ref(storage, refPath);
       const imgBlob = await fetch(image.uri).then(r => r.blob());
 
@@ -49,7 +53,7 @@ export default function SubmitProofScreen() {
       const imgUrl = await getDownloadURL(imgRef);
 
       await addDoc(collection(firestore, 'challengeProofs'), {
-          uid: user.uid,
+          uid,
           caption,
           imageUrl: imgUrl,
           createdAt: new Date() // ✅ replacing serverTimestamp()

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -16,6 +16,7 @@ import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { collection, doc, updateDoc, increment, setDoc } from 'firebase/firestore';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function TriviaScreen() {
   const [story, setStory] = useState('');
@@ -31,7 +32,8 @@ export default function TriviaScreen() {
   const { user } = useUser();
 
   const fetchTrivia = async () => {
-    if (!user) return;
+    const uid = await ensureAuth(user?.uid);
+    if (!uid) return;
 
     setLoading(true);
     setRevealed(false);
@@ -66,7 +68,8 @@ export default function TriviaScreen() {
   const submitAnswer = async () => {
     if (!answer) return;
 
-    if (!user) return;
+    const uid = await ensureAuth(user?.uid);
+    if (!uid) return;
 
     setRevealed(true);
 
@@ -74,7 +77,7 @@ export default function TriviaScreen() {
       correctReligion && answer.toLowerCase().includes(correctReligion.toLowerCase());
 
     try {
-      const userRef = doc(collection(firestore, 'users'), user.uid);
+      const userRef = doc(collection(firestore, 'users'), uid);
 
       if (isCorrect) {
         await updateDoc(userRef, {
@@ -82,7 +85,7 @@ export default function TriviaScreen() {
         });
 
         await setDoc(
-          doc(collection(firestore, 'completedChallenges'), user.uid),
+          doc(collection(firestore, 'completedChallenges'), uid),
           {
             lastTrivia: new Date().toISOString(),
             triviaCompleted: true

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -19,6 +19,7 @@ import {
   updateDoc,
   arrayUnion
 } from 'firebase/firestore';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function JoinOrganizationScreen() {
   const { user } = useUser();
@@ -32,6 +33,9 @@ export default function JoinOrganizationScreen() {
 
   const fetchOrgs = async () => {
     try {
+      const uid = await ensureAuth(user?.uid);
+      if (!uid) return;
+
       const snap = await getDocs(collection(firestore, 'organizations'));
       const all = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
       setOrgs(all);
@@ -52,13 +56,15 @@ export default function JoinOrganizationScreen() {
 
   const joinOrg = async (org: any) => {
     if (!user) return;
+    const uid = await ensureAuth(user.uid);
+    if (!uid) return;
     if ((org.members?.length || 0) >= org.seatLimit) {
       Alert.alert('Full', 'This organization has no available seats.');
       return;
     }
 
     try {
-      const userRef = doc(collection(firestore, 'users'), user.uid);
+      const userRef = doc(collection(firestore, 'users'), uid);
       const orgRef = doc(collection(firestore, 'organizations'), org.id);
 
       await updateDoc(userRef, {

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -19,6 +19,7 @@ import {
 import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
+import { ensureAuth } from '@/utils/authGuard';
 
 export default function OrganizationManagementScreen() {
   const { user } = useUser();
@@ -31,9 +32,11 @@ export default function OrganizationManagementScreen() {
 
   const loadOrg = async () => {
     if (!user) return;
+    const uid = await ensureAuth(user.uid);
+    if (!uid) return;
     setLoading(true);
     try {
-      const userSnap = await getDoc(doc(collection(firestore, 'users'), user.uid));
+      const userSnap = await getDoc(doc(collection(firestore, 'users'), uid));
       const orgId = userSnap.data()?.organizationId;
       if (!orgId) throw new Error('No organization found');
 
@@ -49,6 +52,8 @@ export default function OrganizationManagementScreen() {
 
   const removeMember = async (uid: string) => {
     if (!org?.id) return;
+    const authUid = await ensureAuth(user?.uid);
+    if (!authUid) return;
 
     try {
       await updateDoc(doc(collection(firestore, 'organizations'), org.id), {

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -7,6 +7,7 @@ import {
   collection
 } from 'firebase/firestore';
 import { useUserStore } from "@/state/userStore";
+import { ensureAuth } from '@/utils/authGuard';
 
 /**
  * Firestore user document structure
@@ -27,7 +28,10 @@ export interface FirestoreUser {
  * Get user from Firestore and set into userStore
  */
 export async function loadUser(uid: string): Promise<void> {
-  const ref = doc(collection(firestore, 'users'), uid);
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+
+  const ref = doc(collection(firestore, 'users'), storedUid);
   const snapshot = await getDoc(ref);
 
   if (snapshot.exists()) {
@@ -65,7 +69,10 @@ export async function createUserProfile({
   region?: string;
   organizationId?: string;
 }) {
-  const ref = doc(collection(firestore, 'users'), uid);
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+
+  const ref = doc(collection(firestore, 'users'), storedUid);
   const now = Date.now();
 
   const userData: FirestoreUser = {
@@ -90,7 +97,10 @@ export async function createUserProfile({
  * Mark onboarding complete
  */
 export async function completeOnboarding(uid: string) {
-  const ref = doc(collection(firestore, 'users'), uid);
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+
+  const ref = doc(collection(firestore, 'users'), storedUid);
   await updateDoc(ref, { onboardingComplete: true });
 }
 
@@ -101,7 +111,10 @@ export async function updateUserFields(
   uid: string,
   updates: Partial<FirestoreUser>
 ) {
-  const ref = doc(collection(firestore, 'users'), uid);
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+
+  const ref = doc(collection(firestore, 'users'), storedUid);
   const filtered = Object.fromEntries(
     Object.entries(updates).filter(([_, v]) => v !== undefined)
   );

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection, serverTimestamp } from 'firebase/firestore';
 import * as SecureStore from 'expo-secure-store';
+import { ensureAuth } from '@/utils/authGuard';
 
 async function getUid(): Promise<string | null> {
   return await SecureStore.getItemAsync('localId');
@@ -35,7 +36,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
   },
 
   syncWithFirestore: async () => {
-    const uid = await getUid();
+    const uid = await ensureAuth();
     if (!uid) return;
 
     const ref = doc(collection(firestore, 'completedChallenges'), uid);
@@ -51,7 +52,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
   },
 
   updateStreakInFirestore: async () => {
-    const uid = await getUid();
+    const uid = await ensureAuth();
     if (!uid) return;
 
     const { lastCompleted, streak } = get();

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,13 +1,9 @@
 import { firestore } from '@/config/firebase';
 import { doc, getDoc, setDoc, collection } from 'firebase/firestore';
-import * as SecureStore from 'expo-secure-store';
-
-async function getUid(): Promise<string | null> {
-  return await SecureStore.getItemAsync('localId');
-}
+import { ensureAuth } from '@/utils/authGuard';
 
 export const getTokenCount = async () => {
-  const uid = await getUid();
+  const uid = await ensureAuth();
   if (!uid) return 0;
 
   const tokenRef = doc(collection(firestore, 'tokens'), uid);
@@ -22,7 +18,7 @@ export const getTokenCount = async () => {
 };
 
 export const setTokenCount = async (count: number) => {
-  const uid = await getUid();
+  const uid = await ensureAuth();
   if (!uid) return;
 
   const tokenRef = doc(collection(firestore, 'tokens'), uid);
@@ -37,7 +33,7 @@ export const consumeToken = async () => {
 };
 
 export const canUseFreeAsk = async () => {
-  const uid = await getUid();
+  const uid = await ensureAuth();
   if (!uid) return false;
 
   const docRef = doc(collection(firestore, 'freeAsk'), uid);
@@ -57,7 +53,7 @@ export const canUseFreeAsk = async () => {
 };
 
 export const useFreeAsk = async () => {
-  const uid = await getUid();
+  const uid = await ensureAuth();
   if (!uid) return;
 
   const docRef = doc(collection(firestore, 'freeAsk'), uid);
@@ -65,7 +61,7 @@ export const useFreeAsk = async () => {
 };
 
 export const syncSubscriptionStatus = async () => {
-  const uid = await getUid();
+  const uid = await ensureAuth();
   if (!uid) return;
 
   const subRef = doc(collection(firestore, 'subscriptions'), uid);

--- a/App/utils/authGuard.ts
+++ b/App/utils/authGuard.ts
@@ -1,0 +1,25 @@
+import * as SecureStore from 'expo-secure-store';
+import { getStoredToken } from '@/services/authService';
+
+/**
+ * Ensure the user is authenticated and the uid matches if provided.
+ * Returns the stored uid when valid, otherwise null.
+ */
+export async function ensureAuth(expectedUid?: string): Promise<string | null> {
+  const [uid, token] = await Promise.all([
+    SecureStore.getItemAsync('localId'),
+    getStoredToken(),
+  ]);
+
+  if (!uid || !token) {
+    console.warn('🚫 Firestore access blocked: missing auth');
+    return null;
+  }
+
+  if (expectedUid && uid !== expectedUid) {
+    console.warn('🚫 Firestore access blocked: uid mismatch');
+    return null;
+  }
+
+  return uid;
+}


### PR DESCRIPTION
## Summary
- add shared `ensureAuth` helper for verifying uid and idToken
- wrap Firestore calls in `ensureAuth`
- block unauthenticated reads/writes across screens and services

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f0b6069a88330bfe572a026b3db30