### PR TITLE
Fix OneVine icon path

### DIFF
--- a/App/screens/auth/WelcomeScreen.tsx
+++ b/App/screens/auth/WelcomeScreen.tsx
@@ -24,7 +24,7 @@ export default function WelcomeScreen() {
   return (
     <LinearGradient colors={["#2E7D32", "#E8F5E9"]} style={styles.container}>
       <Animated.Image
-        source={require('../../assets/OneVineIcon.png')}
+        source={require('../../../assets/OneVineIcon.png')}
         style={[styles.logo, { opacity: anim, transform: [{ scale }] }]}
         resizeMode="contain"
       />


### PR DESCRIPTION
## Summary
- update WelcomeScreen asset path

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_684f36f0740c83309666eac1086ba2ac