### PR TITLE
Fix missing styles

### DIFF
--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -32,6 +32,20 @@ export default function GiveBackScreen({ navigation }: Props) {
         donateWrap: { marginBottom: 16, alignItems: 'center' },
         price: { color: theme.colors.accent, fontWeight: '600' },
         buttonWrap: { marginTop: 32, alignItems: 'center' },
+        section: {
+          marginVertical: 20,
+          padding: 16,
+          backgroundColor: '#fff',
+          borderRadius: 12,
+          shadowColor: '#000',
+          shadowOpacity: 0.05,
+          shadowOffset: { width: 0, height: 2 },
+          shadowRadius: 6,
+          elevation: 2,
+        }, // ✅ added missing 'section' style
+        buttonGroup: { flexDirection: 'row', justifyContent: 'space-around', marginVertical: 16 }, // ✅ added missing 'buttonGroup' style
+        note: { fontSize: 14, textAlign: 'center', marginTop: 16, color: theme.colors.text }, // ✅ added missing 'note' style
+        backWrap: { marginTop: 32, alignItems: 'center' }, // ✅ added missing 'backWrap' style
       }),
     [theme],
   );

--- a/App/screens/QuoteScreen.tsx
+++ b/App/screens/QuoteScreen.tsx
@@ -14,12 +14,19 @@ export default function QuoteScreen({ navigation }: Props) {
     () =>
       StyleSheet.create({
         content: { flex: 1, justifyContent: 'center' },
+        center: { flex: 1, justifyContent: 'center', alignItems: 'center' }, // ✅ added missing 'center' style
         verse: {
           fontSize: 20,
           textAlign: 'center',
           marginBottom: 16,
           color: theme.colors.text,
         },
+        quote: {
+          fontSize: 20,
+          textAlign: 'center',
+          marginBottom: 16,
+          color: theme.colors.text,
+        }, // ✅ added missing 'quote' style
         reference: {
           fontSize: 16,
           textAlign: 'center',

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -50,6 +50,21 @@ export default function ReligionAIScreen() {
           fontStyle: 'italic',
           color: theme.colors.text,
         },
+        title: {
+          fontSize: 24,
+          fontWeight: 'bold',
+          textAlign: 'center',
+          marginBottom: 16,
+          color: theme.colors.primary,
+        }, // ✅ added missing 'title' style
+        subscriptionBanner: {
+          padding: 12,
+          backgroundColor: theme.colors.surface,
+          borderRadius: 8,
+          marginBottom: 12,
+          alignItems: 'center',
+        }, // ✅ added missing 'subscriptionBanner' style
+        subscriptionText: { marginBottom: 8, color: theme.colors.text }, // ✅ added missing 'subscriptionText' style
       }),
     [theme],
   );

--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -12,6 +12,13 @@ export default function ForgotUsernameScreen() {
     () =>
       StyleSheet.create({
         container: { paddingBottom: 64 },
+        title: {
+          fontSize: 24,
+          fontWeight: '700',
+          color: theme.colors.text,
+          marginBottom: 20,
+          textAlign: 'center',
+        }, // ✅ added missing 'title' style
         label: { fontSize: 16, marginBottom: 8, color: theme.colors.text },
         email: { fontSize: 18, textAlign: 'center', color: theme.colors.primary },
         input: {
@@ -24,6 +31,12 @@ export default function ForgotUsernameScreen() {
           color: theme.colors.text,
         },
         buttonWrap: { marginTop: 24, alignItems: 'center' },
+        result: {
+          marginTop: 16,
+          fontSize: 16,
+          color: theme.colors.text,
+          textAlign: 'center',
+        }, // ✅ added missing 'result' style
       }),
     [theme],
   );

--- a/App/screens/auth/OrganizationSignupScreen.tsx
+++ b/App/screens/auth/OrganizationSignupScreen.tsx
@@ -41,6 +41,9 @@ export default function OrganizationSignupScreen({ navigation }: Props) {
         tierRow: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 16 },
         tierOption: { color: theme.colors.text },
         buttonWrap: { marginTop: 24, alignItems: 'center' },
+        label: { fontSize: 16, marginBottom: 8, color: theme.colors.text }, // ✅ added missing 'label' style
+        buttonGroup: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 16 }, // ✅ added missing 'buttonGroup' style
+        submitWrap: { marginTop: 24, alignItems: 'center' }, // ✅ added missing 'submitWrap' style
       }),
     [theme],
   );

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -40,6 +40,20 @@ export default function SelectReligionScreen({ navigation }: Props) {
         itemText: { color: theme.colors.text },
         selectedItem: { backgroundColor: theme.colors.accent },
         buttonWrap: { marginTop: 24, alignItems: 'center' },
+        religionItem: {
+          padding: 12,
+          borderBottomWidth: 1,
+          borderColor: theme.colors.border,
+        }, // ✅ added missing 'religionItem' style
+        religionText: { color: theme.colors.text }, // ✅ added missing 'religionText' style
+        selectedText: { color: theme.colors.background }, // ✅ added missing 'selectedText' style
+        title: {
+          fontSize: 24,
+          fontWeight: '700',
+          color: theme.colors.text,
+          marginBottom: 20,
+          textAlign: 'center',
+        }, // ✅ added missing 'title' style
       }),
     [theme],
   );

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -41,6 +41,11 @@ export default function ChallengeScreen() {
           marginBottom: 12,
           color: theme.colors.text,
         },
+        challenge: {
+          fontSize: 16,
+          marginBottom: 12,
+          color: theme.colors.text,
+        }, // ✅ added missing 'challenge' style
         buttonWrap: { marginVertical: 8 },
       }),
     [theme],

