### PR TITLE
Finalize login flow and branding polish

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,7 @@ import { View, ActivityIndicator } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { User } from '@/hooks/useUser';
+import { useUser } from '@/hooks/useUser';
 import { loadUser } from '@/services/userService';
 import { getStoredToken } from './App/services/authService';
 
@@ -46,7 +46,7 @@ import GiveBackScreen from './App/screens/GiveBackScreen';
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
-  const [user, setUser] = useState<User | null>(null);
+  const { user } = useUser();
   const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | undefined>();
   const [checkingAuth, setCheckingAuth] = useState(true);
 
@@ -58,7 +58,6 @@ export default function App() {
         if (uid && token) {
           await loadUser(uid);
           const hasSeen = await SecureStore.getItemAsync(`hasSeenOnboarding-${uid}`);
-          setUser({ uid } as User);
           setInitialRoute(hasSeen === 'true' ? 'Quote' : 'Onboarding');
 
           const { init } = await import('./App/utils/TokenManager');
@@ -76,6 +75,12 @@ export default function App() {
 
     initialize();
   }, []);
+
+  useEffect(() => {
+    if (user) {
+      setInitialRoute((prev) => prev ?? 'Home');
+    }
+  }, [user]);
 
   if (checkingAuth || (!initialRoute && user)) {
     return (

--- a/App/components/common/Button.tsx
+++ b/App/components/common/Button.tsx
@@ -12,7 +12,11 @@ interface ButtonProps {
 export default function Button({ title, onPress, disabled, loading }: ButtonProps) {
   return (
     <Pressable
-      style={({ pressed }) => [styles.button, pressed && styles.pressed, disabled && styles.disabled]}
+      style={({ pressed }) => [
+        styles.button,
+        pressed && styles.pressed,
+        disabled && styles.disabled,
+      ]}
       onPress={onPress}
       disabled={disabled || loading}
     >
@@ -29,7 +33,7 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: theme.colors.primary,
     paddingVertical: 14,
-    borderRadius: 12,
+    borderRadius: 16,
     alignItems: 'center',
     marginVertical: 10,
     shadowColor: '#000',
@@ -37,9 +41,10 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowRadius: 4,
     elevation: 2,
+    minHeight: 48,
   },
   pressed: {
-    opacity: 0.8,
+    backgroundColor: theme.colors.success,
     transform: [{ scale: 0.98 }],
   },
   text: {

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet, Alert, ActivityIndicator } from 'react-native';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
 import { loadUser } from "@/services/userService";
+import * as SecureStore from 'expo-secure-store';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { theme } from "@/components/theme/theme";
-import { useUserStore } from "@/state/userStore";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -24,7 +24,10 @@ export default function LoginScreen() {
     try {
       const result = await login(email, password);
       if (result.localId) {
+        await SecureStore.setItemAsync('userId', result.localId);
+        await SecureStore.setItemAsync('idToken', result.idToken);
         await loadUser(result.localId);
+        navigation.replace('Home');
       }
     } catch (err: any) {
       Alert.alert('Login Failed', err.message);
@@ -48,6 +51,13 @@ export default function LoginScreen() {
 
   return (
     <ScreenContainer>
+      {loading && (
+        <ActivityIndicator
+          style={styles.spinner}
+          size="large"
+          color={theme.colors.primary}
+        />
+      )}
       <Text style={styles.title}>Welcome Back</Text>
 
       <TextField
@@ -102,6 +112,9 @@ const styles = StyleSheet.create({
     marginTop: 20,
     color: theme.colors.primary,
     textAlign: 'center',
+  },
+  spinner: {
+    marginBottom: 16,
   },
 });
 

--- a/App/screens/auth/WelcomeScreen.tsx
+++ b/App/screens/auth/WelcomeScreen.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, Animated, Image } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import Button from '@/components/common/Button';
-import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -9,25 +9,67 @@ import { theme } from '@/components/theme/theme';
 
 export default function WelcomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const anim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: 1,
+      duration: 500,
+      useNativeDriver: true,
+    }).start();
+  }, [anim]);
+
+  const scale = anim.interpolate({ inputRange: [0, 1], outputRange: [0.9, 1] });
+
   return (
-    <ScreenContainer>
-      <View style={styles.center}>
-        <Text style={styles.title}>Welcome to OneVine</Text>
-        <Button title="Log In" onPress={() => navigation.navigate('Login')} />
-        <Button title="Sign Up" onPress={() => navigation.navigate('Signup')} />
-        <Button title="Forgot Password" onPress={() => navigation.navigate('ForgotPassword')} />
-        <Button title="Forgot Username" onPress={() => navigation.navigate('ForgotUsername')} />
+    <LinearGradient colors={["#2E7D32", "#E8F5E9"]} style={styles.container}>
+      <Animated.Image
+        source={require('../../assets/OneVineIcon.png')}
+        style={[styles.logo, { opacity: anim, transform: [{ scale }] }]}
+        resizeMode="contain"
+      />
+      <Text style={styles.title}>Welcome to OneVine</Text>
+      <View style={styles.buttons}>
+        <View style={styles.buttonWrap}>
+          <Button title="Log In" onPress={() => navigation.navigate('Login')} />
+        </View>
+        <View style={styles.buttonWrap}>
+          <Button title="Sign Up" onPress={() => navigation.navigate('Signup')} />
+        </View>
+        <View style={styles.buttonWrap}>
+          <Button title="Forgot Password" onPress={() => navigation.navigate('ForgotPassword')} />
+        </View>
+        <View style={styles.buttonWrap}>
+          <Button title="Forgot Username" onPress={() => navigation.navigate('ForgotUsername')} />
+        </View>
       </View>
-    </ScreenContainer>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  logo: {
+    width: 200,
+    height: 200,
+    alignSelf: 'center',
+    marginBottom: 24,
+  },
+  buttons: {
+    width: '80%',
+    alignSelf: 'center',
+  },
+  buttonWrap: {
+    marginVertical: 8,
+  },
   title: {
     fontSize: 24,
     fontWeight: '700',
     color: theme.colors.text,
-    marginBottom: 20,
+    textAlign: 'center',
+    marginBottom: 24,
   },
 });

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+  "expo": {
+    "icon": "./assets/OneVineIcon.png"
+  }
+}


### PR DESCRIPTION
## Summary
- smooth login flow by saving auth credentials and navigating to home
- animate OneVine icon and polish the welcome screen layout
- tweak common button styling
- integrate user store in App.tsx for navigation updates
- reference OneVine icon in app.json
- add placeholder `assets` directory

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition)*

------
https://chatgpt.com/codex/tasks/task_e_684f2c6ba708833099cfa94397770cba