### PR TITLE
Fix onboarding navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -138,6 +138,8 @@ export default function App() {
             <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Reset Password' }} />
             <Stack.Screen name="ForgotUsername" component={ForgotUsernameScreen} options={{ title: 'Find Email' }} />
             <Stack.Screen name="OrganizationSignup" component={OrganizationSignupScreen} options={{ title: 'Create Organization' }} />
+            {/* Onboarding needs to be accessible immediately after login */}
+            <Stack.Screen name="Onboarding" component={OnboardingScreen} options={{ headerShown: false }} />
           </>
         ) : (
           <>

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -6,6 +6,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
+import { loadUser } from "@/services/userService";
 import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -28,6 +29,9 @@ export default function LoginScreen() {
       if (result.localId) {
         await SafeStore.setItem('userId', result.localId);
         await SafeStore.setItem('idToken', result.idToken);
+
+        // Load the user profile so the root navigator registers authenticated screens
+        await loadUser(result.localId);
 
         const hasSeen = await SafeStore.getItem(
           `hasSeenOnboarding-${result.localId}`


### PR DESCRIPTION
## Summary
- ensure login loads user data before navigating
- register Onboarding route in the unauthenticated navigator

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_6857812d2db88330ab8e39efe27a80f8