### PR TITLE
Implement earthy theme and header

### DIFF
--- a/App/components/common/Button.tsx
+++ b/App/components/common/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { theme } from '@/components/theme/theme'; // ✅ Fixed path
 
 interface ButtonProps {
@@ -7,24 +8,35 @@ interface ButtonProps {
   onPress: () => void;
   disabled?: boolean;
   loading?: boolean;
+  color?: string;
 }
 
-export default function Button({ title, onPress, disabled, loading }: ButtonProps) {
+export default function Button({ title, onPress, disabled, loading, color }: ButtonProps) {
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
   return (
     <Pressable
       style={({ pressed }) => [
         styles.button,
+        { backgroundColor: color || theme.colors.primary },
         pressed && styles.pressed,
         disabled && styles.disabled,
       ]}
+      onPressIn={() => { scale.value = withTiming(0.97); }}
+      onPressOut={() => { scale.value = withTiming(1); }}
       onPress={onPress}
       disabled={disabled || loading}
     >
-      {loading ? (
-        <ActivityIndicator color="white" />
-      ) : (
-        <Text style={styles.text}>{title}</Text>
-      )}
+      <Animated.View style={animatedStyle}>
+        {loading ? (
+          <ActivityIndicator color={theme.colors.buttonText} />
+        ) : (
+          <Text style={styles.text}>{title}</Text>
+        )}
+      </Animated.View>
     </Pressable>
   );
 }
@@ -45,10 +57,9 @@ const styles = StyleSheet.create({
   },
   pressed: {
     backgroundColor: theme.colors.success,
-    transform: [{ scale: 0.98 }],
   },
   text: {
-    color: 'white',
+    color: theme.colors.buttonText,
     fontSize: 16,
     fontWeight: '600',
   },

--- a/App/components/common/Header.tsx
+++ b/App/components/common/Header.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, StyleSheet, Pressable, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { theme } from '@/components/theme/theme';
+import { RootStackParamList } from '@/navigation/RootStackParamList';
+import { logout } from '@/services/authService';
+
+export default function Header() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const handleLogout = () => {
+    Alert.alert('Sign Out', 'Are you sure you want to sign out?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Sign Out',
+        style: 'destructive',
+        onPress: async () => {
+          await logout();
+          navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Pressable onPress={() => navigation.navigate('Settings')} style={styles.iconWrap}>
+        <Ionicons name="settings-outline" size={24} color={theme.colors.text} />
+      </Pressable>
+      <Pressable onPress={handleLogout} style={styles.iconWrap}>
+        <Ionicons name="log-out-outline" size={24} color={theme.colors.text} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingVertical: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+  },
+  iconWrap: {
+    marginLeft: theme.spacing.md,
+  },
+});

--- a/App/components/theme/ScreenContainer.tsx
+++ b/App/components/theme/ScreenContainer.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import Background from '@/components/theme/Background'; // ✅ Corrected relative import to alias
 import { theme } from '@/components/theme/theme'; // ✅ Corrected alias for theme
+import Header from '@/components/common/Header';
 
 export default function ScreenContainer({ children }: { children: React.ReactNode }) {
   return (
     <Background>
-      <View style={styles.container}>{children}</View>
+      <View style={styles.container}>
+        <Header />
+        {children}
+      </View>
     </Background>
   );
 }

--- a/App/components/theme/theme.ts
+++ b/App/components/theme/theme.ts
@@ -2,19 +2,20 @@
 
 export const theme = {
   colors: {
-    background: '#E8F5E9',
-    surface: '#F1F8E9',
-    text: '#1B1B1B',
-    fadedText: '#3E2723',
-    primary: '#4CAF50',
-    accent: '#81C784',
-    success: '#388E3C',
+    background: '#F5F5E5',
+    surface: '#EFE8D8',
+    text: '#4E342E',
+    fadedText: '#6D4C41',
+    primary: '#6B8E23',
+    accent: '#8FBC8F',
+    success: '#556B2F',
     warning: '#FDD835',
     danger: '#E57373',
-    border: '#A5D6A7',
+    border: '#A1887F',
     gray: '#888888',
-    card: '#C8E6C9',
-    inputBackground: '#F1F8E9'
+    card: '#DDE4C9',
+    inputBackground: '#F8F4EC',
+    buttonText: '#F8F8F0'
   },
 
 

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, Button, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import Button from '@/components/common/Button';
 import { setTokenCount, getTokenCount } from "@/utils/TokenManager";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -3,13 +3,14 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  
   ActivityIndicator,
   StyleSheet,
   Alert,
   ScrollView,
 } from 'react-native';
 import ScreenContainer from "@/components/theme/ScreenContainer";
+import Button from '@/components/common/Button';
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
 import { getDocument } from '@/services/firestoreService';
@@ -111,7 +112,7 @@ const styles = StyleSheet.create({
     minHeight: 100,
     marginBottom: 16,
     textAlignVertical: 'top',
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.surface,
   },
   buttonWrap: {
     marginVertical: 12,

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet, Alert, Linking } from 'react-native';
+import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -10,8 +10,8 @@ import {
   ActivityIndicator,
   Modal,
   Pressable,
-  Button,
 } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import * as LocalAuthentication from 'expo-local-authentication';

--- a/App/screens/QuoteScreen.tsx
+++ b/App/screens/QuoteScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -3,12 +3,12 @@ import {
   View,
   Text,
   TextInput,
-  Button,
   ActivityIndicator,
   StyleSheet,
   Alert,
   ScrollView,
 } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
@@ -217,7 +217,7 @@ const styles = StyleSheet.create({
     minHeight: 100,
     marginBottom: 16,
     textAlignVertical: 'top',
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.surface,
   },
   buttonWrap: {
     marginVertical: 12,

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -109,7 +109,7 @@ const styles = StyleSheet.create({
     color: theme.colors.text
   },
   selectedText: {
-    color: '#fff',
+    color: theme.colors.buttonText,
     fontWeight: 'bold'
   },
   buttonWrap: {

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from 'react';
 import {
   View,
   Text,
-  Button,
   ActivityIndicator,
   StyleSheet,
   Alert,
   ScrollView,
 } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import Button from '@/components/common/Button';
 import * as SecureStore from 'expo-secure-store';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";

--- a/App/screens/dashboard/StreakScreen.tsx
+++ b/App/screens/dashboard/StreakScreen.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from 'react';
 import {
   View,
   Text,
-  Button,
   ActivityIndicator,
   ScrollView,
   StyleSheet,
   Alert,
 } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { ASK_GEMINI_SIMPLE } from "@/utils/constants";

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -3,10 +3,11 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  
   StyleSheet,
   Alert
 } from 'react-native';
+import Button from '@/components/common/Button';
 import * as ImagePicker from 'expo-image-picker';
 import { uploadImage } from '@/services/storageService';
 import { addDocument } from '@/services/firestoreService';
@@ -133,7 +134,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 12,
     marginBottom: 12,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.surface,
     color: theme.colors.text
   },
   filename: {

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -3,12 +3,13 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  
   StyleSheet,
   Alert,
   ActivityIndicator,
   ScrollView
 } from 'react-native';
+import Button from '@/components/common/Button';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
 import ScreenContainer from '@/components/theme/ScreenContainer';
@@ -149,7 +150,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 12,
     marginBottom: 12,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.surface,
     color: theme.colors.text
   }
 });

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet, Alert, Linking } from 'react-native';
+import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
+import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { theme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -3,11 +3,11 @@ import {
   View,
   Text,
   TextInput,
-  Button,
   FlatList,
   StyleSheet,
   Alert
 } from 'react-native';
+import Button from '@/components/common/Button';
 import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { theme } from '@/components/theme/theme';
@@ -135,7 +135,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 12,
     marginBottom: 16,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.surface,
     color: theme.colors.text
   },
   row: {

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -3,11 +3,11 @@ import {
   View,
   Text,
   FlatList,
-  Button,
   StyleSheet,
   Alert,
   ActivityIndicator,
 } from 'react-native';
+import Button from '@/components/common/Button';
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';


### PR DESCRIPTION
## Summary
- refresh theme colors for earthy look
- create Header with Settings and Logout icons
- display Header in ScreenContainer
- convert native buttons to custom Button across screens
- tweak styles to use theme colors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f713a12dc8330a6dab2dd17b201bd