### PR TITLE
Fix login flow and add error boundary

### DIFF
--- a/App/components/common/ErrorBoundary.tsx
+++ b/App/components/common/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/components/theme/theme';
+
+export default class ErrorBoundary extends React.Component<{children: React.ReactNode}> {
+  state = { hasError: false, error: null as any };
+
+  static getDerivedStateFromError(error: any) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: any, info: any) {
+    console.error('Unhandled error caught by ErrorBoundary:', error, info);
+  }
+
+  render() {
+    const { hasError, error } = this.state as any;
+    const theme = useTheme();
+    if (hasError) {
+      return (
+        <View style={styles(theme).container}>
+          <Text style={styles(theme).text}>Something went wrong.</Text>
+          {error && <Text style={styles(theme).error}>{String(error)}</Text>}
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = (theme: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.background,
+      padding: 16,
+    },
+    text: { color: theme.colors.text, marginBottom: 8, fontSize: 16 },
+    error: { color: theme.colors.accent, textAlign: 'center' },
+  });


### PR DESCRIPTION
## Summary
- start unauthenticated users on the Login screen
- add console logging for auth/navigation state
- check onboarding status on login and route accordingly
- wrap navigator in an error boundary

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_68507f86f2ac8330b34f9459ae0ed420