### PR TITLE
Fix API auth and add completeChallenge function

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -104,6 +104,7 @@ export default function ConfessionalScreen() {
                    'Spiritual Guide';
 
       const idToken = await getStoredToken();
+      if (!idToken) console.warn('Missing idToken for askGeminiSimple');
       const conversation = messages
         .map((m) => `${m.sender === 'user' ? 'User' : role}: ${m.text}`)
         .join('\n');

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -234,6 +234,7 @@ export default function JournalScreen() {
 
       if (userData.religion) {
         const idToken = await SecureStore.getItemAsync('idToken');
+        if (!idToken) console.warn('Missing idToken for incrementReligionPoints');
         const url = INCREMENT_RELIGION_POINTS_URL;
         console.log('📡 Calling endpoint:', url);
         try {

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -81,6 +81,7 @@ export default function ReligionAIScreen() {
     }
 
     let idToken = await getStoredToken();
+    if (!idToken) console.warn('Missing idToken for ReligionAI fetch');
     const userId = await SafeStore.getItem('userId');
     if (!idToken || !userId) {
       Alert.alert('Login Required', 'Please log in again.');
@@ -152,6 +153,7 @@ export default function ReligionAIScreen() {
 
       // Reuse the token instead of fetching it again
       idToken = idToken || (await getStoredToken());
+      if (!idToken) console.warn('Missing idToken for ReligionAI request');
       const response = await fetch(ASK_GEMINI_V2, {
         method: 'POST',
         headers: {

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -79,6 +79,7 @@ export default function ChallengeScreen() {
       });
 
       const idToken = await getStoredToken();
+      if (!idToken) console.warn('Missing idToken for askGeminiSimple');
       const res = await fetch(ASK_GEMINI_SIMPLE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
@@ -97,6 +98,7 @@ export default function ChallengeScreen() {
   const fetchChallenge = async () => {
     try {
       let idToken = await getStoredToken();
+      if (!idToken) console.warn('Missing idToken for fetchChallenge');
       const userId = await SafeStore.getItem('userId');
       if (!idToken || !userId) {
         Alert.alert('Login Required', 'Please log in again.');
@@ -259,6 +261,7 @@ export default function ChallengeScreen() {
 
     if (userData.religion) {
       const idToken = await SecureStore.getItemAsync('idToken');
+      if (!idToken) console.warn('Missing idToken for incrementReligionPoints');
       const url = INCREMENT_RELIGION_POINTS_URL;
       console.log('📡 Calling endpoint:', url);
       try {

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -82,6 +82,7 @@ export default function TriviaScreen() {
 
     try {
       const idToken = await getStoredToken();
+      if (!idToken) console.warn('Missing idToken for askGeminiSimple');
       const response = await fetch(ASK_GEMINI_SIMPLE, {
         method: 'POST',
         headers: {
@@ -137,6 +138,7 @@ export default function TriviaScreen() {
 
         if (userData.religion) {
           const idToken = await SecureStore.getItemAsync('idToken');
+          if (!idToken) console.warn('Missing idToken for incrementReligionPoints');
           const url = INCREMENT_RELIGION_POINTS_URL;
           console.log('📡 Calling endpoint:', url);
           try {

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,6 +23,10 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == uid;
     }
 
+    match /users/{userId}/journalEntries/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     match /tokens/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
     }

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,5 +1,6 @@
 import { onRequest } from "firebase-functions/v2/https";
 import { auth, db } from "./firebase";
+import * as admin from "firebase-admin";
 
 export const incrementReligionPoints = onRequest(async (req, res) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
@@ -33,5 +34,57 @@ export const incrementReligionPoints = onRequest(async (req, res) => {
   } catch (err: any) {
     console.error("🔥 Backend error:", err.message);
     res.status(500).send("Internal error");
+  }
+});
+
+export const completeChallenge = onRequest(async (req, res) => {
+  const idToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!idToken) {
+    res.status(401).send("Unauthorized");
+    return;
+  }
+
+  try {
+    const { userId, challengeId, religion, points } = req.body;
+
+    if (!userId || !challengeId || !religion || typeof points !== "number") {
+      res.status(400).send("Missing input fields");
+      return;
+    }
+
+    const decoded = await auth.verifyIdToken(idToken);
+    if (decoded.uid !== userId) {
+      res.status(403).send("Forbidden");
+      return;
+    }
+
+    const ref = db.collection("completedChallenges").doc(userId);
+    await db.runTransaction(async (t) => {
+      const snap = await t.get(ref);
+      const data = snap.exists ? snap.data() : {};
+      const list = Array.isArray(data?.challenges) ? data!.challenges : [];
+      list.push({ id: challengeId, completedAt: Date.now() });
+      t.set(ref, { challenges: list }, { merge: true });
+    });
+
+    await db.collection("users").doc(userId).set(
+      {
+        individualPoints: admin.firestore.FieldValue.increment(points),
+        lastStreakDate: new Date().toISOString(),
+      },
+      { merge: true }
+    );
+
+    const relRef = db.collection("religions").doc(religion);
+    await db.runTransaction(async (t) => {
+      const snap = await t.get(relRef);
+      const current = snap.exists ? (snap.data()?.totalPoints ?? 0) : 0;
+      t.set(relRef, { totalPoints: current + points }, { merge: true });
+    });
+
+    res.status(200).send({ message: "Challenge completed" });
+  } catch (err: any) {
+    console.error("🔥 completeChallenge error:", err.message);
+    res.status(500).send("Internal error: " + err.message);
   }
 });


### PR DESCRIPTION
## Summary
- add `completeChallenge` cloud function implementation
- improve Firestore rules for nested journal entries
- log when `idToken` is missing before hitting function endpoints
- compile Cloud Functions to verify build

## Testing
- `npm run build` in `functions`
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_68582a96557483308b16b0c7fb30b27b