### PR TITLE
Fix Kotlin version for EAS build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   dependencies {
     classpath('com.android.tools.build:gradle')
     classpath('com.facebook.react:react-native-gradle-plugin')
-    classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+    classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22')
   }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -57,4 +57,3 @@ expo.useLegacyPackaging=false
 
 # Whether the app is configured to use edge-to-edge via the app config or `react-native-edge-to-edge` plugin
 expo.edgeToEdgeEnabled=false
-android.kotlinVersion=1.8.10


### PR DESCRIPTION
## Summary
- fix kotlin gradle plugin version
- clean up gradle.properties

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850cad031a08330a29c5383ca6154e7