### PR TITLE
Introduce Gus Bug Error Logging Protocol

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -17,6 +17,7 @@ import { useUser } from '@/hooks/useUser';
 import { getStoredToken } from '@/services/authService';
 import { ensureAuth } from '@/utils/authGuard';
 import { showGracefulError } from '@/utils/gracefulError';
+import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 
 export default function ConfessionalScreen() {
   const theme = useTheme();
@@ -112,17 +113,19 @@ export default function ConfessionalScreen() {
       const conversation = messages
         .map((m) => `${m.sender === 'user' ? 'User' : role}: ${m.text}`)
         .join('\n');
-      const res = await fetch(ASK_GEMINI_SIMPLE, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${idToken}`,
-        },
-        body: JSON.stringify({
-          prompt: `${conversation}\nUser: ${text}\n${role}:`,
-          history: historyMsgs,
-        }),
-      });
+      const res = await sendRequestWithGusBugLogging(() =>
+        fetch(ASK_GEMINI_SIMPLE, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({
+            prompt: `${conversation}\nUser: ${text}\n${role}:`,
+            history: historyMsgs,
+          }),
+        })
+      );
 
       const data = await res.json();
       const answer = data.response || 'You are forgiven. Walk in peace.';

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -21,6 +21,7 @@ import * as SafeStore from '@/utils/secureStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
+import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 
 export default function ReligionAIScreen() {
   const theme = useTheme();
@@ -158,19 +159,21 @@ export default function ReligionAIScreen() {
         role: m.startsWith('User:') ? 'user' : 'model',
         text: m.replace(/^[^:]+:\s*/, ''),
       }));
-      const response = await fetch(ASK_GEMINI_V2, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${idToken}`,
-        },
-        body: JSON.stringify({
-          prompt: `You are a ${promptRole} of the ${religion} faith. ` +
-            `Answer the user using teachings from that tradition and cite any ` +
-            `relevant scriptures.\n${conversationContext}\nUser: ${question}\n${promptRole}:`,
-          history: historyMsgs,
-        }),
-      });
+      const response = await sendRequestWithGusBugLogging(() =>
+        fetch(ASK_GEMINI_V2, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({
+            prompt: `You are a ${promptRole} of the ${religion} faith. ` +
+              `Answer the user using teachings from that tradition and cite any ` +
+              `relevant scriptures.\n${conversationContext}\nUser: ${question}\n${promptRole}:`,
+            history: historyMsgs,
+          }),
+        })
+      );
 
       const data = await response.json();
       const answer = data?.response || 'I am always with you. Trust in Me.';

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -17,6 +17,7 @@ import { useTheme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { callFunction, incrementReligionPoints } from '@/services/functionService';
+import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 import { ensureAuth } from '@/utils/authGuard';
 
 export default function TriviaScreen() {
@@ -81,17 +82,19 @@ export default function TriviaScreen() {
     try {
       const idToken = await getStoredToken();
       if (!idToken) console.warn('Missing idToken for askGeminiSimple');
-      const response = await fetch(ASK_GEMINI_SIMPLE, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${idToken}`
-        },
-        body: JSON.stringify({
-          prompt: `Give me a short moral story originally from any major world religion. Replace all real names and locations with fictional ones so that it seems to come from a different culture. Keep the meaning and lesson intact. After the story, add two lines: RELIGION: <religion> and STORY: <story name>.`,
-          history: [],
+      const response = await sendRequestWithGusBugLogging(() =>
+        fetch(ASK_GEMINI_SIMPLE, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({
+            prompt: `Give me a short moral story originally from any major world religion. Replace all real names and locations with fictional ones so that it seems to come from a different culture. Keep the meaning and lesson intact. After the story, add two lines: RELIGION: <religion> and STORY: <story name>.`,
+            history: [],
+          }),
         })
-      });
+      );
 
       const data = await response.json();
       const [cleanStory, info] = data.response.split('\nRELIGION:');

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { GEMINI_API_URL, STRIPE_API_URL } from '@/config/apiConfig';
 import { getStoredToken } from './authService';
+import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 
 type AskGeminiResponse = {
   reply: string;
@@ -21,7 +22,9 @@ export async function askGemini(prompt: string): Promise<string> {
       Authorization: `Bearer ${idToken}`,
       'Content-Type': 'application/json',
     };
-    const res = await axios.post<AskGeminiResponse>(GEMINI_API_URL, { prompt }, { headers });
+    const res = await sendRequestWithGusBugLogging(() =>
+      axios.post<AskGeminiResponse>(GEMINI_API_URL, { prompt }, { headers })
+    );
     return res.data.reply;
   } catch (err: any) {
     if (err.response?.status === 403) {
@@ -46,10 +49,12 @@ export async function createStripeCheckout(
       Authorization: `Bearer ${idToken}`,
       'Content-Type': 'application/json',
     };
-    const res = await axios.post<StripeCheckoutResponse>(STRIPE_API_URL, {
-      uid,
-      ...options,
-    }, { headers });
+    const res = await sendRequestWithGusBugLogging(() =>
+      axios.post<StripeCheckoutResponse>(STRIPE_API_URL, {
+        uid,
+        ...options,
+      }, { headers })
+    );
     return res.data.url;
   } catch (err: any) {
     if (err.response?.status === 403) {

--- a/App/services/functionService.ts
+++ b/App/services/functionService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getStoredToken, getFreshIdToken } from './authService';
+import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 
 const BASE_URL = process.env.EXPO_PUBLIC_FUNCTION_BASE_URL;
 
@@ -13,14 +14,14 @@ export async function callFunction(name: string, data: any): Promise<any> {
   const url = `${BASE_URL}/${name}`;
   console.log('📡 Calling endpoint:', url);
   try {
-    const res = await fetch(url, {
+    const res = await sendRequestWithGusBugLogging(() => fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${idToken}`,
       },
       body: JSON.stringify(data ?? {}),
-    });
+    }));
 
     if (!res.ok) {
       const text = await res.text();
@@ -47,15 +48,17 @@ export async function incrementReligionPoints(
   const url = `${BASE_URL}/incrementReligionPoints`;
   console.log('📡 Calling endpoint:', url);
   try {
-    await axios.post(
-      url,
-      { religion, points },
-      {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-          'Content-Type': 'application/json',
+    await sendRequestWithGusBugLogging(() =>
+      axios.post(
+        url,
+        { religion, points },
+        {
+          headers: {
+            Authorization: `Bearer ${idToken}`,
+            'Content-Type': 'application/json',
+          },
         },
-      },
+      )
     );
   } catch (err: any) {
     console.error('🔥 Backend error:', err?.response?.data || err.message);

--- a/App/services/storageService.ts
+++ b/App/services/storageService.ts
@@ -1,4 +1,5 @@
 import { getStoredToken } from './authService';
+import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 
 const BUCKET = process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET;
 
@@ -13,14 +14,16 @@ export async function uploadImage(fileUri: string, path: string): Promise<string
   const blob = await response.blob();
   const uploadUrl = `https://firebasestorage.googleapis.com/v0/b/${BUCKET}/o?name=${encodeURIComponent(path)}`;
 
-  const res = await fetch(uploadUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': blob.type || 'application/octet-stream',
-      Authorization: `Bearer ${idToken}`,
-    },
-    body: blob,
-  });
+  const res = await sendRequestWithGusBugLogging(() =>
+    fetch(uploadUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': blob.type || 'application/octet-stream',
+        Authorization: `Bearer ${idToken}`,
+      },
+      body: blob,
+    })
+  );
 
   if (!res.ok) {
     if (res.status === 403) {

--- a/App/utils/gusBugLogger.ts
+++ b/App/utils/gusBugLogger.ts
@@ -1,0 +1,31 @@
+export const LOGGING_MODE = process.env.EXPO_PUBLIC_LOGGING_MODE || 'gusbug';
+
+export async function sendRequestWithGusBugLogging<T>(
+  requestFn: () => Promise<T>,
+): Promise<T> {
+  try {
+    const res: any = await requestFn();
+
+    const status = res?.status;
+    if (status === 401 || status === 403) {
+      if (LOGGING_MODE === 'gusbug') {
+        console.warn('⚠️ Gus Bug Interception: Backend rejected the token. 🧸🕵️');
+      } else {
+        console.warn('Request failed with auth error');
+      }
+    } else if (LOGGING_MODE === 'gusbug') {
+      console.log('🎉 Gus Bug cleared the path. Request successful!');
+    }
+
+    return res;
+  } catch (err: any) {
+    if (err?.response?.status === 401 || err?.response?.status === 403) {
+      if (LOGGING_MODE === 'gusbug') {
+        console.warn('⚠️ Gus Bug Interception: Backend rejected the token. 🧸🕵️');
+      } else {
+        console.warn('Request failed with auth error');
+      }
+    }
+    throw err;
+  }
+}

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -7,22 +7,19 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "";
+const LOGGING_MODE = process.env.LOGGING_MODE || "gusbug";
 
 export const incrementReligionPoints = onRequest(async (req, res) => {
-  const header = req.headers.authorization || "";
-  console.log("🪪 Authorization Header:", header);
-
-  if (!header.toLowerCase().startsWith("bearer ")) {
-    res.status(401).send("Missing or malformed Authorization header");
+  const idToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!idToken) {
+    console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
+    res.status(401).json({ error: "Unauthorized — Gus bug stole the token!" });
     return;
   }
-
-  const idToken = header.replace(/^Bearer\s+/i, "").trim();
-
   let decoded: admin.auth.DecodedIdToken;
   try {
     decoded = await auth.verifyIdToken(idToken);
-    console.log("✅ Authenticated user:", decoded.uid);
+    console.log(`✅ Gus Bug Authenticated: ${decoded.uid} is legit! 🎯`);
     const { religion, points } = req.body;
 
     if (
@@ -44,29 +41,44 @@ export const incrementReligionPoints = onRequest(async (req, res) => {
 
     res.status(200).send({ message: "Points updated" });
   } catch (err: any) {
-    console.error("🔥 Backend error:", err.message);
+    console.error("🛑 Gus Bug Tampered Token: Couldn't verify. 🧙‍♂️✨", err);
     if (err.code === "auth/argument-error") {
-      res.status(401).send("Invalid token");
-    } else {
-      res.status(500).send("Internal error");
+      res.status(401).json({
+        error: "Unauthorized — Gus bug cast an invalid token spell.",
+      });
+      return;
     }
+    res.status(500).send("Internal error");
   }
 });
 
-export const completeChallenge = onRequest(async (_req, res) => {
-  res.status(200).send({ message: "✅ completeChallenge function is live" });
+export const completeChallenge = onRequest(async (req, res) => {
+  const idToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!idToken) {
+    console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
+    res.status(401).json({ error: "Unauthorized — Gus bug stole the token!" });
+    return;
+  }
+  try {
+    const decodedToken = await auth.verifyIdToken(idToken);
+    console.log(`✅ Gus Bug Authenticated: ${decodedToken.uid} is legit! 🎯`);
+    res.status(200).send({ message: "✅ completeChallenge function is live" });
+  } catch (err) {
+    console.error("🛑 Gus Bug Tampered Token: Couldn't verify. 🧙‍♂️✨", err);
+    res.status(401).json({
+      error: "Unauthorized — Gus bug cast an invalid token spell.",
+    });
+    return;
+  }
 });
 
 export const askGeminiV2 = onRequest(async (req, res) => {
-  const header = req.headers.authorization || "";
-  console.log("🪪 Authorization Header:", header);
-
-  if (!header.toLowerCase().startsWith("bearer ")) {
-    res.status(401).json({ error: "Missing or malformed Authorization header" });
+  const idToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!idToken) {
+    console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
+    res.status(401).json({ error: "Unauthorized — Gus bug stole the token!" });
     return;
   }
-
-  const idToken = header.replace(/^Bearer\s+/i, "").trim();
 
   const { prompt = "", history = [] } = req.body || {};
 
@@ -74,7 +86,7 @@ export const askGeminiV2 = onRequest(async (req, res) => {
   try {
     decoded = await auth.verifyIdToken(idToken);
     const uid = decoded.uid;
-    console.log("✅ Authenticated user:", uid);
+    console.log(`✅ Gus Bug Authenticated: ${uid} is legit! 🎯`);
 
     const userRef = db.collection("users").doc(uid);
     const snap = await userRef.get();
@@ -115,11 +127,18 @@ export const askGeminiV2 = onRequest(async (req, res) => {
 
     res.status(200).json({ response: text });
   } catch (err: any) {
-    console.error("🔥 Gemini Error:", err.message);
+    console.error("🛑 Gus Bug Tampered Token: Couldn't verify. 🧙‍♂️✨", err);
     if (err.code === "auth/argument-error") {
-      res.status(401).json({ error: "Invalid token" });
-    } else {
-      res.status(500).json({ error: "Gemini failed" });
+      res.status(401).json({
+        error: "Unauthorized — Gus bug cast an invalid token spell.",
+      });
+      return;
     }
+    res.status(500).json({ error: "Gemini failed" });
   }
+});
+
+export const handleStripeWebhookV2 = onRequest(async (req, res) => {
+  console.log('💰 Gus Bug Webhook triggered. No auth needed!');
+  res.status(200).send({ received: true });
 });


### PR DESCRIPTION
## Summary
- implement `sendRequestWithGusBugLogging` helper and logging mode toggle
- wrap all Firebase REST calls in the new logger
- add Gus Bug authentication snippet to Cloud Functions
- add playful Stripe webhook handler

## Testing
- `npx tsc -p functions/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68584b54feac83308eda5ff2b01ac945