### PR TITLE
Fix crash from invalid onDone callback

### DIFF
--- a/App/components/common/StartupAnimation.tsx
+++ b/App/components/common/StartupAnimation.tsx
@@ -10,7 +10,11 @@ export default function StartupAnimation({ onDone }: { onDone: () => void }) {
 
   useEffect(() => {
     opacity.value = withTiming(1, { duration: 800 }, () => {
-      opacity.value = withTiming(0, { duration: 800 }, () => onDone());
+      opacity.value = withTiming(0, { duration: 800 }, () => {
+        if (typeof onDone === 'function') {
+          onDone();
+        }
+      });
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- prevent crashes in `StartupAnimation` by checking `onDone` before calling

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68577f5e019c8330a44ec3c3e99c5280