### PR TITLE
Cleanup text component and update metadata

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -62,10 +62,8 @@ export default function App() {
   useEffect(() => {
     if (fontsLoaded) {
       console.log('✅ Fonts loaded');
-      Text.defaultProps = Text.defaultProps || {};
-      Text.defaultProps.style = { fontFamily: theme.fonts.body };
     }
-  }, [fontsLoaded, theme]);
+  }, [fontsLoaded]);
 
   useEffect(() => {
     const initialize = async () => {

--- a/App/components/TextField.tsx
+++ b/App/components/TextField.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React from 'react';
-import { TextInput, StyleSheet, View, Text } from 'react-native';
+import { TextInput, StyleSheet, View } from 'react-native';
 import { useTheme } from '@/components/theme/theme';
 
 interface TextFieldProps {
@@ -40,7 +41,7 @@ export default function TextField({
   );
   return (
     <View style={styles.wrapper}>
-      {label && <Text style={styles.label}>{label}</Text>}
+      {label && <CustomText style={styles.label}>{label}</CustomText>}
       <TextInput
         style={styles.input}
         placeholder={placeholder}

--- a/App/components/common/Button.tsx
+++ b/App/components/common/Button.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React from 'react';
-import { Text, Pressable, StyleSheet, ActivityIndicator, View } from 'react-native';
+import {  Pressable, StyleSheet, ActivityIndicator, View } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useTheme } from '@/components/theme/theme';
 import { useThemeAssets } from '@/components/theme/themeAssets';
@@ -71,14 +72,14 @@ export default function Button({ title, onPress, disabled, loading, color }: But
       disabled={disabled || loading}
     >
       <LinearGradient
-        colors={color ? [color, color] : assets.buttonGradient}
+        colors={color ? [color, color] : (assets.buttonGradient as [string, string])}
         style={styles.gradient}
       >
         <Animated.View style={animatedStyle}>
           {loading ? (
             <ActivityIndicator color={theme.colors.buttonText} />
           ) : (
-            <Text style={styles.text}>{title}</Text>
+            <CustomText style={styles.text}>{title}</CustomText>
           )}
         </Animated.View>
       </LinearGradient>

--- a/App/components/common/CustomText.tsx
+++ b/App/components/common/CustomText.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, TextProps } from 'react-native';
+import { useTheme } from '../theme/theme';
+
+export default function CustomText(props: TextProps) {
+  const theme = useTheme();
+  return (
+    <Text allowFontScaling={false} {...props} style={[{ fontFamily: theme.fonts.body }, props.style]} />
+  );
+}

--- a/App/components/common/ErrorBoundary.tsx
+++ b/App/components/common/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View,  StyleSheet } from 'react-native';
 import { useTheme } from '@/components/theme/theme';
 
 interface BoundaryProps {
@@ -24,8 +25,8 @@ class Boundary extends React.Component<BoundaryProps> {
     if (hasError) {
       return (
         <View style={styles(theme).container}>
-          <Text style={styles(theme).text}>Something went wrong.</Text>
-          {error && <Text style={styles(theme).error}>{String(error)}</Text>}
+          <CustomText style={styles(theme).text}>Something went wrong.</CustomText>
+          {error && <CustomText style={styles(theme).error}>{String(error)}</CustomText>}
         </View>
       );
     }

--- a/App/components/common/Modal.tsx
+++ b/App/components/common/Modal.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React from 'react'
-import { Modal as RNModal, View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { Modal as RNModal, View,  StyleSheet, TouchableOpacity } from 'react-native'
 import { useTheme } from "@/components/theme/theme"
 
 interface ModalProps {
@@ -50,10 +51,10 @@ export default function Modal({ visible, title, onClose, children }: ModalProps)
     <RNModal animationType="slide" transparent visible={visible}>
       <View style={styles.overlay}>
         <View style={styles.container}>
-          {title && <Text style={styles.title}>{title}</Text>}
+          {title && <CustomText style={styles.title}>{title}</CustomText>}
           <View style={styles.content}>{children}</View>
           <TouchableOpacity onPress={onClose} style={styles.close}>
-            <Text style={styles.closeText}>Close</Text>
+            <CustomText style={styles.closeText}>Close</CustomText>
           </TouchableOpacity>
         </View>
       </View>

--- a/App/components/common/StartupAnimation.tsx
+++ b/App/components/common/StartupAnimation.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View,  StyleSheet } from 'react-native';
 import Animated, { useSharedValue, withTiming, useAnimatedStyle } from 'react-native-reanimated';
 import { useTheme } from '@/components/theme/theme';
 
@@ -26,7 +27,7 @@ export default function StartupAnimation({ onDone }: { onDone: () => void }) {
 
   return (
     <Animated.View style={[styles.container, animStyle]} pointerEvents="none">
-      <Text style={styles.text}>OneVine</Text>
+      <CustomText style={styles.text}>OneVine</CustomText>
     </Animated.View>
   );
 }

--- a/App/components/theme/Background.tsx
+++ b/App/components/theme/Background.tsx
@@ -18,7 +18,7 @@ export default function Background({ children }: { children: React.ReactNode }) 
   return (
     <View style={styles.wrapper}>
       <LinearGradient
-        colors={assets.bgGradient}
+        colors={assets.bgGradient as [string, string]}
         style={StyleSheet.absoluteFill}
       />
       <View style={styles.content}>{children}</View>

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React from 'react';
-import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
+import { View,  StyleSheet, Alert, Linking } from 'react-native';
 import Button from '@/components/common/Button';
 import { useUser } from '@/hooks/useUser';
 import { createStripeCheckout } from '@/services/apiService';
@@ -77,27 +78,27 @@ export default function BuyTokensScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <Text style={styles.title}>Buy Grace Tokens</Text>
-        <Text style={styles.subtitle}>Use tokens for extra asks and confessions</Text>
+        <CustomText style={styles.title}>Buy Grace Tokens</CustomText>
+        <CustomText style={styles.subtitle}>Use tokens for extra asks and confessions</CustomText>
 
         <View style={styles.pack}>
-          <Text style={styles.amount}>
-            5 Tokens — <Text style={styles.price}>$1.99</Text>
-          </Text>
+          <CustomText style={styles.amount}>
+            5 Tokens — <CustomText style={styles.price}>$1.99</CustomText>
+          </CustomText>
           <Button title="Buy 5 Tokens" onPress={() => purchase(5)} />
         </View>
 
         <View style={styles.pack}>
-          <Text style={styles.amount}>
-            15 Tokens — <Text style={styles.price}>$4.99</Text>
-          </Text>
+          <CustomText style={styles.amount}>
+            15 Tokens — <CustomText style={styles.price}>$4.99</CustomText>
+          </CustomText>
           <Button title="Buy 15 Tokens" onPress={() => purchase(15)} />
         </View>
 
         <View style={styles.pack}>
-          <Text style={styles.amount}>
-            40 Tokens — <Text style={styles.price}>$9.99</Text>
-          </Text>
+          <CustomText style={styles.amount}>
+            40 Tokens — <CustomText style={styles.price}>$9.99</CustomText>
+          </CustomText>
           <Button title="Buy 40 Tokens" onPress={() => purchase(40)} />
         </View>
 

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState, useEffect } from 'react';
 import {
   View,
@@ -134,7 +135,7 @@ export default function ConfessionalScreen() {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>Confessional</Text>
+        <CustomText style={styles.title}>Confessional</CustomText>
         <TextInput
           style={styles.input}
           placeholder="What's on your heart?"
@@ -142,13 +143,13 @@ export default function ConfessionalScreen() {
           onChangeText={setText}
           multiline
         />
-        <Text style={styles.systemMsg}>This conversation is private and vanishes when you leave.</Text>
+        <CustomText style={styles.systemMsg}>This conversation is private and vanishes when you leave.</CustomText>
         <View style={styles.buttonWrap}>
           <Button title="Send" onPress={handleConfess} disabled={loading || messages.length >= 10} />
         </View>
         {loading && <ActivityIndicator size="large" color={theme.colors.primary} />}
         {messages.map((m, idx) => (
-          <Text key={idx} style={styles.response}>{m.sender === 'user' ? 'You: ' : ''}{m.text}</Text>
+          <CustomText key={idx} style={styles.response}>{m.sender === 'user' ? 'You: ' : ''}{m.text}</CustomText>
         ))}
       </ScrollView>
     </ScreenContainer>

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
+import { View,  StyleSheet, Alert, Linking } from 'react-native';
 import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
@@ -79,12 +80,12 @@ export default function GiveBackScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <Text style={styles.title}>Give Back</Text>
-        <Text style={styles.subtitle}>
+        <CustomText style={styles.title}>Give Back</CustomText>
+        <CustomText style={styles.subtitle}>
           Your donations help others receive spiritual guidance, food support, and emotional healing.
-        </Text>
+        </CustomText>
 
-        <Text style={styles.section}>Make a One-Time Gift:</Text>
+        <CustomText style={styles.section}>Make a One-Time Gift:</CustomText>
 
         <View style={styles.buttonGroup}>
           <Button title="$2" onPress={() => handleDonation(2)} disabled={donating} />
@@ -92,9 +93,9 @@ export default function GiveBackScreen({ navigation }: Props) {
           <Button title="$10" onPress={() => handleDonation(10)} disabled={donating} />
         </View>
 
-        <Text style={styles.note}>
+        <CustomText style={styles.note}>
           Thank you for walking in love. Every gift reflects the heart of Christ.
-        </Text>
+        </CustomText>
 
         <View style={styles.backWrap}>
           <Button title="Back to Home" onPress={() => navigation.navigate('Home')} />

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState, useEffect } from 'react';
 import {
   View,
@@ -276,10 +277,10 @@ export default function JournalScreen() {
       <ScrollView contentContainerStyle={styles.container}>
         {!guidedMode ? (
           <>
-            <Text style={styles.prompt}>
+            <CustomText style={styles.prompt}>
               Today’s Prompt:{' '}
-              <Text style={styles.promptBold}>What’s on your heart this morning?</Text>
-            </Text>
+              <CustomText style={styles.promptBold}>What’s on your heart this morning?</CustomText>
+            </CustomText>
 
             <TextInput
               style={styles.input}
@@ -309,8 +310,8 @@ export default function JournalScreen() {
           </>
         ) : (
           <>
-            <Text style={styles.prompt}>{prompts[currentStep]}</Text>
-            <Text style={styles.promptBold}>{`${currentStep + 1} of ${prompts.length}`}</Text>
+            <CustomText style={styles.prompt}>{prompts[currentStep]}</CustomText>
+            <CustomText style={styles.promptBold}>{`${currentStep + 1} of ${prompts.length}`}</CustomText>
             <TextInput
               style={styles.input}
               multiline
@@ -326,21 +327,21 @@ export default function JournalScreen() {
           </>
         )}
 
-        <Text style={styles.sectionTitle}>Past Reflections</Text>
+        <CustomText style={styles.sectionTitle}>Past Reflections</CustomText>
         {entries.length === 0 && (
-          <Text style={styles.emptyText}>No journal entries yet.</Text>
+          <CustomText style={styles.emptyText}>No journal entries yet.</CustomText>
         )}
         {entries.map((e) => (
           <Pressable key={e.id} onPress={() => openEntry(e)}>
             <View style={styles.entryItem}>
-              <Text style={styles.entryDate}>
+              <CustomText style={styles.entryDate}>
                 {e.createdAt?.toDate
                   ? e.createdAt.toDate().toLocaleString()
                   : '(no date)'}
-              </Text>
-              <Text style={styles.entryText}>
+              </CustomText>
+              <CustomText style={styles.entryText}>
                 {e.content.length > 100 ? e.content.slice(0, 100) + '…' : e.content}
-              </Text>
+              </CustomText>
             </View>
           </Pressable>
         ))}
@@ -354,13 +355,13 @@ export default function JournalScreen() {
       >
         <View style={styles.modalBackdrop}>
           <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>
+            <CustomText style={styles.modalTitle}>
               {selectedEntry?.createdAt?.toDate
                 ? selectedEntry.createdAt.toDate().toLocaleString()
                 : '(no date)'}
-            </Text>
+            </CustomText>
             <ScrollView>
-              <Text style={styles.modalText}>{selectedEntry?.content}</Text>
+              <CustomText style={styles.modalText}>{selectedEntry?.content}</CustomText>
             </ScrollView>
             <Button title="Close" onPress={() => setModalVisible(false)} />
           </View>

--- a/App/screens/QuoteScreen.tsx
+++ b/App/screens/QuoteScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { View,  StyleSheet, ActivityIndicator } from 'react-native';
 import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
@@ -87,8 +88,8 @@ export default function QuoteScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <Text style={styles.quote}>“{quote.text}”</Text>
-        <Text style={styles.reference}>— {quote.reference}</Text>
+        <CustomText style={styles.quote}>“{quote.text}”</CustomText>
+        <CustomText style={styles.reference}>— {quote.reference}</CustomText>
         <View style={styles.buttonWrap}>
           <Button title="Continue" onPress={() => navigation.replace('Home')} />
         </View>

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
 import {
   View,
@@ -194,11 +195,11 @@ export default function ReligionAIScreen() {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>Ask for Guidance</Text>
+        <CustomText style={styles.title}>Ask for Guidance</CustomText>
 
         {isSubscribed && (
           <View style={styles.subscriptionBanner}>
-            <Text style={styles.subscriptionText}>💎 OneVine+ Unlimited Chat Enabled</Text>
+            <CustomText style={styles.subscriptionText}>💎 OneVine+ Unlimited Chat Enabled</CustomText>
             <Button title="Clear Conversation" onPress={handleClear} color={theme.colors.accent} />
           </View>
         )}
@@ -218,7 +219,7 @@ export default function ReligionAIScreen() {
         {loading && <ActivityIndicator size="large" color={theme.colors.primary} />}
 
         {messages.map((msg, idx) => (
-          <Text key={idx} style={styles.answer}>{msg}</Text>
+          <CustomText key={idx} style={styles.answer}>{msg}</CustomText>
         ))}
       </ScrollView>
     </ScreenContainer>

--- a/App/screens/auth/ForgotPasswordScreen.tsx
+++ b/App/screens/auth/ForgotPasswordScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View,  StyleSheet, Alert } from 'react-native';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import TextField from '@/components/TextField';
 import Button from '@/components/common/Button';
@@ -41,7 +42,7 @@ export default function ForgotPasswordScreen() {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Reset Password</Text>
+      <CustomText style={styles.title}>Reset Password</CustomText>
       <TextField label="Email" value={email} onChangeText={setEmail} placeholder="you@example.com" />
       <Button title="Send Reset Link" onPress={handleReset} loading={loading} />
     </ScreenContainer>

--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View,  StyleSheet, Alert } from 'react-native';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import TextField from '@/components/TextField';
 import Button from '@/components/common/Button';
@@ -68,11 +69,11 @@ export default function ForgotUsernameScreen() {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Find Your Email</Text>
+      <CustomText style={styles.title}>Find Your Email</CustomText>
       <TextField label="Name" value={name} onChangeText={setName} placeholder="Your name" />
       <TextField label="Region" value={region} onChangeText={setRegion} placeholder="Region" />
       <Button title="Lookup" onPress={handleLookup} loading={loading} />
-      {email && <Text style={styles.result}>Email: {email}</Text>}
+      {email && <CustomText style={styles.result}>Email: {email}</CustomText>}
     </ScreenContainer>
   );
 }

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, ActivityIndicator } from 'react-native';
+import { View,  StyleSheet, Alert, ActivityIndicator } from 'react-native';
 import { showGracefulError } from '@/utils/gracefulError';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
@@ -83,7 +84,7 @@ export default function LoginScreen() {
           color={theme.colors.primary}
         />
       )}
-      <Text style={styles.title}>Welcome Back</Text>
+      <CustomText style={styles.title}>Welcome Back</CustomText>
 
       <TextField
         label="Email"
@@ -101,27 +102,27 @@ export default function LoginScreen() {
       />
 
       <Button title="Log In" onPress={handleLogin} loading={loading} />
-      <Text
+      <CustomText
         style={styles.link}
         onPress={handleForgotPassword}
       >
         Forgot Password?
-      </Text>
+      </CustomText>
 
 
-      <Text
+      <CustomText
         style={styles.link}
         onPress={() => navigation.navigate('Signup')}
       >
         Don’t have an account? Sign up
-      </Text>
+      </CustomText>
 
-      <Text
+      <CustomText
         style={styles.link}
         onPress={() => navigation.navigate('OrganizationSignup')}
       >
         Want to register your organization? Click here
-      </Text>
+      </CustomText>
     </ScreenContainer>
   );
 }

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, TextInput } from 'react-native';
+import { View,  StyleSheet, Alert, TextInput } from 'react-native';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from "@/components/common/Button";
 import { useNavigation, CommonActions } from '@react-navigation/native';
@@ -129,8 +130,8 @@ export default function OnboardingScreen() {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Welcome to OneVine 🌿</Text>
-      <Text style={styles.subtitle}>Tell us about yourself:</Text>
+      <CustomText style={styles.title}>Welcome to OneVine 🌿</CustomText>
+      <CustomText style={styles.subtitle}>Tell us about yourself:</CustomText>
 
       <TextInput
         style={styles.input}
@@ -146,7 +147,7 @@ export default function OnboardingScreen() {
         onChangeText={setRegion}
       />
 
-      <Text style={styles.subtitle}>Choose your spiritual lens:</Text>
+      <CustomText style={styles.subtitle}>Choose your spiritual lens:</CustomText>
 
       <View style={styles.pickerWrapper}>
         <Picker
@@ -168,9 +169,9 @@ export default function OnboardingScreen() {
       />
 
       <Button title="Continue" onPress={handleContinue} loading={loading} />
-      <Text style={styles.link} onPress={() => navigation.replace('Login')}>
+      <CustomText style={styles.link} onPress={() => navigation.replace('Login')}>
         Already have an account? Log in
-      </Text>
+      </CustomText>
     </ScreenContainer>
   );
 }

--- a/App/screens/auth/OrganizationSignupScreen.tsx
+++ b/App/screens/auth/OrganizationSignupScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
 import {
   View,
@@ -87,7 +88,7 @@ export default function OrganizationSignupScreen({ navigation }: Props) {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Create Organization</Text>
+      <CustomText style={styles.title}>Create Organization</CustomText>
 
       <TextInput
         style={styles.input}
@@ -96,7 +97,7 @@ export default function OrganizationSignupScreen({ navigation }: Props) {
         onChangeText={setName}
       />
 
-      <Text style={styles.label}>Select Plan:</Text>
+      <CustomText style={styles.label}>Select Plan:</CustomText>
       <View style={styles.buttonGroup}>
         <Button
           title="Enterprise"

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
 import {
   View,
@@ -82,7 +83,7 @@ export default function SelectReligionScreen({ navigation }: Props) {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Select Your Faith</Text>
+      <CustomText style={styles.title}>Select Your Faith</CustomText>
       <FlatList
         data={RELIGIONS}
         keyExtractor={(item) => item}
@@ -94,14 +95,14 @@ export default function SelectReligionScreen({ navigation }: Props) {
             ]}
             onPress={() => setSelected(item)}
           >
-            <Text
+            <CustomText
               style={[
                 styles.religionText,
                 selected === item && styles.selectedText
               ]}
             >
               {item}
-            </Text>
+            </CustomText>
           </TouchableOpacity>
         )}
       />

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View,  StyleSheet, Alert } from 'react-native';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
@@ -59,7 +60,7 @@ export default function SignupScreen() {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Create an Account</Text>
+      <CustomText style={styles.title}>Create an Account</CustomText>
 
       <TextField
         label="Email"
@@ -78,19 +79,19 @@ export default function SignupScreen() {
 
       <Button title="Sign Up" onPress={handleSignup} loading={loading} />
 
-      <Text
+      <CustomText
         style={styles.link}
         onPress={() => navigation.navigate('Login')}
       >
         Already have an account? Log in
-      </Text>
+      </CustomText>
 
-      <Text
+      <CustomText
         style={styles.link}
         onPress={() => navigation.navigate('OrganizationSignup')}
       >
         Want to register your organization? Click here
-      </Text>
+      </CustomText>
     </ScreenContainer>
   );
 }

--- a/App/screens/auth/WelcomeScreen.tsx
+++ b/App/screens/auth/WelcomeScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useRef } from 'react';
-import { View, Text, StyleSheet, Animated } from 'react-native';
+import { View,  StyleSheet, Animated } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Button from '@/components/common/Button';
 import { useNavigation } from '@react-navigation/native';
@@ -61,11 +62,11 @@ export default function WelcomeScreen() {
 
   return (
     <LinearGradient colors={[theme.colors.primary, theme.colors.surface]} style={styles.container}>
-      <Text style={styles.loginLink} onPress={() => navigation.replace('Login')}>
+      <CustomText style={styles.loginLink} onPress={() => navigation.replace('Login')}>
         Already have an account? Go to Login
-      </Text>
+      </CustomText>
       {/* Image removed if asset missing to prevent crash */}
-      <Text style={styles.title}>Welcome to OneVine</Text>
+      <CustomText style={styles.title}>Welcome to OneVine</CustomText>
       <View style={styles.buttons}>
         <View style={styles.buttonWrap}>
           <Button title="Log In" onPress={() => navigation.navigate('Login')} />

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
 import {
   View,
@@ -226,12 +227,12 @@ export default function ChallengeScreen() {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>Daily Challenge</Text>
-        <Text style={styles.streak}>Streak: {streak} days</Text>
+        <CustomText style={styles.title}>Daily Challenge</CustomText>
+        <CustomText style={styles.streak}>Streak: {streak} days</CustomText>
         {loading ? (
           <ActivityIndicator size="large" color={theme.colors.primary} />
         ) : (
-          <Text style={styles.challenge}>{challenge}</Text>
+          <CustomText style={styles.challenge}>{challenge}</CustomText>
         )}
         <View style={styles.buttonWrap}>
           {canSkip && <Button title="Skip Challenge" onPress={handleSkip} />}

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { View,  StyleSheet, ScrollView } from 'react-native';
 import Button from '@/components/common/Button';
 import * as SecureStore from 'expo-secure-store';
 import ScreenContainer from "@/components/theme/ScreenContainer";
@@ -79,14 +80,14 @@ export default function HomeScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <Text style={styles.title}>Welcome to OneVine</Text>
-        <Text style={styles.subtitle}>Grow in Faith Daily</Text>
+        <CustomText style={styles.title}>Welcome to OneVine</CustomText>
+        <CustomText style={styles.subtitle}>Grow in Faith Daily</CustomText>
 
         <View style={styles.statusBox}>
           {subscribed ? (
-            <Text style={styles.subscribed}>🌟 OneVine+ Active</Text>
+            <CustomText style={styles.subscribed}>🌟 OneVine+ Active</CustomText>
           ) : (
-            <Text style={styles.tokenInfo}>🎟️ Tokens: {tokens}</Text>
+            <CustomText style={styles.tokenInfo}>🎟️ Tokens: {tokens}</CustomText>
           )}
         </View>
 

--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
 import {
   View,
@@ -89,12 +90,12 @@ export default function LeaderboardsScreen() {
 
   const renderList = (title: string, data: any[], keyName: string, valueName: string) => (
     <View style={styles.section}>
-      <Text style={styles.sectionTitle}>{title}</Text>
+      <CustomText style={styles.sectionTitle}>{title}</CustomText>
       {data.map((item, index) => (
         <View key={item.id || index} style={styles.row}>
-          <Text style={styles.rank}>{index + 1}.</Text>
-          <Text style={styles.name}>{item[keyName]}</Text>
-          <Text style={styles.points}>{item[valueName]} pts</Text>
+          <CustomText style={styles.rank}>{index + 1}.</CustomText>
+          <CustomText style={styles.name}>{item[keyName]}</CustomText>
+          <CustomText style={styles.points}>{item[valueName]} pts</CustomText>
         </View>
       ))}
     </View>
@@ -103,7 +104,7 @@ export default function LeaderboardsScreen() {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>Leaderboards</Text>
+        <CustomText style={styles.title}>Leaderboards</CustomText>
         {loading ? (
           <ActivityIndicator size="large" color={theme.colors.primary} />
         ) : (

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState, useEffect } from 'react';
 import {
   View,
@@ -120,7 +121,7 @@ export default function SubmitProofScreen() {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Submit Challenge Proof</Text>
+      <CustomText style={styles.title}>Submit Challenge Proof</CustomText>
 
       <TextInput
         style={styles.input}
@@ -132,9 +133,9 @@ export default function SubmitProofScreen() {
       <Button title="Pick Image" onPress={pickImage} />
 
       {image && (
-        <Text style={styles.filename}>
+        <CustomText style={styles.filename}>
           Selected: {image.fileName || image.uri.split('/').pop()}
-        </Text>
+        </CustomText>
       )}
 
       <View style={styles.buttonWrap}>

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
 import {
   View,
@@ -161,12 +162,12 @@ export default function TriviaScreen() {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>Trivia Challenge</Text>
+        <CustomText style={styles.title}>Trivia Challenge</CustomText>
 
         {loading ? (
           <ActivityIndicator size="large" color={theme.colors.primary} />
         ) : (
-          <Text style={styles.story}>{story}</Text>
+          <CustomText style={styles.story}>{story}</CustomText>
         )}
 
         {!loading && (

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
+import { View,  StyleSheet, Alert, Linking } from 'react-native';
 import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
@@ -7,6 +8,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
 import * as SecureStore from 'expo-secure-store';
+import { getStoredToken } from '@/services/authService';
 import { createStripeCheckout } from '@/services/apiService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
@@ -80,17 +82,17 @@ export default function UpgradeScreen({ navigation }: Props) {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <Text style={styles.title}>OneVine+ Membership</Text>
-        <Text style={styles.subtitle}>Experience the full blessing</Text>
+        <CustomText style={styles.title}>OneVine+ Membership</CustomText>
+        <CustomText style={styles.subtitle}>Experience the full blessing</CustomText>
 
         <View style={styles.benefitsBox}>
-          <Text style={styles.benefit}>✅ Unlimited Religion AI questions</Text>
-          <Text style={styles.benefit}>✅ Full Confessional access</Text>
-          <Text style={styles.benefit}>✅ Personalized journaling prompts</Text>
-          <Text style={styles.benefit}>✅ Early access to new features</Text>
+          <CustomText style={styles.benefit}>✅ Unlimited Religion AI questions</CustomText>
+          <CustomText style={styles.benefit}>✅ Full Confessional access</CustomText>
+          <CustomText style={styles.benefit}>✅ Personalized journaling prompts</CustomText>
+          <CustomText style={styles.benefit}>✅ Early access to new features</CustomText>
         </View>
 
-        <Text style={styles.price}>$9.99 / month</Text>
+        <CustomText style={styles.price}>$9.99 / month</CustomText>
 
         <View style={styles.buttonWrap}>
           <Button title="Join OneVine+" onPress={handleUpgrade} disabled={loading} />

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState, useEffect } from 'react';
 import {
   View,
@@ -47,7 +48,7 @@ export default function JoinOrganizationScreen() {
         row: { flexDirection: 'row', alignItems: 'center', paddingVertical: 8, borderBottomWidth: 1, borderColor: theme.colors.border }, // ✅ added missing 'row' style
         infoWrap: { flex: 1, marginRight: 8 }, // ✅ added missing 'infoWrap' style
         name: { fontSize: 16, fontWeight: '600', color: theme.colors.text }, // ✅ added missing 'name' style
-        meta: { color: theme.colors.fadedText, fontSize: 14 }, // ✅ added missing 'meta' style
+        meta: { color: theme.colors.fadedText, fontSize: 14 },
       }),
     [theme],
   );
@@ -125,7 +126,7 @@ export default function JoinOrganizationScreen() {
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>Join an Organization</Text>
+      <CustomText style={styles.title}>Join an Organization</CustomText>
       <TextInput
         style={styles.input}
         placeholder="Search by name"
@@ -139,11 +140,11 @@ export default function JoinOrganizationScreen() {
         renderItem={({ item }) => (
           <View style={styles.row}>
             <View style={styles.infoWrap}>
-              <Text style={styles.name}>{item.name}</Text>
-              <Text style={styles.meta}>Tier: {item.tier}</Text>
-              <Text style={styles.meta}>
+              <CustomText style={styles.name}>{item.name}</CustomText>
+              <CustomText style={styles.meta}>Tier: {item.tier}</CustomText>
+              <CustomText style={styles.meta}>
                 Seats: {item.members?.length || 0} / {item.seatLimit}
-              </Text>
+              </CustomText>
             </View>
             <Button title="Join" onPress={() => joinOrg(item)} />
           </View>

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -1,3 +1,4 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
 import {
   View,
@@ -148,26 +149,26 @@ export default function OrganizationManagementScreen() {
   if (!org) {
     return (
       <ScreenContainer>
-        <Text style={styles.title}>No organization found</Text>
+        <CustomText style={styles.title}>No organization found</CustomText>
       </ScreenContainer>
     );
   }
 
   return (
     <ScreenContainer>
-      <Text style={styles.title}>{org.name}</Text>
-      <Text style={styles.subtitle}>Tier: {org.tier}</Text>
-      <Text style={styles.subtitle}>
+      <CustomText style={styles.title}>{org.name}</CustomText>
+      <CustomText style={styles.subtitle}>Tier: {org.tier}</CustomText>
+      <CustomText style={styles.subtitle}>
         Seats Used: {org.members?.length || 0} / {org.seatLimit}
-      </Text>
+      </CustomText>
 
-      <Text style={styles.sectionTitle}>Members</Text>
+      <CustomText style={styles.sectionTitle}>Members</CustomText>
       <FlatList
         data={org.members || []}
         keyExtractor={(item) => item}
         renderItem={({ item }) => (
           <View style={styles.row}>
-            <Text style={styles.memberText}>{item}</Text>
+            <CustomText style={styles.memberText}>{item}</CustomText>
             <Button title="Remove" onPress={() => removeMember(item)} />
           </View>
         )}

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View,  StyleSheet, Alert } from 'react-native';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import TextField from '@/components/TextField';
 import Button from '@/components/common/Button';
@@ -89,7 +90,7 @@ export default function ProfileScreen() {
         <TextField label="Username" value={username} onChangeText={setUsername} />
         <TextField label="Region" value={region} onChangeText={setRegion} />
 
-        <Text style={styles.label}>Religion</Text>
+        <CustomText style={styles.label}>Religion</CustomText>
         <View style={styles.pickerWrapper}>
           <Picker
             selectedValue={religion}
@@ -102,9 +103,9 @@ export default function ProfileScreen() {
           </Picker>
         </View>
 
-        <Text style={styles.info}>Points: {points}</Text>
-        <Text style={styles.info}>Subscribed: {user?.isSubscribed ? 'Yes' : 'No'}</Text>
-        <Text style={styles.info}>Tokens: {tokens}</Text>
+        <CustomText style={styles.info}>Points: {points}</CustomText>
+        <CustomText style={styles.info}>Subscribed: {user?.isSubscribed ? 'Yes' : 'No'}</CustomText>
+        <CustomText style={styles.info}>Tokens: {tokens}</CustomText>
 
         <Button title="Save Changes" onPress={handleSave} loading={saving} />
       </View>

--- a/App/screens/profile/SettingsScreen.tsx
+++ b/App/screens/profile/SettingsScreen.tsx
@@ -1,5 +1,6 @@
+import CustomText from '@/components/common/CustomText';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Switch, Alert, LayoutAnimation } from 'react-native';
+import { View,  StyleSheet, Switch, Alert, LayoutAnimation } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import Constants from 'expo-constants';
 import ScreenContainer from "@/components/theme/ScreenContainer";
@@ -77,11 +78,11 @@ export default function SettingsScreen() {
     <ScreenContainer>
       <View style={styles.center}>
         <View style={styles.row}>
-          <Text style={styles.text}>Night Mode</Text>
+          <CustomText style={styles.text}>Night Mode</CustomText>
           <Switch value={nightMode} onValueChange={toggleNight} />
         </View>
         <View style={styles.row}>
-          <Text style={styles.text}>Enable Reflection Reminder</Text>
+          <CustomText style={styles.text}>Enable Reflection Reminder</CustomText>
           <Switch
             value={reminderEnabled}
             onValueChange={async (v) => {
@@ -96,7 +97,7 @@ export default function SettingsScreen() {
         </View>
         {reminderEnabled && (
           <View style={styles.row}>
-            <Text style={styles.text}>Time of Reminder</Text>
+            <CustomText style={styles.text}>Time of Reminder</CustomText>
             <DateTimePicker
               value={new Date(`1970-01-01T${reminderTime}:00`)}
               mode="time"
@@ -138,7 +139,7 @@ export default function SettingsScreen() {
             />
           </>
         )}
-        <Text style={styles.version}>v{Constants.expoConfig?.version}</Text>
+        <CustomText style={styles.version}>v{Constants.expoConfig?.version}</CustomText>
       </View>
     </ScreenContainer>
   );

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -11,7 +11,7 @@ interface ChallengeStore {
   lastCompleted: number | null;
   streak: number;
   setLastCompleted: (timestamp: number) => void;
-  incrementStreak: () => void;
+  incrementStreak: () => number;
   resetStreak: () => void;
   syncWithFirestore: () => Promise<void>;
   updateStreakInFirestore: () => Promise<void>;

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ This project uses **React Native (via Expo)** and is powered by **Firebase** for
 ## 🧰 Tech Stack
 
 - **React Native** (with Expo)
-- **Firebase Web SDK**
-  - `firebase/app`, `firebase/auth`, `firebase/firestore`
-  - Anonymous Auth for guest use
-  - Firestore for user journals and token tracking
+- **Firebase via REST API**
+  - Authentication and Firestore calls use direct REST endpoints
 - **Google Gemini / OpenAI GPT**
   - Faith-aligned reflection prompts
 - **Stripe**
@@ -34,8 +32,8 @@ This project uses **React Native (via Expo)** and is powered by **Firebase** for
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/AustinJR6/wwjd-app.git
-cd wwjd-app
+git clone https://github.com/AustinJR6/onevine-app.git
+cd onevine-app
 2. Install Dependencies
 bash
 Copy
@@ -49,7 +47,7 @@ Enable Anonymous Authentication
 
 Set up Firestore
 
-Firebase Setup uses the Expo-compatible Web SDK via the `firebase` package.
+Firebase calls are made via the Firebase REST API, so no Firebase SDK packages are required.
 
 ### Environment Variables
 
@@ -57,7 +55,7 @@ Create a `.env` file in the project root with the following entry so the app can
 reach your deployed Firebase functions from any network:
 
 ```env
-EXPO_PUBLIC_FUNCTION_BASE_URL=https://us-central1-wwjd-app.cloudfunctions.net
+EXPO_PUBLIC_FUNCTION_BASE_URL=https://us-central1-onevine-app.cloudfunctions.net
 ```
 📱 Key Features
 ✝️ 🕉️ ☪️ 🕎 Multi-Faith Reflection AI
@@ -89,7 +87,7 @@ Organization leaderboards (e.g., churches, mosques, temples)
 bash
 Copy
 Edit
-wwjd-app/
+onevine-app/
 ├── app/                  # App entry points and routing
 ├── components/           # Shared UI components
 ├── screens/              # Major app pages (Ask, Journal, Trivia)
@@ -119,7 +117,7 @@ OneVine is rooted in the belief that truth and love transcend labels. Whether Ch
 Austin Rittenhouse – Founder, developer
 
 🛠 Development Notes
-All Firebase integrations now use the Firebase Web SDK initialized in `App/config/firebase.ts`.
+All Firebase integrations now use direct REST API calls defined in `App/config/apiConfig.ts`.
 
 Stripe subscription flow is being integrated with Firebase webhook handling
 

--- a/app.config.js
+++ b/app.config.js
@@ -1,7 +1,8 @@
 // app.config.js
 export default {
-  name: "wwjd-app",
-  slug: "wwjd-app",
+  name: "OneVine",
+  slug: "onevine-app",
+  owner: "whippybuckle",
   version: "1.0.0",
   orientation: "portrait",
   icon: "./assets/OneVineIcon.png",
@@ -41,7 +42,7 @@ export default {
   ],
   extra: {
     eas: {
-      projectId: "4e9fc79d-ed33-4fc3-8e71-5533c8872160", // ✅ Required for EAS build linkage
+      projectId: "bbf209be-1b48-4f76-a496-9d4fcd8339fd",
     },
   },
 };

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "OneVine",
     "slug": "onevine-app",
+    "owner": "whippybuckle",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/OneVineIcon.png",
@@ -38,7 +39,7 @@
         "projectId": "bbf209be-1b48-4f76-a496-9d4fcd8339fd"
       },
       "firebase": {
-        "projectId": "wwjd-app"
+        "projectId": "onevine-app"
       }
     }
   }

--- a/eas.json
+++ b/eas.json
@@ -33,13 +33,13 @@
       "env": {
         "EXPO_PUBLIC_OPENAI_API_KEY": "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",
         "EXPO_PUBLIC_FIREBASE_API_KEY": "AIzaSyAeitpWVBGmPZJ540vgCNZpte_05LPx0Z8",
-        "EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN": "wwjd-app.firebaseapp.com",
-        "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "wwjd-app",
-        "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "wwjd-app.appspot.com",
+        "EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN": "onevine-app.firebaseapp.com",
+        "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "onevine-app",
+        "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "onevine-app.appspot.com",
         "EXPO_PUBLIC_FIREBASE_MSG_SENDER_ID": "402334171334",
         "EXPO_PUBLIC_FIREBASE_APP_ID": "1:402334171334:web:69a89d40732306572757c7",
         "EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID": "G-20W5BML7DM",
-        "EXPO_PUBLIC_FUNCTION_BASE_URL": "https://us-central1-wwjd-app.cloudfunctions.net"
+        "EXPO_PUBLIC_FUNCTION_BASE_URL": "https://us-central1-onevine-app.cloudfunctions.net"
       }
     },
     "development-simulator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wwjd-app",
+  "name": "onevine-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wwjd-app",
+      "name": "onevine-app",
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/merriweather": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wwjd-app",
+  "name": "onevine-app",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- add `CustomText` wrapper to disable font scaling and use theme fonts
- replace all `Text` usages with `CustomText`
- align Expo metadata with `onevine-app` project
- update Firebase config and example URLs
- fix type errors in challenge store and join org screen
- adjust button and background gradient types

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint .` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68575252ae6483308c8bf949e764d653