### PR TITLE
Align Firestore rules with app features

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,55 +2,67 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    match /dailyChallenges/{docId} {
-      allow read: if true;
-      allow write: if request.auth != null && request.auth.token.admin == true;
-    }
-
-    match /journalEntries/{docId} {
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
-      allow read, update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
-    }
-
-    match /completedChallenges/{docId} {
-      allow read, write: if request.auth != null && request.auth.uid == docId;
-    }
-
-    match /testCollection/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
-    }
-
-    match /users/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
-    }
-
+    // \u{1F9D8}\u200D\u2642\uFE0F Journal entries
     match /users/{userId}/journals/{journalId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // \u{1F5E3} ReligionAI chat history
+    match /users/{userId}/religionAI/history {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // \u{1F64F} Confessions
+    match /users/{userId}/confessions/{confessionId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // \u{1F3C6} Challenge + profile data
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // \u{1FA99} Token docs inside user
+    match /users/{userId}/tokens/{tokenId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // \u{1FA99} Legacy token docs
     match /tokens/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
     }
 
-    match /subscriptions/{uid} {
+    // \u{1F9FE} Free ask timestamps
+    match /freeAsk/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
     }
 
-    match /proofSubmissions/{docId} {
+    // \u{1F4F7} Challenge proof submissions
+    match /challengeProofs/{docId} {
       allow create: if request.auth != null;
       allow read, update, delete: if request.auth != null && resource.data.uid == request.auth.uid;
     }
 
-    match /organizations/{orgId} {
-      allow read: if true;
-      allow write: if request.auth != null;
+    // \u{1F9FE} Subscriptions
+    match /subscriptions/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // \u{1F3DB} Organizations
+    match /organizations/{orgId} {
+      allow read: if true;
+      allow write: if request.auth != null &&
+        exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.organizationId == orgId;
+    }
+
+    // \u{1F64B}\u200D\u2642\uFE0F Religions (public)
     match /religions/{name} {
       allow read: if true;
       allow write: if request.auth != null && request.auth.token.admin == true;
     }
 
+    // Default deny
     match /{document=**} {
       allow read, write: if false;
     }

--- a/functions/firestore.rules
+++ b/functions/firestore.rules
@@ -2,22 +2,55 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Public readable data
-    match /religions/{religion} {
-      allow read: if true;
-      allow write: if request.auth != null;
+    match /users/{userId}/journals/{journalId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    // Authenticated user data
+    match /users/{userId}/religionAI/history {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /users/{userId}/confessions/{confessionId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     match /users/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    match /users/{userId}/{document=**} {
+    match /users/{userId}/tokens/{tokenId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    // Default deny
+    match /tokens/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+
+    match /freeAsk/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+
+    match /challengeProofs/{docId} {
+      allow create: if request.auth != null;
+      allow read, update, delete: if request.auth != null && resource.data.uid == request.auth.uid;
+    }
+
+    match /subscriptions/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /organizations/{orgId} {
+      allow read: if true;
+      allow write: if request.auth != null &&
+        exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.organizationId == orgId;
+    }
+
+    match /religions/{name} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.admin == true;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Summary
- update firestore.rules with paths for journal, ReligionAI, tokens, subscriptions and organizations
- mirror the same rules under `functions/`

## Testing
- `npm install -g firebase-tools`
- `firebase deploy --only firestore:rules` *(fails: no active project)*

------
https://chatgpt.com/codex/tasks/task_e_68585e4445008330a737db39fe73f709