### PR TITLE
Fix Firestore writes and Stripe checkout

### DIFF
--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
+import { createStripeCheckout } from '@/services/apiService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'GiveBack'>;
 
@@ -43,30 +44,13 @@ export default function GiveBackScreen({ navigation }: Props) {
     try {
       if (!user) return;
 
-      const res = await fetch('https://us-central1-wwjd-app.cloudfunctions.net/createCheckoutSession', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          uid: user.uid,
-          type: 'one-time',
-          amount,
-        }),
+      const url = await createStripeCheckout(user.uid, {
+        type: 'one-time',
+        amount,
       });
 
-      const rawText = await res.text();
-      console.log('🔥 Raw response:', rawText);
-      let data: any;
-      try {
-        data = JSON.parse(rawText);
-      } catch {
-        Alert.alert('Error', 'Unexpected server response.');
-        return;
-      }
-
-      if (data.url) {
-        Linking.openURL(data.url);
+      if (url) {
+        Linking.openURL(url);
       } else {
         Alert.alert('Error', 'Something went wrong. Please try again.');
       }

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -164,6 +164,20 @@ export default function ChallengeScreen() {
       individualPoints: (userData.individualPoints || 0) + 5,
     });
 
+    if (userData.religion) {
+      const relData = await getDocument(`religions/${userData.religion}`);
+      await setDocument(`religions/${userData.religion}`, {
+        totalPoints: (relData?.totalPoints || 0) + 5,
+      });
+    }
+
+    if (userData.organizationId) {
+      const orgData = await getDocument(`organizations/${userData.organizationId}`);
+      await setDocument(`organizations/${userData.organizationId}`, {
+        totalPoints: (orgData?.totalPoints || 0) + 5,
+      });
+    }
+
     Alert.alert('Great job!', 'Challenge completed.');
   };
 

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -7,6 +7,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
 import * as SecureStore from 'expo-secure-store';
+import { createStripeCheckout } from '@/services/apiService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
 
@@ -62,32 +63,9 @@ export default function UpgradeScreen({ navigation }: Props) {
         return;
       }
 
-      const res = await fetch(
-        'https://us-central1-wwjd-app.cloudfunctions.net/createCheckoutSession',
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            uid: user.uid,
-            type: 'subscription',
-          }),
-        }
-      );
-
-      const rawText = await res.text();
-      console.log('🔥 OneVine+ raw response:', rawText);
-      let data: any;
-      try {
-        data = JSON.parse(rawText);
-      } catch {
-        Alert.alert('Error', 'Unexpected server response.');
-        return;
-      }
-
-      if (data.url) {
-        Linking.openURL(data.url);
+      const url = await createStripeCheckout(user.uid, { type: 'subscription' });
+      if (url) {
+        Linking.openURL(url);
       } else {
         Alert.alert('Error', 'Something went wrong. Please try again.');
       }

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -6,7 +6,7 @@ type AskGeminiResponse = {
 };
 
 type StripeCheckoutResponse = {
-  checkoutUrl: string;
+  url: string;
 };
 
 export async function askGemini(prompt: string): Promise<string> {
@@ -19,13 +19,16 @@ export async function askGemini(prompt: string): Promise<string> {
   }
 }
 
-export async function createStripeCheckout(userId: string): Promise<string> {
+export async function createStripeCheckout(
+  uid: string,
+  options: { type: 'subscription' | 'one-time'; amount?: number }
+): Promise<string> {
   try {
-    const res = await axios.post<StripeCheckoutResponse>(
-      `${STRIPE_API_URL}/create-checkout`,
-      { userId }
-    );
-    return res.data.checkoutUrl;
+    const res = await axios.post<StripeCheckoutResponse>(STRIPE_API_URL, {
+      uid,
+      ...options,
+    });
+    return res.data.url;
   } catch (err: any) {
     console.error('Stripe API error:', err);
     throw new Error('Unable to start checkout.');


### PR DESCRIPTION
## Summary
- refresh Firebase ID tokens as needed
- improve journal entry saving with extra fields and scoring updates
- fix challenge and trivia scoring + leaderboards
- revise trivia flow with two questions
- hook up Stripe checkout helpers and update purchase screens

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'react-native')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68506b57a3d88330b2c7d2335315a5dd