### PR TITLE
Fix token checks and Firestore REST usage

### DIFF
--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -32,7 +32,13 @@ export default function GiveBackScreen({ navigation }: Props) {
 
       const rawText = await res.text();
       console.log('🔥 Raw response:', rawText);
-      const data = JSON.parse(rawText);
+      let data: any;
+      try {
+        data = JSON.parse(rawText);
+      } catch {
+        Alert.alert('Error', 'Unexpected server response.');
+        return;
+      }
 
       if (data.url) {
         Linking.openURL(data.url);

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -36,7 +36,7 @@ export default function ReligionAIScreen() {
       return;
     }
 
-    let idToken = await SecureStore.getItemAsync('idToken');
+    let idToken = await getStoredToken();
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -30,7 +30,7 @@ export default function ChallengeScreen() {
 
   const fetchChallenge = async () => {
     try {
-      let idToken = await SecureStore.getItemAsync('idToken');
+      let idToken = await getStoredToken();
       const userId = await SecureStore.getItemAsync('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
@@ -92,7 +92,7 @@ export default function ChallengeScreen() {
       return;
     }
 
-    const idToken = await SecureStore.getItemAsync('idToken');
+    const idToken = await getStoredToken();
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -33,7 +33,7 @@ export default function StreakScreen() {
 
   const fetchStreakMessage = async () => {
     try {
-      let idToken = await SecureStore.getItemAsync('idToken');
+      let idToken = await getStoredToken();
       const userId = await SecureStore.getItemAsync('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -55,7 +55,7 @@ export default function SubmitProofScreen() {
       return;
     }
 
-    const idToken = await SecureStore.getItemAsync('idToken');
+    const idToken = await getStoredToken();
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -17,7 +17,7 @@ export default function UpgradeScreen({ navigation }: Props) {
     setLoading(true);
 
     try {
-      const idToken = await SecureStore.getItemAsync('idToken');
+      const idToken = await getStoredToken();
       const userId = await SecureStore.getItemAsync('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
@@ -46,7 +46,13 @@ export default function UpgradeScreen({ navigation }: Props) {
 
       const rawText = await res.text();
       console.log('🔥 OneVine+ raw response:', rawText);
-      const data = JSON.parse(rawText);
+      let data: any;
+      try {
+        data = JSON.parse(rawText);
+      } catch {
+        Alert.alert('Error', 'Unexpected server response.');
+        return;
+      }
 
       if (data.url) {
         Linking.openURL(data.url);

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -31,7 +31,7 @@ export default function JoinOrganizationScreen() {
 
   const fetchOrgs = async () => {
     try {
-      const idToken = await SecureStore.getItemAsync('idToken');
+      const idToken = await getStoredToken();
       const userId = await SecureStore.getItemAsync('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
@@ -61,7 +61,7 @@ export default function JoinOrganizationScreen() {
 
   const joinOrg = async (org: any) => {
     if (!user) return;
-    const idToken = await SecureStore.getItemAsync('idToken');
+    const idToken = await getStoredToken();
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -42,7 +42,7 @@ export default function OrganizationManagementScreen() {
 
   const loadOrg = async () => {
     if (!user) return;
-    const idToken = await SecureStore.getItemAsync('idToken');
+    const idToken = await getStoredToken();
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
@@ -69,7 +69,7 @@ export default function OrganizationManagementScreen() {
 
   const removeMember = async (uid: string) => {
     if (!org?.id) return;
-    const idToken = await SecureStore.getItemAsync('idToken');
+    const idToken = await getStoredToken();
     const userId = await SecureStore.getItemAsync('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');


### PR DESCRIPTION
## Summary
- validate field names in Firestore REST helpers and improve error logging
- compute updateMask correctly and expose `updateDocument`
- support filtering in `queryCollection`
- check auth token via `getStoredToken` across screens
- handle empty journal cases and HTML API responses gracefully

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f6ecef6488330b10722c38a151c6d