### PR TITLE
Fix token handling for challenge endpoints

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -25,7 +25,6 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
 import { getPromptsForReligion } from '@/utils/guidedPrompts';
 import axios from 'axios';
-import * as SecureStore from 'expo-secure-store';
 import { INCREMENT_RELIGION_POINTS_URL } from '@/utils/constants';
 
 export default function JournalScreen() {
@@ -233,7 +232,7 @@ export default function JournalScreen() {
       });
 
       if (userData.religion) {
-        const idToken = await SecureStore.getItemAsync('idToken');
+        const idToken = await getStoredToken();
         if (!idToken) console.warn('Missing idToken for incrementReligionPoints');
         const url = INCREMENT_RELIGION_POINTS_URL;
         console.log('📡 Calling endpoint:', url);

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -20,7 +20,6 @@ import { ensureAuth } from '@/utils/authGuard';
 import { useChallengeStore } from '@/state/challengeStore';
 import * as SafeStore from '@/utils/secureStore';
 import axios from 'axios';
-import * as SecureStore from 'expo-secure-store';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -260,7 +259,7 @@ export default function ChallengeScreen() {
     });
 
     if (userData.religion) {
-      const idToken = await SecureStore.getItemAsync('idToken');
+      const idToken = await getStoredToken();
       if (!idToken) console.warn('Missing idToken for incrementReligionPoints');
       const url = INCREMENT_RELIGION_POINTS_URL;
       console.log('📡 Calling endpoint:', url);

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -19,7 +19,6 @@ import { getDocument, setDocument } from '@/services/firestoreService';
 import { callFunction } from '@/services/functionService';
 import { ensureAuth } from '@/utils/authGuard';
 import axios from 'axios';
-import * as SecureStore from 'expo-secure-store';
 
 export default function TriviaScreen() {
   const theme = useTheme();
@@ -137,7 +136,7 @@ export default function TriviaScreen() {
         });
 
         if (userData.religion) {
-          const idToken = await SecureStore.getItemAsync('idToken');
+          const idToken = await getStoredToken();
           if (!idToken) console.warn('Missing idToken for incrementReligionPoints');
           const url = INCREMENT_RELIGION_POINTS_URL;
           console.log('📡 Calling endpoint:', url);


### PR DESCRIPTION
## Summary
- use `getStoredToken` when calling incrementReligionPoints
- remove direct `SecureStore` usage

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find expo tsconfig and react-native types)*
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68583594170c8330b1575ba21bd068e6