### PR TITLE
Fix Android compile SDK

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -85,13 +85,13 @@ android {
     ndkVersion rootProject.ext.ndkVersion
 
     buildToolsVersion rootProject.ext.buildToolsVersion
-    compileSdk rootProject.ext.compileSdkVersion
+    compileSdk 35
 
     namespace 'com.whippybuckle.onevineapp'
     defaultConfig {
         applicationId 'com.whippybuckle.onevineapp'
         minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0.0"
     }

--- a/app.config.js
+++ b/app.config.js
@@ -32,6 +32,8 @@ export default ({ config }) => ({
           // ✅ No need to configure Google Services or Firebase here anymore
           kotlinVersion: "1.8.10",
           jsEngine: "jsc",
+          compileSdkVersion: 35,
+          targetSdkVersion: 35,
         },
         ios: {
           jsEngine: "jsc",


### PR DESCRIPTION
## Summary
- update compileSdkVersion and targetSdkVersion to 35
- expose these settings in app.config.js for future prebuilds

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_6850f50908988330b62ea6ab275aea99