### PR TITLE
Fix dotenv loading for functions

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -5,7 +5,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import Stripe from "stripe";
 import * as dotenv from "dotenv";
 
-dotenv.config();
+dotenv.config({ path: ".env.functions" });
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "";
 const LOGGING_MODE = process.env.LOGGING_MODE || "gusbug";


### PR DESCRIPTION
## Summary
- ensure functions load `.env.functions` explicitly

## Testing
- `npm run build` in `functions`
- `firebase deploy --only functions` *(fails: No currently active project)*

------
https://chatgpt.com/codex/tasks/task_e_6858bbbc89308330b60e947f58dc9074