### PR TITLE
Improve auth storage and add welcome flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,9 @@ import { theme } from './App/components/theme/theme';
 // Auth Screens
 import LoginScreen from './App/screens/auth/LoginScreen';
 import SignupScreen from './App/screens/auth/SignupScreen';
+import WelcomeScreen from './App/screens/auth/WelcomeScreen';
+import ForgotPasswordScreen from './App/screens/auth/ForgotPasswordScreen';
+import ForgotUsernameScreen from './App/screens/auth/ForgotUsernameScreen';
 import OnboardingScreen from './App/screens/auth/OnboardingScreen';
 import SelectReligionScreen from './App/screens/auth/SelectReligionScreen';
 import OrganizationSignupScreen from './App/screens/auth/OrganizationSignupScreen';
@@ -50,7 +53,7 @@ export default function App() {
   useEffect(() => {
     const initialize = async () => {
       try {
-        const uid = await SecureStore.getItemAsync('localId');
+        const uid = await SecureStore.getItemAsync('userId');
         const token = await getStoredToken();
         if (uid && token) {
           await loadUser(uid);
@@ -61,11 +64,11 @@ export default function App() {
           const { init } = await import('./App/utils/TokenManager');
           init?.();
         } else {
-          setInitialRoute('Login');
+          setInitialRoute('Welcome');
         }
       } catch (err) {
         console.error('❌ Auth load error:', err);
-        setInitialRoute('Login');
+        setInitialRoute('Welcome');
       } finally {
         setCheckingAuth(false);
       }
@@ -92,7 +95,7 @@ export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator
-        initialRouteName={user ? initialRoute : 'Login'}
+        initialRouteName={user ? initialRoute : 'Welcome'}
         screenOptions={{
           headerStyle: { backgroundColor: theme.colors.background },
           headerTintColor: theme.colors.text,
@@ -101,8 +104,11 @@ export default function App() {
       >
         {!user ? (
           <>
+            <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
             <Stack.Screen name="Login" component={LoginScreen} options={{ title: 'Login' }} />
             <Stack.Screen name="Signup" component={SignupScreen} options={{ title: 'Sign Up' }} />
+            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Reset Password' }} />
+            <Stack.Screen name="ForgotUsername" component={ForgotUsernameScreen} options={{ title: 'Find Email' }} />
             <Stack.Screen name="OrganizationSignup" component={OrganizationSignupScreen} options={{ title: 'Create Organization' }} />
           </>
         ) : (

--- a/App/components/TextField.tsx
+++ b/App/components/TextField.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
   input: {
     borderWidth: 1,
     borderColor: theme.colors.border,
-    borderRadius: 8,
+    borderRadius: 12,
     padding: 12,
     color: theme.colors.text,
     backgroundColor: theme.colors.inputBackground,

--- a/App/components/common/Button.tsx
+++ b/App/components/common/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
 import { theme } from '@/components/theme/theme'; // ✅ Fixed path
 
 interface ButtonProps {
@@ -11,8 +11,8 @@ interface ButtonProps {
 
 export default function Button({ title, onPress, disabled, loading }: ButtonProps) {
   return (
-    <TouchableOpacity
-      style={[styles.button, disabled && styles.disabled]}
+    <Pressable
+      style={({ pressed }) => [styles.button, pressed && styles.pressed, disabled && styles.disabled]}
       onPress={onPress}
       disabled={disabled || loading}
     >
@@ -21,7 +21,7 @@ export default function Button({ title, onPress, disabled, loading }: ButtonProp
       ) : (
         <Text style={styles.text}>{title}</Text>
       )}
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
@@ -29,9 +29,18 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: theme.colors.primary,
     paddingVertical: 14,
-    borderRadius: 10,
+    borderRadius: 12,
     alignItems: 'center',
     marginVertical: 10,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  pressed: {
+    opacity: 0.8,
+    transform: [{ scale: 0.98 }],
   },
   text: {
     color: 'white',

--- a/App/components/theme/Background.tsx
+++ b/App/components/theme/Background.tsx
@@ -7,7 +7,7 @@ export default function Background({ children }: { children: React.ReactNode }) 
   return (
     <View style={styles.wrapper}>
       <LinearGradient
-        colors={[theme.colors.background, '#1a1f2b']}
+        colors={[theme.colors.background, theme.colors.card]}
         style={StyleSheet.absoluteFill}
       />
       <View style={styles.content}>

--- a/App/components/theme/theme.ts
+++ b/App/components/theme/theme.ts
@@ -2,24 +2,24 @@
 
 export const theme = {
   colors: {
-    background: '#0d1117',
-    surface: '#1e2530',
-    text: '#e6edf3',
-    fadedText: '#a0aec0',
-    primary: '#6db3f2',
-    accent: '#91a7ff',
-    success: '#50fa7b',
-    warning: '#ffb86c',
-    danger: '#ff5555',
-    border: '#3b4252',
+    background: '#E8F5E9',
+    surface: '#F1F8E9',
+    text: '#1B1B1B',
+    fadedText: '#3E2723',
+    primary: '#4CAF50',
+    accent: '#81C784',
+    success: '#388E3C',
+    warning: '#FDD835',
+    danger: '#E57373',
+    border: '#A5D6A7',
     gray: '#888888',
-    card: '#2c333f',
-    inputBackground: '#1a1f27'  // 👈 new input background
+    card: '#C8E6C9',
+    inputBackground: '#F1F8E9'
   },
 
 
   fonts: {
-    title: 'serif',                   // swap this with a custom font if desired
+    title: 'System',
     body: 'System'
   },
   spacing: {

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -12,8 +12,11 @@ declare global {
 
 export type RootStackParamList = {
   // Auth stack screens
+  Welcome: undefined;
   Login: undefined;
   Signup: undefined;
+  ForgotPassword: undefined;
+  ForgotUsername: undefined;
   Onboarding: undefined;
   OrganizationSignup: undefined;
 

--- a/App/screens/auth/ForgotPasswordScreen.tsx
+++ b/App/screens/auth/ForgotPasswordScreen.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import ScreenContainer from '@/components/theme/ScreenContainer';
+import TextField from '@/components/TextField';
+import Button from '@/components/common/Button';
+import { resetPassword } from '@/services/authService';
+import { theme } from '@/components/theme/theme';
+
+export default function ForgotPasswordScreen() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleReset = async () => {
+    if (!email) {
+      Alert.alert('Enter Email', 'Please enter your email.');
+      return;
+    }
+    setLoading(true);
+    try {
+      await resetPassword(email);
+      Alert.alert('Password Reset', 'If this email is registered, a reset link has been sent.');
+    } catch (err: any) {
+      Alert.alert('Error', err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScreenContainer>
+      <Text style={styles.title}>Reset Password</Text>
+      <TextField label="Email" value={email} onChangeText={setEmail} placeholder="you@example.com" />
+      <Button title="Send Reset Link" onPress={handleReset} loading={loading} />
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: theme.colors.text,
+    marginBottom: 20,
+  },
+});

--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import ScreenContainer from '@/components/theme/ScreenContainer';
+import TextField from '@/components/TextField';
+import Button from '@/components/common/Button';
+import { queryCollection } from '@/services/firestoreService';
+import { theme } from '@/components/theme/theme';
+
+export default function ForgotUsernameScreen() {
+  const [name, setName] = useState('');
+  const [region, setRegion] = useState('');
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleLookup = async () => {
+    if (!name || !region) {
+      Alert.alert('Missing Info', 'Please enter your name and region.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const users = await queryCollection('users');
+      const match = users.find((u: any) => u.displayName === name && u.region === region);
+      if (match) {
+        setEmail(match.email);
+      } else {
+        Alert.alert('Not Found', 'No matching user found.');
+      }
+    } catch (err) {
+      Alert.alert('Error', 'Lookup failed.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScreenContainer>
+      <Text style={styles.title}>Find Your Email</Text>
+      <TextField label="Name" value={name} onChangeText={setName} placeholder="Your name" />
+      <TextField label="Region" value={region} onChangeText={setRegion} placeholder="Region" />
+      <Button title="Lookup" onPress={handleLookup} loading={loading} />
+      {email && <Text style={styles.result}>Email: {email}</Text>}
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: theme.colors.text,
+    marginBottom: 20,
+  },
+  result: {
+    marginTop: 20,
+    color: theme.colors.primary,
+    textAlign: 'center',
+  },
+});

--- a/App/screens/auth/WelcomeScreen.tsx
+++ b/App/screens/auth/WelcomeScreen.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Button from '@/components/common/Button';
+import ScreenContainer from '@/components/theme/ScreenContainer';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '@/navigation/RootStackParamList';
+import { theme } from '@/components/theme/theme';
+
+export default function WelcomeScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <ScreenContainer>
+      <View style={styles.center}>
+        <Text style={styles.title}>Welcome to OneVine</Text>
+        <Button title="Log In" onPress={() => navigation.navigate('Login')} />
+        <Button title="Sign Up" onPress={() => navigation.navigate('Signup')} />
+        <Button title="Forgot Password" onPress={() => navigation.navigate('ForgotPassword')} />
+        <Button title="Forgot Username" onPress={() => navigation.navigate('ForgotUsername')} />
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: theme.colors.text,
+    marginBottom: 20,
+  },
+});

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -43,7 +43,7 @@ export async function login(email: string, password: string): Promise<AuthRespon
 export async function logout(): Promise<void> {
   await SecureStore.deleteItemAsync('idToken');
   await SecureStore.deleteItemAsync('refreshToken');
-  await SecureStore.deleteItemAsync('localId');
+  await SecureStore.deleteItemAsync('userId');
   await SecureStore.deleteItemAsync('email');
 }
 
@@ -72,7 +72,7 @@ export async function getStoredToken(): Promise<string | null> {
 async function storeAuth(auth: AuthResponse) {
   await SecureStore.setItemAsync('idToken', auth.idToken);
   await SecureStore.setItemAsync('refreshToken', auth.refreshToken);
-  await SecureStore.setItemAsync('localId', auth.localId);
+  await SecureStore.setItemAsync('userId', auth.localId);
   await SecureStore.setItemAsync('email', auth.email);
 }
 

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -4,7 +4,7 @@ import * as SecureStore from 'expo-secure-store';
 import { ensureAuth } from '@/utils/authGuard';
 
 async function getUid(): Promise<string | null> {
-  return await SecureStore.getItemAsync('localId');
+  return await SecureStore.getItemAsync('userId');
 }
 
 interface ChallengeStore {

--- a/App/utils/authGuard.ts
+++ b/App/utils/authGuard.ts
@@ -7,7 +7,7 @@ import { getStoredToken } from '@/services/authService';
  */
 export async function ensureAuth(expectedUid?: string): Promise<string | null> {
   const [uid, token] = await Promise.all([
-    SecureStore.getItemAsync('localId'),
+    SecureStore.getItemAsync('userId'),
     getStoredToken(),
   ]);
 


### PR DESCRIPTION
## Summary
- store userId alongside idToken during login/signup
- guard Firebase calls with new userId key
- add Welcome, ForgotPassword and ForgotUsername screens
- route unauthenticated users to Welcome screen
- soften UI with green theme and polished button styles
- handle Firestore collection errors gracefully

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f1ea8a08330938e033872810ca4