### PR TITLE
Fix startup crash in OneVine

### DIFF
--- a/App/components/common/ErrorBoundary.tsx
+++ b/App/components/common/ErrorBoundary.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/components/theme/theme';
 
-export default class ErrorBoundary extends React.Component<{children: React.ReactNode}> {
+interface BoundaryProps {
+  children: React.ReactNode;
+  theme: ReturnType<typeof useTheme>;
+}
+
+class Boundary extends React.Component<BoundaryProps> {
   state = { hasError: false, error: null as any };
 
   static getDerivedStateFromError(error: any) {
@@ -15,7 +20,7 @@ export default class ErrorBoundary extends React.Component<{children: React.Reac
 
   render() {
     const { hasError, error } = this.state as any;
-    const theme = useTheme();
+    const { theme } = this.props;
     if (hasError) {
       return (
         <View style={styles(theme).container}>
@@ -26,6 +31,11 @@ export default class ErrorBoundary extends React.Component<{children: React.Reac
     }
     return this.props.children;
   }
+}
+
+export default function ErrorBoundary({ children }: { children: React.ReactNode }) {
+  const theme = useTheme();
+  return <Boundary theme={theme}>{children}</Boundary>;
 }
 
 const styles = (theme: any) =>

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
 import Button from '@/components/common/Button';
 import { useUser } from '@/hooks/useUser';
 import { createStripeCheckout } from '@/services/apiService';

--- a/App/screens/auth/WelcomeScreen.tsx
+++ b/App/screens/auth/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { View, Text, StyleSheet, Animated, Image } from 'react-native';
+import { View, Text, StyleSheet, Animated } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Button from '@/components/common/Button';
 import { useNavigation } from '@react-navigation/native';
@@ -64,11 +64,7 @@ export default function WelcomeScreen() {
       <Text style={styles.loginLink} onPress={() => navigation.replace('Login')}>
         Already have an account? Go to Login
       </Text>
-      <Animated.Image
-        source={require('../../../assets/OneVineIcon.png')}
-        style={[styles.logo, { opacity: anim, transform: [{ scale }] }]}
-        resizeMode="contain"
-      />
+      {/* Image removed if asset missing to prevent crash */}
       <Text style={styles.title}>Welcome to OneVine</Text>
       <View style={styles.buttons}>
         <View style={styles.buttonWrap}>


### PR DESCRIPTION
## Summary
- fix invalid hook usage in ErrorBoundary
- import Linking on BuyTokens screen
- remove missing image from Welcome screen

## Testing
- `npm install`
- `npx tsc --noEmit` *(fails: cannot find type definition file and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68508a0c364c8330903463536e99e0dd