### PR TITLE
Align screens with responsibilities

### DIFF
--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -5,8 +5,6 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
-import { loadUser } from "@/services/userService";
-import { getDocument } from "@/services/firestoreService";
 import * as SecureStore from 'expo-secure-store';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -29,20 +27,10 @@ export default function LoginScreen() {
       if (result.localId) {
         await SecureStore.setItemAsync('userId', result.localId);
         await SecureStore.setItemAsync('idToken', result.idToken);
-        await loadUser(result.localId);
-        let hasSeen = await SecureStore.getItemAsync(
+
+        const hasSeen = await SecureStore.getItemAsync(
           `hasSeenOnboarding-${result.localId}`
         );
-        if (!hasSeen) {
-          const userDoc = await getDocument(`users/${result.localId}`);
-          if (userDoc?.onboardingComplete) {
-            hasSeen = 'true';
-            await SecureStore.setItemAsync(
-              `hasSeenOnboarding-${result.localId}`,
-              'true'
-            );
-          }
-        }
         navigation.replace(hasSeen === 'true' ? 'Home' : 'Onboarding');
       }
     } catch (err: any) {

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -5,6 +5,7 @@ import Button from "@/components/common/Button";
 import { useNavigation, CommonActions } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { completeOnboarding, updateUserFields } from "@/services/userService";
+import { loadUser } from "@/services/userService";
 import { useUserStore } from "@/state/userStore";
 import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
@@ -25,6 +26,21 @@ export default function OnboardingScreen() {
   const [region, setRegion] = useState('');
   const [organization, setOrganization] = useState('');
   const [loading, setLoading] = useState(false);
+
+  React.useEffect(() => {
+    if (user) return;
+    async function fetchUser() {
+      try {
+        const uid = await SecureStore.getItemAsync('userId');
+        if (uid) {
+          await loadUser(uid);
+        }
+      } catch (err) {
+        console.warn('Failed to load user', err);
+      }
+    }
+    fetchUser();
+  }, [user]);
 
   const handleContinue = async () => {
     if (!user) {


### PR DESCRIPTION
## Summary
- trim LoginScreen logic down to auth-only responsibilities
- fetch user profile after login from OnboardingScreen if missing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685094c402488330b3c91cbdcfe2c815