--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -31,6 +31,27 @@ export default function LeaderboardsScreen() {
           borderRadius: 8,
         },
         itemText: { color: theme.colors.text },
+        section: {
+          marginBottom: 24,
+          padding: 16,
+          backgroundColor: '#fff',
+          borderRadius: 12,
+          shadowColor: '#000',
+          shadowOpacity: 0.05,
+          shadowOffset: { width: 0, height: 2 },
+          shadowRadius: 6,
+          elevation: 2,
+        }, // ✅ added missing 'section' style
+        sectionTitle: {
+          fontSize: 18,
+          fontWeight: '600',
+          marginBottom: 8,
+          color: theme.colors.text,
+        }, // ✅ added missing 'sectionTitle' style
+        row: { flexDirection: 'row', alignItems: 'center', marginBottom: 4 }, // ✅ added missing 'row' style
+        rank: { width: 30, color: theme.colors.text, fontWeight: 'bold' }, // ✅ added missing 'rank' style
+        name: { flex: 1, color: theme.colors.text }, // ✅ added missing 'name' style
+        points: { color: theme.colors.accent }, // ✅ added missing 'points' style
       }),
     [theme],
   );

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -27,6 +27,13 @@ export default function SubmitProofScreen() {
     () =>
       StyleSheet.create({
         container: { paddingBottom: 64 },
+        title: {
+          fontSize: 24,
+          fontWeight: '700',
+          color: theme.colors.text,
+          marginBottom: 20,
+          textAlign: 'center',
+        }, // ✅ added missing 'title' style
         input: {
           borderWidth: 1,
           borderColor: theme.colors.border,
@@ -38,6 +45,7 @@ export default function SubmitProofScreen() {
         },
         preview: { marginVertical: 12, width: '100%', height: 200 },
         buttonWrap: { marginVertical: 8 },
+        filename: { marginVertical: 8, color: theme.colors.text }, // ✅ added missing 'filename' style
       }),
     [theme],
   );

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -24,6 +24,13 @@ export default function TriviaScreen() {
     () =>
       StyleSheet.create({
         container: { paddingBottom: 64 },
+        title: {
+          fontSize: 24,
+          fontWeight: '700',
+          color: theme.colors.text,
+          marginBottom: 16,
+          textAlign: 'center',
+        }, // ✅ added missing 'title' style
         question: {
           fontSize: 16,
           marginBottom: 12,
@@ -40,6 +47,11 @@ export default function TriviaScreen() {
         },
         buttonWrap: { marginVertical: 8 },
         answer: { marginTop: 12, color: theme.colors.primary },
+        story: {
+          fontSize: 16,
+          marginBottom: 12,
+          color: theme.colors.text,
+        }, // ✅ added missing 'story' style
       }),
     [theme],
   );

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -25,6 +25,13 @@ export default function JoinOrganizationScreen() {
     () =>
       StyleSheet.create({
         container: { paddingBottom: 64 },
+        title: {
+          fontSize: 24,
+          fontWeight: '700',
+          color: theme.colors.text,
+          marginBottom: 20,
+          textAlign: 'center',
+        }, // ✅ added missing 'title' style
         input: {
           borderWidth: 1,
           borderColor: theme.colors.border,
@@ -37,6 +44,10 @@ export default function JoinOrganizationScreen() {
         item: { padding: 12, borderBottomWidth: 1, borderColor: theme.colors.border },
         itemName: { color: theme.colors.text },
         buttonWrap: { marginTop: 24, alignItems: 'center' },
+        row: { flexDirection: 'row', alignItems: 'center', paddingVertical: 8, borderBottomWidth: 1, borderColor: theme.colors.border }, // ✅ added missing 'row' style
+        infoWrap: { flex: 1, marginRight: 8 }, // ✅ added missing 'infoWrap' style
+        name: { fontSize: 16, fontWeight: '600', color: theme.colors.text }, // ✅ added missing 'name' style
+        meta: { color: theme.colors.fadedText, fontSize: 14 }, // ✅ added missing 'meta' style
       }),
     [theme],
   );

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -32,6 +32,12 @@ export default function OrganizationManagementScreen() {
           textAlign: 'center',
           color: theme.colors.primary,
         },
+        subtitle: {
+          fontSize: 16,
+          color: theme.colors.text,
+          marginBottom: 8,
+          textAlign: 'center',
+        }, // ✅ added missing 'subtitle' style
         item: {
           padding: 12,
           borderBottomWidth: 1,
@@ -39,6 +45,22 @@ export default function OrganizationManagementScreen() {
         },
         itemText: { color: theme.colors.text },
         buttonWrap: { marginTop: 24, alignItems: 'center' },
+        sectionTitle: {
+          fontSize: 18,
+          fontWeight: '600',
+          marginTop: 16,
+          marginBottom: 8,
+          color: theme.colors.text,
+        }, // ✅ added missing 'sectionTitle' style
+        row: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingVertical: 8,
+          borderBottomWidth: 1,
+          borderColor: theme.colors.border,
+        }, // ✅ added missing 'row' style
+        memberText: { flex: 1, color: theme.colors.text }, // ✅ added missing 'memberText' style
       }),
     [theme],
   );


### PR DESCRIPTION
## Summary
- add missing `section` and other layout styles across screens
- fix undefined styles in Quote and Trivia screens
- clean up organization and leaderboard styles
- ensure all used styles are defined

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_6856fd0d8a308330953c1e2f1601cc3b