### PR TITLE
Allow continuous confessional chat

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -85,7 +85,11 @@ export default function ConfessionalScreen() {
       return;
     }
 
-    if (messages.length >= 10) return;
+    if (messages.length >= 30)
+      Alert.alert(
+        'Conversation full',
+        'Try a fresh start for a new conversation.',
+      );
 
     setLoading(true);
     try {
@@ -129,7 +133,13 @@ export default function ConfessionalScreen() {
 
       const data = await res.json();
       const answer = data.response || 'You are forgiven. Walk in peace.';
-      setMessages((prev) => [...prev, { sender: 'user', text }, { sender: 'ai', text: answer }]);
+      console.log('✝️ Confessional input:', text);
+      console.log('🕊️ Confessional AI reply:', answer);
+      setMessages((prev) => [
+        ...prev,
+        { sender: 'user', text },
+        { sender: 'ai', text: answer },
+      ]);
       setText('');
     } catch (err) {
       console.error('❌ Confession error:', err);
@@ -152,7 +162,7 @@ export default function ConfessionalScreen() {
         />
         <CustomText style={styles.systemMsg}>This conversation is private and vanishes when you leave.</CustomText>
         <View style={styles.buttonWrap}>
-          <Button title="Send" onPress={handleConfess} disabled={loading || messages.length >= 10} />
+          <Button title="Send" onPress={handleConfess} disabled={loading} />
         </View>
         {loading && <ActivityIndicator size="large" color={theme.colors.primary} />}
         {messages.map((m, idx) => (


### PR DESCRIPTION
## Summary
- keep clearing messages when the Confessional screen unmounts
- remove the hard cap of 10 messages
- warn if the conversation goes over 30 messages
- log user input and AI reply in the Confessional screen
- let the `Send` button enable as long as the screen isn't loading

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68585bfb30588330944f581d3dbae10e