### PR TITLE
Prepare functions for public EAS build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_FUNCTION_BASE_URL=https://us-central1-wwjd-app.cloudfunctions.net

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ build/
 firebase-debug.log
 .firebase/
 # Environment
-.env
 .env.*
+!.env.example
 
 # VSCode/Visual Studio files
 .vscode/

--- a/App/config/apiConfig.ts
+++ b/App/config/apiConfig.ts
@@ -1,2 +1,4 @@
-export const GEMINI_API_URL = 'https://us-central1-wwjd-app.cloudfunctions.net/geminiHandler';
-export const STRIPE_API_URL = 'https://us-central1-wwjd-app.cloudfunctions.net/createCheckoutSession';
+const BASE_URL = process.env.EXPO_PUBLIC_FUNCTION_BASE_URL;
+
+export const GEMINI_API_URL = `${BASE_URL}/askGeminiV2`;
+export const STRIPE_API_URL = `${BASE_URL}/createCheckoutSession`;

--- a/App/services/functionService.ts
+++ b/App/services/functionService.ts
@@ -1,7 +1,6 @@
 import { getStoredToken } from './authService';
 
-const PROJECT_ID = process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID;
-const REGION = process.env.EXPO_PUBLIC_FIREBASE_REGION || 'us-central1';
+const BASE_URL = process.env.EXPO_PUBLIC_FUNCTION_BASE_URL;
 
 export async function callFunction(name: string, data: any): Promise<any> {
   const idToken = await getStoredToken();
@@ -11,7 +10,7 @@ export async function callFunction(name: string, data: any): Promise<any> {
   }
 
   const res = await fetch(
-    `https://${REGION}-${PROJECT_ID}.cloudfunctions.net/${name}`,
+    `${BASE_URL}/${name}`,
     {
       method: 'POST',
       headers: {

--- a/App/utils/constants.ts
+++ b/App/utils/constants.ts
@@ -1,8 +1,9 @@
-// Direct URLs to deployed Gemini and Stripe endpoints
-export const ASK_GEMINI_V2 = 'https://askgeminiv2-xjp7iiye6a-uc.a.run.app';
+const BASE_URL = process.env.EXPO_PUBLIC_FUNCTION_BASE_URL;
+
+export const ASK_GEMINI_V2 = `${BASE_URL}/askGeminiV2`;
 export const ASK_GEMINI_SIMPLE = ASK_GEMINI_V2; // alias to unify usage
 
-export const STRIPE_WEBHOOK_URL = 'https://handlestripewebhookv2-xjp7iiye6a-uc.a.run.app'; // Optional if you plan to ping it
+export const STRIPE_WEBHOOK_URL = `${BASE_URL}/handleStripeWebhookV2`; // Optional if you plan to ping it
 
 // Optional legacy API base (if still using other functions there)
-export const API_BASE_URL = 'https://us-central1-wwjd-app.cloudfunctions.net';
+export const API_BASE_URL = BASE_URL;

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Enable Anonymous Authentication
 Set up Firestore
 
 Firebase Setup uses the Expo-compatible Web SDK via the `firebase` package.
+
+### Environment Variables
+
+Create a `.env` file in the project root with the following entry so the app can
+reach your deployed Firebase functions from any network:
+
+```env
+EXPO_PUBLIC_FUNCTION_BASE_URL=https://us-central1-wwjd-app.cloudfunctions.net
+```
 📱 Key Features
 ✝️ 🕉️ ☪️ 🕎 Multi-Faith Reflection AI
 Dynamic prompts based on selected religion


### PR DESCRIPTION
## Summary
- fetch Cloud Functions from URL in `EXPO_PUBLIC_FUNCTION_BASE_URL`
- adjust constants and services to use env-based URLs
- document `EXPO_PUBLIC_FUNCTION_BASE_URL` and provide `.env.example`
- track `.env.example` in git

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_6850771f64c08330b84c22154be5cf6e