### PR TITLE
Fix Expo Go login and notification issues

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,7 @@ import { View, ActivityIndicator, Text } from 'react-native';
 import ErrorBoundary from './App/components/common/ErrorBoundary';
 import { useFonts, Poppins_600SemiBold } from '@expo-google-fonts/poppins';
 import { Merriweather_400Regular } from '@expo-google-fonts/merriweather';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useUser } from '@/hooks/useUser';
@@ -69,12 +69,12 @@ export default function App() {
     const initialize = async () => {
       console.log('🔑 Checking saved auth credentials');
       try {
-        const uid = await SecureStore.getItemAsync('userId');
+        const uid = await SafeStore.getItem('userId');
         const token = await getStoredToken();
         if (uid && token) {
           await loadUser(uid);
           console.log('✅ Authenticated user', uid);
-          const hasSeen = await SecureStore.getItemAsync(`hasSeenOnboarding-${uid}`);
+          const hasSeen = await SafeStore.getItem(`hasSeenOnboarding-${uid}`);
           const route = hasSeen === 'true' ? 'Quote' : 'Onboarding';
           console.log('🔀 Initial route', route);
           setInitialRoute(route);

--- a/App/hooks/useNotifications.ts
+++ b/App/hooks/useNotifications.ts
@@ -1,13 +1,24 @@
 import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
+
+const isExpoGo = Constants.appOwnership === 'expo';
 
 export async function scheduleDailyNotification(title: string, body: string) {
-  await Notifications.scheduleNotificationAsync({
-    content: { title, body },
-    trigger: {
-      type: 'calendar',
-      hour: 8,
-      minute: 0,
-      repeats: true
-    } as any // ✅ cast to bypass incorrect type
-  });
+  if (isExpoGo) {
+    console.log('🔕 Notification skipped in Expo Go');
+    return;
+  }
+  try {
+    await Notifications.scheduleNotificationAsync({
+      content: { title, body },
+      trigger: {
+        type: 'calendar',
+        hour: 8,
+        minute: 0,
+        repeats: true
+      } as any // ✅ cast to bypass incorrect type
+    });
+  } catch (err) {
+    console.warn('Failed to schedule daily notification', err);
+  }
 }

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -17,7 +17,7 @@ import { showGracefulError } from '@/utils/gracefulError';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { queryCollection, addDocument, getDocument, setDocument } from '@/services/firestoreService';
 import { ensureAuth } from '@/utils/authGuard';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { getStoredToken } from '@/services/authService';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -132,7 +132,7 @@ export default function JournalScreen() {
     async function authenticateAndLoad() {
       try {
         const idToken = await getStoredToken();
-        const userId = await SecureStore.getItemAsync('userId');
+        const userId = await SafeStore.getItem('userId');
         if (!idToken || !userId) {
           Alert.alert('Login Required', 'Please log in again.');
           navigation.replace('Login');

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -17,7 +17,7 @@ import { getDocument, setDocument } from '@/services/firestoreService';
 import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
 import { ensureAuth } from '@/utils/authGuard';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -81,7 +81,7 @@ export default function ReligionAIScreen() {
     }
 
     let idToken = await getStoredToken();
-    const userId = await SecureStore.getItemAsync('userId');
+    const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
       navigation.replace('Login');

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -6,7 +6,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from "@/components/theme/theme";
@@ -26,10 +26,10 @@ export default function LoginScreen() {
     try {
       const result = await login(email, password);
       if (result.localId) {
-        await SecureStore.setItemAsync('userId', result.localId);
-        await SecureStore.setItemAsync('idToken', result.idToken);
+        await SafeStore.setItem('userId', result.localId);
+        await SafeStore.setItem('idToken', result.idToken);
 
-        const hasSeen = await SecureStore.getItemAsync(
+        const hasSeen = await SafeStore.getItem(
           `hasSeenOnboarding-${result.localId}`
         );
         navigation.replace(hasSeen === 'true' ? 'Home' : 'Onboarding');

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -10,7 +10,7 @@ import { loadUser } from "@/services/userService";
 import { useUserStore } from "@/state/userStore";
 import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { Picker } from '@react-native-picker/picker';
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
 
@@ -32,7 +32,7 @@ export default function OnboardingScreen() {
     if (user) return;
     async function fetchUser() {
       try {
-        const uid = await SecureStore.getItemAsync('userId');
+        const uid = await SafeStore.getItem('userId');
         if (uid) {
           await loadUser(uid);
         }
@@ -65,7 +65,7 @@ export default function OnboardingScreen() {
           organizationId: organization || undefined,
         });
         await completeOnboarding(user.uid);
-        await SecureStore.setItemAsync(`hasSeenOnboarding-${user.uid}`, 'true');
+        await SafeStore.setItem(`hasSeenOnboarding-${user.uid}`, 'true');
 
         navigation.reset({
           index: 0,

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -17,7 +17,7 @@ import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
 import { ensureAuth } from '@/utils/authGuard';
 import { useChallengeStore } from '@/state/challengeStore';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -91,7 +91,7 @@ export default function ChallengeScreen() {
   const fetchChallenge = async () => {
     try {
       let idToken = await getStoredToken();
-      const userId = await SecureStore.getItemAsync('userId');
+      const userId = await SafeStore.getItem('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
         navigation.replace('Login');
@@ -155,7 +155,7 @@ export default function ChallengeScreen() {
     }
 
     const idToken = await getStoredToken();
-    const userId = await SecureStore.getItemAsync('userId');
+    const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
       navigation.replace('Login');

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import CustomText from '@/components/CustomText';
 import { View, StyleSheet, ScrollView } from 'react-native';
 import Button from '@/components/common/Button';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { getTokenCount, syncSubscriptionStatus } from "@/utils/TokenManager";
@@ -24,8 +24,8 @@ export default function HomeScreen({ navigation }: Props) {
       await syncSubscriptionStatus(); // updates Firestore token state
       setTokens(t);
       setSubscribed(t >= 9999); // 9999 token cap implies OneVine+ sub
-      const adminFlag = await SecureStore.getItemAsync('isAdmin');
-      const managerFlag = await SecureStore.getItemAsync('isOrgManager');
+      const adminFlag = await SafeStore.getItem('isAdmin');
+      const managerFlag = await SafeStore.getItem('isOrgManager');
       setIsAdmin(adminFlag === 'true');
       setIsOrgManager(managerFlag === 'true');
     };

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -16,7 +16,7 @@ import { getStoredToken } from '@/services/authService';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { ensureAuth } from '@/utils/authGuard';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -57,7 +57,7 @@ export default function SubmitProofScreen() {
 
   useEffect(() => {
     const checkAccess = async () => {
-      const sub = await SecureStore.getItemAsync('isSubscribed');
+      const sub = await SafeStore.getItem('isSubscribed');
       if (sub !== 'true') {
         Alert.alert('Access Denied', 'This feature is for OneVine+ or Org Managers only.');
         navigation.goBack();
@@ -85,7 +85,7 @@ export default function SubmitProofScreen() {
     }
 
     const idToken = await getStoredToken();
-    const userId = await SecureStore.getItemAsync('userId');
+    const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
       navigation.replace('Login');

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -7,8 +7,8 @@ import { useTheme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
-import * as SecureStore from 'expo-secure-store';
 import { createStripeCheckout } from '@/services/apiService';
+import * as SafeStore from '@/utils/secureStore';
 import { getStoredToken } from '@/services/authService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
@@ -53,7 +53,7 @@ export default function UpgradeScreen({ navigation }: Props) {
 
     try {
       const idToken = await getStoredToken();
-      const userId = await SecureStore.getItemAsync('userId');
+      const userId = await SafeStore.getItem('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
         navigation.replace('Login');

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '@/components/theme/theme';
 import { queryCollection, setDocument, getDocument } from '@/services/firestoreService';
 import { getStoredToken } from '@/services/authService';
 import { ensureAuth } from '@/utils/authGuard';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -64,7 +64,7 @@ export default function JoinOrganizationScreen() {
   const fetchOrgs = async () => {
     try {
       const idToken = await getStoredToken();
-      const userId = await SecureStore.getItemAsync('userId');
+      const userId = await SafeStore.getItem('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
         navigation.replace('Login');
@@ -94,7 +94,7 @@ export default function JoinOrganizationScreen() {
   const joinOrg = async (org: any) => {
     if (!user) return;
     const idToken = await getStoredToken();
-    const userId = await SecureStore.getItemAsync('userId');
+    const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
       navigation.replace('Login');

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -13,7 +13,7 @@ import { getStoredToken } from '@/services/authService';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -70,8 +70,8 @@ export default function OrganizationManagementScreen() {
 
   useEffect(() => {
     const checkAccess = async () => {
-      const admin = await SecureStore.getItemAsync('isAdmin');
-      const manager = await SecureStore.getItemAsync('isOrgManager');
+      const admin = await SafeStore.getItem('isAdmin');
+      const manager = await SafeStore.getItem('isOrgManager');
       if (admin !== 'true' && manager !== 'true') {
         Alert.alert('Access Denied', 'This feature is for OneVine+ or Org Managers only.');
         navigation.goBack();
@@ -87,7 +87,7 @@ export default function OrganizationManagementScreen() {
   const loadOrg = async () => {
     if (!user) return;
     const idToken = await getStoredToken();
-    const userId = await SecureStore.getItemAsync('userId');
+    const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
       navigation.replace('Login');
@@ -114,7 +114,7 @@ export default function OrganizationManagementScreen() {
   const removeMember = async (uid: string) => {
     if (!org?.id) return;
     const idToken = await getStoredToken();
-    const userId = await SecureStore.getItemAsync('userId');
+    const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
       navigation.replace('Login');

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 
 const API_KEY = process.env.EXPO_PUBLIC_FIREBASE_API_KEY;
 const BASE_URL = 'https://identitytoolkit.googleapis.com/v1';
@@ -41,10 +41,10 @@ export async function login(email: string, password: string): Promise<AuthRespon
 
 // ✅ Logout
 export async function logout(): Promise<void> {
-  await SecureStore.deleteItemAsync('idToken');
-  await SecureStore.deleteItemAsync('refreshToken');
-  await SecureStore.deleteItemAsync('userId');
-  await SecureStore.deleteItemAsync('email');
+  await SafeStore.deleteItem('idToken');
+  await SafeStore.deleteItem('refreshToken');
+  await SafeStore.deleteItem('userId');
+  await SafeStore.deleteItem('email');
 }
 
 // ✅ Trigger password reset email
@@ -75,7 +75,7 @@ export async function changePassword(newPassword: string): Promise<void> {
 
 // ✅ Refresh ID token using the stored refreshToken
 export async function refreshIdToken(): Promise<string> {
-  const refreshToken = await SecureStore.getItemAsync('refreshToken');
+  const refreshToken = await SafeStore.getItem('refreshToken');
   if (!refreshToken) {
     throw new Error('Missing refresh token');
   }
@@ -87,16 +87,16 @@ export async function refreshIdToken(): Promise<string> {
     },
   );
   const { id_token, refresh_token, user_id, email } = res.data;
-  await SecureStore.setItemAsync('idToken', id_token);
-  await SecureStore.setItemAsync('refreshToken', refresh_token);
-  if (user_id) await SecureStore.setItemAsync('userId', String(user_id));
-  if (email) await SecureStore.setItemAsync('email', email);
+  await SafeStore.setItem('idToken', id_token);
+  await SafeStore.setItem('refreshToken', refresh_token);
+  if (user_id) await SafeStore.setItem('userId', String(user_id));
+  if (email) await SafeStore.setItem('email', email);
   return id_token as string;
 }
 
 // ✅ Get stored token (if any) and refresh if expired
 export async function getStoredToken(): Promise<string | null> {
-  let token = await SecureStore.getItemAsync('idToken');
+  let token = await SafeStore.getItem('idToken');
   if (!token) {
     console.warn('🚫 idToken missing from SecureStore');
     return null;
@@ -124,9 +124,9 @@ export async function getStoredToken(): Promise<string | null> {
 
 // ✅ Save token securely
 async function storeAuth(auth: AuthResponse) {
-  await SecureStore.setItemAsync('idToken', auth.idToken);
-  await SecureStore.setItemAsync('refreshToken', auth.refreshToken);
-  await SecureStore.setItemAsync('userId', auth.localId);
-  await SecureStore.setItemAsync('email', auth.email);
+  await SafeStore.setItem('idToken', auth.idToken);
+  await SafeStore.setItem('refreshToken', auth.refreshToken);
+  await SafeStore.setItem('userId', auth.localId);
+  await SafeStore.setItem('email', auth.email);
 }
 

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand';
 import { getDocument, setDocument } from '@/services/firestoreService';
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { ensureAuth } from '@/utils/authGuard';
 
 async function getUid(): Promise<string | null> {
-  return await SecureStore.getItemAsync('userId');
+  return await SafeStore.getItem('userId');
 }
 
 interface ChallengeStore {

--- a/App/utils/authGuard.ts
+++ b/App/utils/authGuard.ts
@@ -1,4 +1,4 @@
-import * as SecureStore from 'expo-secure-store';
+import * as SafeStore from '@/utils/secureStore';
 import { getStoredToken } from '@/services/authService';
 
 /**
@@ -7,7 +7,7 @@ import { getStoredToken } from '@/services/authService';
  */
 export async function ensureAuth(expectedUid?: string): Promise<string | null> {
   const [uid, token] = await Promise.all([
-    SecureStore.getItemAsync('userId'),
+    SafeStore.getItem('userId'),
     getStoredToken(),
   ]);
 

--- a/App/utils/secureStore.ts
+++ b/App/utils/secureStore.ts
@@ -1,0 +1,26 @@
+import * as SecureStore from 'expo-secure-store';
+
+export async function getItem(key: string): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch (err) {
+    console.warn(`SecureStore getItem failed for ${key}`, err);
+    return null;
+  }
+}
+
+export async function setItem(key: string, value: string): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(key, value);
+  } catch (err) {
+    console.warn(`SecureStore setItem failed for ${key}`, err);
+  }
+}
+
+export async function deleteItem(key: string): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(key);
+  } catch (err) {
+    console.warn(`SecureStore deleteItem failed for ${key}`, err);
+  }
+}


### PR DESCRIPTION
## Summary
- add safe SecureStore helpers with logging
- disable notifications in Expo Go
- guard auth flows and screens against missing credentials
- use SafeStore in auth service and screens

## Testing
- `npx tsc` *(fails: Cannot find type definition file for 'react-native')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685779712b34833091c775a3c4df589d