### PR TITLE
Fix Cloud Function calls

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -26,6 +26,7 @@ import { RootStackParamList } from '@/navigation/RootStackParamList';
 import { getPromptsForReligion } from '@/utils/guidedPrompts';
 import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
+import { INCREMENT_RELIGION_POINTS_URL } from '@/utils/constants';
 
 export default function JournalScreen() {
   const theme = useTheme();
@@ -233,20 +234,21 @@ export default function JournalScreen() {
 
       if (userData.religion) {
         const idToken = await SecureStore.getItemAsync('idToken');
+        const url = INCREMENT_RELIGION_POINTS_URL;
+        console.log('📡 Calling endpoint:', url);
         try {
           await axios.post(
-            'https://us-central1-wwjd-app.cloudfunctions.net/incrementReligionPoints',
+            url,
             { religion: userData.religion, points: 2 },
-            { headers: { Authorization: `Bearer ${idToken}` } }
+            {
+              headers: {
+                Authorization: `Bearer ${idToken}`,
+                'Content-Type': 'application/json',
+              },
+            }
           );
         } catch (err: any) {
-          if (err.response?.status === 404) {
-            console.error('❌ Cloud Function not deployed or wrong URL');
-          } else if (err.response?.status === 401) {
-            console.error('❌ Unauthorized – invalid or missing token');
-          } else {
-            console.error('🔥 Challenge point error:', err.message);
-          }
+          console.error('🔥 Backend error:', err.response?.data || err.message);
         }
       }
 

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -11,7 +11,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
-import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
+import { ASK_GEMINI_SIMPLE, INCREMENT_RELIGION_POINTS_URL } from "@/utils/constants";
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { callFunction } from '@/services/functionService';
 import { useUser } from '@/hooks/useUser';
@@ -259,20 +259,21 @@ export default function ChallengeScreen() {
 
     if (userData.religion) {
       const idToken = await SecureStore.getItemAsync('idToken');
+      const url = INCREMENT_RELIGION_POINTS_URL;
+      console.log('📡 Calling endpoint:', url);
       try {
         await axios.post(
-          'https://us-central1-wwjd-app.cloudfunctions.net/incrementReligionPoints',
+          url,
           { religion: userData.religion, points: 5 },
-          { headers: { Authorization: `Bearer ${idToken}` } }
+          {
+            headers: {
+              Authorization: `Bearer ${idToken}`,
+              'Content-Type': 'application/json',
+            },
+          },
         );
       } catch (err: any) {
-        if (err.response?.status === 404) {
-          console.error('❌ Cloud Function not deployed or wrong URL');
-        } else if (err.response?.status === 401) {
-          console.error('❌ Unauthorized – invalid or missing token');
-        } else {
-          console.error('🔥 Challenge point error:', err.message);
-        }
+        console.error('🔥 Backend error:', err.response?.data || err.message);
       }
     }
 

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -14,7 +14,7 @@ import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
-import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
+import { ASK_GEMINI_SIMPLE, INCREMENT_RELIGION_POINTS_URL } from '@/utils/constants';
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { callFunction } from '@/services/functionService';
 import { ensureAuth } from '@/utils/authGuard';
@@ -137,20 +137,21 @@ export default function TriviaScreen() {
 
         if (userData.religion) {
           const idToken = await SecureStore.getItemAsync('idToken');
+          const url = INCREMENT_RELIGION_POINTS_URL;
+          console.log('📡 Calling endpoint:', url);
           try {
             await axios.post(
-              'https://us-central1-wwjd-app.cloudfunctions.net/incrementReligionPoints',
+              url,
               { religion: userData.religion, points: earned },
-              { headers: { Authorization: `Bearer ${idToken}` } }
+              {
+                headers: {
+                  Authorization: `Bearer ${idToken}`,
+                  'Content-Type': 'application/json',
+                },
+              }
             );
           } catch (err: any) {
-            if (err.response?.status === 404) {
-              console.error('❌ Cloud Function not deployed or wrong URL');
-            } else if (err.response?.status === 401) {
-              console.error('❌ Unauthorized – invalid or missing token');
-            } else {
-              console.error('🔥 Challenge point error:', err.message);
-            }
+            console.error('🔥 Backend error:', err.response?.data || err.message);
           }
         }
 

--- a/App/services/functionService.ts
+++ b/App/services/functionService.ts
@@ -9,22 +9,26 @@ export async function callFunction(name: string, data: any): Promise<any> {
     throw new Error('Missing auth token');
   }
 
-  const res = await fetch(
-    `${BASE_URL}/${name}`,
-    {
+  const url = `${BASE_URL}/${name}`;
+  console.log('📡 Calling endpoint:', url);
+  try {
+    const res = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${idToken}`,
       },
       body: JSON.stringify(data ?? {}),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Function call failed');
     }
-  );
 
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || 'Function call failed');
+    return res.json();
+  } catch (err: any) {
+    console.error('🔥 Backend error:', err?.response?.data || err.message);
+    throw err;
   }
-
-  return res.json();
 }


### PR DESCRIPTION
## Summary
- use shared Function base URL for incrementReligionPoints
- add logging and auth headers to Cloud Function calls
- log and catch errors in callFunction helper

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'react-native')*
- `npx eslint .` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6858248c91d8833094a0321afabb25e4