### PR TITLE
Remove challenge injection from Gemini endpoints

### DIFF
--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -199,6 +199,8 @@ export default function ReligionAIScreen() {
 
       const data = await response.json();
       const answer = data?.response || 'I am always with you. Trust in Me.';
+      console.log('📖 ReligionAI input:', question);
+      console.log('🙏 ReligionAI reply:', answer);
 
       let updatedMessages: string[];
       if (subscribed) {

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -11,7 +11,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
-import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
+import { ASK_GEMINI_SIMPLE, GENERATE_CHALLENGE_URL } from "@/utils/constants";
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { callFunction, incrementReligionPoints } from '@/services/functionService';
 import { useUser } from '@/hooks/useUser';
@@ -130,7 +130,7 @@ export default function ChallengeScreen() {
       // Reuse the token instead of fetching it again
       idToken = idToken || (await getStoredToken());
       const response = await sendRequestWithGusBugLogging(() =>
-        fetch(ASK_GEMINI_SIMPLE, {
+        fetch(GENERATE_CHALLENGE_URL, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/App/utils/constants.ts
+++ b/App/utils/constants.ts
@@ -1,7 +1,8 @@
 const BASE_URL = process.env.EXPO_PUBLIC_FUNCTION_BASE_URL;
 
 export const ASK_GEMINI_V2 = `${BASE_URL}/askGeminiV2`;
-export const ASK_GEMINI_SIMPLE = ASK_GEMINI_V2; // alias to unify usage
+export const ASK_GEMINI_SIMPLE = `${BASE_URL}/askGeminiSimple`;
+export const GENERATE_CHALLENGE_URL = `${BASE_URL}/generateChallenge`;
 
 export const STRIPE_WEBHOOK_URL = `${BASE_URL}/handleStripeWebhookV2`; // Optional if you plan to ping it
 export const INCREMENT_RELIGION_POINTS_URL = `${BASE_URL}/incrementReligionPoints`;

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -75,7 +75,7 @@ export const completeChallenge = onRequest(async (req, res) => {
   }
 });
 
-export const askGeminiV2 = onRequest(async (req, res) => {
+export const askGeminiSimple = onRequest(async (req, res) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -88,6 +88,87 @@ export const askGeminiV2 = onRequest(async (req, res) => {
   let decoded: admin.auth.DecodedIdToken;
   try {
     decoded = await auth.verifyIdToken(idToken);
+    const uid = decoded.uid;
+    console.log(`✅ Gus Bug Authenticated: ${uid} is legit! 🎯`);
+
+    const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-pro" });
+
+    const chat = await model.startChat({
+      history: (history as any[]).map((msg) => ({
+        role: msg.role,
+        parts: [{ text: msg.text }],
+      })),
+    });
+
+    const result = await chat.sendMessage(prompt);
+    const text = result?.response?.text?.() ?? "No response text returned.";
+
+    res.status(200).json({ response: text });
+  } catch (err: any) {
+    console.error("🛑 Gus Bug Tampered Token: Couldn't verify. 🧙‍♂️✨", err);
+    if (err.code === "auth/argument-error") {
+      res.status(401).json({
+        error: "Unauthorized — Gus bug cast an invalid token spell.",
+      });
+      return;
+    }
+    res.status(500).json({ error: "Gemini failed" });
+  }
+});
+
+export const askGeminiV2 = onRequest(async (req, res) => {
+  const idToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!idToken) {
+    console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
+    res.status(401).json({ error: "Unauthorized — Gus bug stole the token!" });
+    return;
+  }
+
+  const { prompt = "", history = [] } = req.body || {};
+
+  try {
+    const decoded = await auth.verifyIdToken(idToken);
+    console.log(`✅ GeminiV2 user: ${decoded.uid}`);
+
+    const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-pro" });
+
+    const chat = await model.startChat({
+      history: (history as any[]).map((msg) => ({
+        role: msg.role,
+        parts: [{ text: msg.text }],
+      })),
+    });
+
+    const result = await chat.sendMessage(prompt);
+    const text = result?.response?.text?.() ?? "No response text returned.";
+
+    res.status(200).json({ response: text });
+  } catch (err: any) {
+    console.error("🛑 Gus Bug Tampered Token: Couldn't verify. 🧙‍♂️✨", err);
+    if (err.code === "auth/argument-error") {
+      res.status(401).json({
+        error: "Unauthorized — Gus bug cast an invalid token spell.",
+      });
+      return;
+    }
+    res.status(500).json({ error: "Gemini failed" });
+  }
+});
+
+export const generateChallenge = onRequest(async (req, res) => {
+  const idToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!idToken) {
+    console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
+    res.status(401).json({ error: "Unauthorized — Gus bug stole the token!" });
+    return;
+  }
+
+  const { history = [] } = req.body || {};
+
+  try {
+    const decoded = await auth.verifyIdToken(idToken);
     const uid = decoded.uid;
     console.log(`✅ Gus Bug Authenticated: ${uid} is legit! 🎯`);
 


### PR DESCRIPTION
## Summary
- split Gemini functions: simple, v2 and challenge generator
- log ReligionAI prompts and replies
- add dedicated generateChallenge endpoint and constant
- call new endpoint from Challenge screen

## Testing
- `npx tsc` in `functions`


------
https://chatgpt.com/codex/tasks/task_e_685861bb81a883309c4bbbc5c3f9e1d8