### PR TITLE
Fix sign-out navigation

### DIFF
--- a/App/components/common/Header.tsx
+++ b/App/components/common/Header.tsx
@@ -40,8 +40,13 @@ export default function Header() {
         text: 'Sign Out',
         style: 'destructive',
         onPress: async () => {
-          await logout();
-          navigation.reset({ index: 0, routes: [{ name: 'Welcome' }] });
+          try {
+            await logout();
+            navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+          } catch (err) {
+            console.error('\u274C Sign out failed:', err);
+            Alert.alert('Logout Error', 'Could not sign out. Please try again.');
+          }
         },
       },
     ]);

--- a/App/screens/profile/SettingsScreen.tsx
+++ b/App/screens/profile/SettingsScreen.tsx
@@ -69,9 +69,14 @@ export default function SettingsScreen() {
   };
 
   const handleLogout = async () => {
-    await logout();
-    clearUser();
-    navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+    try {
+      await logout();
+      clearUser();
+      navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+    } catch (err) {
+      console.error('\u274C Sign out failed:', err);
+      Alert.alert('Logout Error', 'Could not sign out. Please try again.');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- redirect to the Login screen after signing out via header or settings
- show an alert if sign out fails

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'react-native')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68586b43f5388330bd3110b0db714de9