### PR TITLE
Fix adaptive icon path for Expo prebuild

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -16,7 +16,7 @@ export default ({ config }) => ({
     package: "com.whippybuckle.onevineapp",
     versionCode: 1,
     adaptiveIcon: {
-      foregroundImage: "./assets/adaptive-icon.png",
+      foregroundImage: "./assets/OneVineIcon.png",
       backgroundColor: "#FFFFFF",
     },
   },


### PR DESCRIPTION
## Summary
- correct `adaptiveIcon` path in `app.config.js`
- verified project prebuild runs cleanly

## Testing
- `npm install`
- `npx expo prebuild --clean --no-install --platform android`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbf69ac88330bfc2071827c0050d