### PR TITLE
Fix duplicate token declarations

### DIFF
--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -36,7 +36,7 @@ export default function ReligionAIScreen() {
       return;
     }
 
-    const idToken = await SecureStore.getItemAsync('idToken');
+    let idToken = await SecureStore.getItemAsync('idToken');
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
@@ -106,7 +106,8 @@ export default function ReligionAIScreen() {
         conversationContext = messages.join('\n');
       }
 
-      const idToken = await getStoredToken();
+      // Reuse the token instead of fetching it again
+      idToken = idToken || (await getStoredToken());
       const response = await fetch(ASK_GEMINI_V2, {
         method: 'POST',
         headers: {

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -30,7 +30,7 @@ export default function ChallengeScreen() {
 
   const fetchChallenge = async () => {
     try {
-      const idToken = await SecureStore.getItemAsync('idToken');
+      let idToken = await SecureStore.getItemAsync('idToken');
       const userId = await SecureStore.getItemAsync('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
@@ -55,7 +55,8 @@ export default function ChallengeScreen() {
         return;
       }
 
-      const idToken = await getStoredToken();
+      // Reuse the token instead of fetching it again
+      idToken = idToken || (await getStoredToken());
       const response = await fetch(ASK_GEMINI_SIMPLE, {
         method: 'POST',
         headers: {

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -33,7 +33,7 @@ export default function StreakScreen() {
 
   const fetchStreakMessage = async () => {
     try {
-      const idToken = await SecureStore.getItemAsync('idToken');
+      let idToken = await SecureStore.getItemAsync('idToken');
       const userId = await SecureStore.getItemAsync('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
@@ -66,7 +66,8 @@ export default function StreakScreen() {
                    religion === 'Judaism' ? 'Rabbi' :
                    'Spiritual Guide';
 
-      const idToken = await getStoredToken();
+      // Reuse the token instead of fetching it again
+      idToken = idToken || (await getStoredToken());
 
       const response = await fetch(ASK_GEMINI_SIMPLE, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- reuse idToken in ReligionAIScreen
- reuse idToken in StreakScreen
- reuse idToken in ChallengeScreen

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684f6724d85083309bc0d387f52a102c