### PR TITLE
Fix Gemini functions and leaderboards

### DIFF
--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -87,16 +87,27 @@ export default function LeaderboardsScreen() {
     }
   };
 
-  const renderList = (title: string, data: any[], keyName: string, valueName: string) => (
+  const renderList = (
+    title: string,
+    data: any[],
+    keyName: string,
+    valueName: string,
+  ) => (
     <View style={styles.section}>
       <CustomText style={styles.sectionTitle}>{title}</CustomText>
-      {data.map((item, index) => (
-        <View key={item.id || index} style={styles.row}>
-          <CustomText style={styles.rank}>{index + 1}.</CustomText>
-          <CustomText style={styles.name}>{item[keyName]}</CustomText>
-          <CustomText style={styles.points}>{item[valueName]} pts</CustomText>
-        </View>
-      ))}
+      {data.length === 0 ? (
+        <CustomText>No leaders yet!</CustomText>
+      ) : (
+        data.map((item, index) => (
+          <View key={item.id || index} style={styles.row}>
+            <CustomText style={styles.rank}>{index + 1}.</CustomText>
+            <CustomText style={styles.name}>
+              {item[keyName] || item.displayName || item.email}
+            </CustomText>
+            <CustomText style={styles.points}>{item[valueName]} pts</CustomText>
+          </View>
+        ))
+      )}
     </View>
   );
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -19,7 +19,10 @@ service cloud.firestore {
 
     // \u{1F3C6} Challenge + profile data
     match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      // Public read access for leaderboards
+      allow read: if true;
+      // Only the owner may write their data
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
 
     // \u{1FA99} Token docs inside user

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -168,7 +168,7 @@ export const generateChallenge = onRequest(async (req, res) => {
     return;
   }
 
-  const { history = [], seed = Date.now() } = req.body || {};
+  const { prompt = "", history = [], seed = Date.now() } = req.body || {};
 
   try {
     const decoded = await auth.verifyIdToken(idToken);
@@ -188,7 +188,9 @@ export const generateChallenge = onRequest(async (req, res) => {
 
     const randomizer = `Seed:${seed}`;
 
-    const fullPrompt = `\nYou are a spiritual guide helping users grow in faith.\n\nDo NOT repeat or closely resemble any of the following recent challenges:\n${avoid}\n\nNow generate a new, unique, and creative spiritual challenge inspired by Christian teachings.\nMake it practical, soul-stirring, and concise.\nRespond ONLY with the new challenge text.`;
+    const basePrompt = prompt.trim() ||
+      "Generate a new, unique, and creative spiritual challenge inspired by Christian teachings.";
+    const fullPrompt = `${basePrompt}\n\nDo NOT repeat or closely resemble any of the following recent challenges:\n${avoid}\n\nRespond ONLY with the new challenge text.`;
 
     const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
     const model = genAI.getGenerativeModel({ model: "gemini-1.5-pro" });


### PR DESCRIPTION
## Summary
- use user-provided prompt in `generateChallenge`
- open read access to `/users` documents for leaderboards
- show fallback message in leaderboard when no entries

## Testing
- `npm test` *(fails: Missing script)*
- `cd functions && npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858a1ee5b5c8330817e18724dc2292c