### PR TITLE
Audit Firebase access for auth guard

### DIFF
--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -5,6 +5,7 @@ import ScreenContainer from '@/components/theme/ScreenContainer';
 import TextField from '@/components/TextField';
 import Button from '@/components/common/Button';
 import { queryCollection } from '@/services/firestoreService';
+import { ensureAuth } from '@/utils/authGuard';
 import { useTheme } from '@/components/theme/theme';
 
 export default function ForgotUsernameScreen() {
@@ -51,6 +52,12 @@ export default function ForgotUsernameScreen() {
       Alert.alert('Missing Info', 'Please enter your name and region.');
       return;
     }
+    const uid = await ensureAuth();
+    if (!uid) {
+      Alert.alert('Login Required', 'Please log in first.');
+      return;
+    }
+
     setLoading(true);
     try {
       const users = await queryCollection('users');


### PR DESCRIPTION
## Summary
- guard Firestore call in ForgotUsernameScreen with `ensureAuth`

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_68576c9fa1188330be486a8d503c2689