### PR TITLE
Fix auth checks and role gating

### DIFF
--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -17,6 +17,10 @@ import { getDocument, setDocument } from '@/services/firestoreService';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
 import { ensureAuth } from '@/utils/authGuard';
+import * as SecureStore from 'expo-secure-store';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '@/navigation/RootStackParamList';
 
 export default function ReligionAIScreen() {
   const [question, setQuestion] = useState('');
@@ -24,10 +28,19 @@ export default function ReligionAIScreen() {
   const [loading, setLoading] = useState(false);
   const [isSubscribed, setIsSubscribed] = useState(false);
   const { user } = useUser();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const handleAsk = async () => {
     if (!question.trim()) {
       Alert.alert('Please enter a question.');
+      return;
+    }
+
+    const idToken = await SecureStore.getItemAsync('idToken');
+    const userId = await SecureStore.getItemAsync('userId');
+    if (!idToken || !userId) {
+      Alert.alert('Login Required', 'Please log in again.');
+      navigation.replace('Login');
       return;
     }
 
@@ -117,9 +130,9 @@ export default function ReligionAIScreen() {
       }
 
       setQuestion('');
-    } catch (err) {
-      console.error('❌ ReligionAI error:', err);
-      Alert.alert('Error', 'Could not get a response. Please try again later.');
+    } catch (err: any) {
+      console.error('🔥 API Error:', err?.response?.data || err.message);
+      Alert.alert('Error', 'Something went wrong. Please try again.');
     } finally {
       setLoading(false);
     }

--- a/App/screens/auth/WelcomeScreen.tsx
+++ b/App/screens/auth/WelcomeScreen.tsx
@@ -23,6 +23,9 @@ export default function WelcomeScreen() {
 
   return (
     <LinearGradient colors={["#2E7D32", "#E8F5E9"]} style={styles.container}>
+      <Text style={styles.loginLink} onPress={() => navigation.replace('Login')}>
+        Already have an account? Go to Login
+      </Text>
       <Animated.Image
         source={require('../../../assets/OneVineIcon.png')}
         style={[styles.logo, { opacity: anim, transform: [{ scale }] }]}
@@ -71,5 +74,11 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
     textAlign: 'center',
     marginBottom: 24,
+  },
+  loginLink: {
+    textAlign: 'center',
+    marginBottom: 12,
+    color: theme.colors.primary,
+    textDecorationLine: 'underline',
   },
 });

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, Button, StyleSheet, ScrollView } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, syncSubscriptionStatus } from "@/utils/TokenManager";
@@ -11,6 +12,8 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 export default function HomeScreen({ navigation }: Props) {
   const [tokens, setTokens] = useState<number>(0);
   const [subscribed, setSubscribed] = useState<boolean>(false);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  const [isOrgManager, setIsOrgManager] = useState<boolean>(false);
 
   useEffect(() => {
     const loadData = async () => {
@@ -18,6 +21,10 @@ export default function HomeScreen({ navigation }: Props) {
       await syncSubscriptionStatus(); // updates Firestore token state
       setTokens(t);
       setSubscribed(t >= 9999); // 9999 token cap implies OneVine+ sub
+      const adminFlag = await SecureStore.getItemAsync('isAdmin');
+      const managerFlag = await SecureStore.getItemAsync('isOrgManager');
+      setIsAdmin(adminFlag === 'true');
+      setIsOrgManager(managerFlag === 'true');
     };
     loadData();
   }, []);
@@ -57,11 +64,17 @@ export default function HomeScreen({ navigation }: Props) {
           <View style={styles.spacer} />
           <Button title="Leaderboards" onPress={() => navigation.navigate('Leaderboards')} />
           <View style={styles.spacer} />
-          <Button title="Submit Proof" onPress={() => navigation.navigate('SubmitProof')} />
-          <View style={styles.spacer} />
+          {subscribed && (
+            <>
+              <Button title="Submit Proof" onPress={() => navigation.navigate('SubmitProof')} />
+              <View style={styles.spacer} />
+            </>
+          )}
           <Button title="Join Organization" onPress={() => navigation.navigate('JoinOrganization')} />
           <View style={styles.spacer} />
-          <Button title="Manage Organization" onPress={() => navigation.navigate('OrganizationManagement')} />
+          {(isAdmin || isOrgManager) && (
+            <Button title="Manage Organization" onPress={() => navigation.navigate('OrganizationManagement')} />
+          )}
         </View>
       </ScrollView>
     </ScreenContainer>

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -5,6 +5,7 @@ import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
+import * as SecureStore from 'expo-secure-store';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
 
@@ -16,6 +17,14 @@ export default function UpgradeScreen({ navigation }: Props) {
     setLoading(true);
 
     try {
+      const idToken = await SecureStore.getItemAsync('idToken');
+      const userId = await SecureStore.getItemAsync('userId');
+      if (!idToken || !userId) {
+        Alert.alert('Login Required', 'Please log in again.');
+        navigation.replace('Login');
+        return;
+      }
+
       if (!user) {
         Alert.alert('Error', 'User not logged in.');
         return;
@@ -44,9 +53,9 @@ export default function UpgradeScreen({ navigation }: Props) {
       } else {
         Alert.alert('Error', 'Something went wrong. Please try again.');
       }
-    } catch (err) {
-      console.error('OneVine+ Subscription Error:', err);
-      Alert.alert('Subscription Failed', 'We could not start the upgrade. Please try again.');
+    } catch (err: any) {
+      console.error('🔥 API Error:', err?.response?.data || err.message);
+      Alert.alert('Error', 'Something went wrong. Please try again.');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- require idToken and userId before API calls
- guard Submit Proof and Manage Organization by user role
- add login link to welcome screen
- log API error bodies for debugging

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find react-native type)*

------
https://chatgpt.com/codex/tasks/task_e_684f4491cbf88330ac0b4fecfa7996f0