### PR TITLE
Fix JSON parsing and update OneVine branding

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -131,7 +131,15 @@ export default function ConfessionalScreen() {
         })
       );
 
-      const data = await res.json();
+      const textResp = await res.text();
+      let data: any;
+      try {
+        data = JSON.parse(textResp);
+      } catch (err) {
+        console.error('Invalid JSON from Confessional:', textResp);
+        showGracefulError();
+        return;
+      }
       const answer = data.response || 'You are forgiven. Walk in peace.';
       console.log('✝️ Confessional input:', text);
       console.log('🕊️ Confessional AI reply:', answer);

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -200,7 +200,15 @@ export default function JournalScreen() {
         },
         body: JSON.stringify({ prompt, history: [] }),
       });
-      const data = await res.json();
+      const text = await res.text();
+      let data: any;
+      try {
+        data = JSON.parse(text);
+      } catch (err) {
+        console.error('Invalid JSON from guided journal:', text);
+        showGracefulError();
+        return;
+      }
       setGuidedText(data.response || '');
       console.log('🎉 Gus Bug: Gemini text received.');
       Alert.alert('Guided Prompt Ready', 'Gemini has provided a suggestion.');

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -130,7 +130,7 @@ export default function ReligionAIScreen() {
       const cost = 5;
       const subscribed = userData.isSubscribed || (subDoc?.active === true);
       setIsSubscribed(subscribed);
-      console.log('💎 WWJD+ Status:', subscribed);
+      console.log('💎 OneVine+ Status:', subscribed);
 
       const religion = userData.religion || 'Spiritual Guide';
       const promptRole = religion === 'Christianity' ? 'Jesus' :
@@ -199,7 +199,15 @@ export default function ReligionAIScreen() {
         })
       );
 
-      const data = await response.json();
+      const text = await response.text();
+      let data: any;
+      try {
+        data = JSON.parse(text);
+      } catch (err) {
+        console.error('Invalid JSON from ReligionAI:', text);
+        showGracefulError();
+        return;
+      }
       const answer = data?.response || 'I am always with you. Trust in Me.';
       console.log('📖 ReligionAI input:', question);
       console.log('🙏 ReligionAI reply:', answer);

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -89,7 +89,14 @@ export default function ChallengeScreen() {
           }),
         })
       );
-      const data = await res.json();
+      const textResp = await res.text();
+      let data: any;
+      try {
+        data = JSON.parse(textResp);
+      } catch (err) {
+        console.error('Invalid JSON from milestone blessing:', textResp);
+        return;
+      }
       const blessing = data.response || "You’ve walked with discipline and devotion. This is your blessing.";
       Alert.alert('Blessing!', `${blessing}\nYou earned ${reward} Grace Tokens.`);
     } catch (err) {
@@ -143,7 +150,15 @@ export default function ChallengeScreen() {
         })
       );
 
-      const data = await response.json();
+      const text = await response.text();
+      let data: any;
+      try {
+        data = JSON.parse(text);
+      } catch (err) {
+        console.error('Invalid JSON from generateChallenge:', text);
+        showGracefulError();
+        return;
+      }
       const newChallenge = data.response || 'Reflect in silence for five minutes today.';
       console.log('🌟 New Challenge:', newChallenge);
       setChallenge(newChallenge);

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -96,7 +96,16 @@ export default function TriviaScreen() {
         })
       );
 
-      const data = await response.json();
+      const text = await response.text();
+      let data: any;
+      try {
+        data = JSON.parse(text);
+      } catch (err) {
+        console.error('Invalid JSON from trivia:', text);
+        Alert.alert('Error', 'Could not load trivia. Please try again later.');
+        setLoading(false);
+        return;
+      }
       const [cleanStory, info] = data.response.split('\nRELIGION:');
       const [religionLine, storyLine] = info?.split('\nSTORY:') || [];
 

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -53,7 +53,7 @@ export const syncSubscriptionStatus = async () => {
   if (!uid) return;
   const sub = await getDocument(`subscriptions/${uid}`);
   const isSubscribed = !!sub && sub.active === true;
-  console.log('💎 WWJD+ Status:', isSubscribed);
+  console.log('💎 OneVine+ Status:', isSubscribed);
   if (isSubscribed) {
     await setDocument(`tokens/${uid}`, { count: 9999 });
   }


### PR DESCRIPTION
## Summary
- guard against invalid JSON for Gemini API calls
- show `OneVine+` status message in logs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685867f360848330a25eec0a8c6ac8ed