### PR TITLE
Improve challenge generation skip logic

### DIFF
--- a/App/utils/constants.ts
+++ b/App/utils/constants.ts
@@ -2,7 +2,7 @@ const BASE_URL = process.env.EXPO_PUBLIC_FUNCTION_BASE_URL;
 
 export const ASK_GEMINI_V2 = `${BASE_URL}/askGeminiV2`;
 export const ASK_GEMINI_SIMPLE = `${BASE_URL}/askGeminiSimple`;
-export const GENERATE_CHALLENGE_URL = `${BASE_URL}/generateChallenge`;
+export const GENERATE_CHALLENGE_URL = `${BASE_URL}/generateDailyChallenge`;
 
 export const STRIPE_WEBHOOK_URL = `${BASE_URL}/handleStripeWebhookV2`; // Optional if you plan to ping it
 export const INCREMENT_RELIGION_POINTS_URL = `${BASE_URL}/incrementReligionPoints`;

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,6 +30,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // \u{1F4DA} Challenge history
+    match /users/{userId}/challengeHistory/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // \u{1FA99} Legacy token docs
     match /tokens/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;


### PR DESCRIPTION
## Summary
- add `generateDailyChallenge` cloud function
- log Gemini prompt and keep recent challenge history
- store weekly skip counts and add exponential token cost for extra skips
- hook mobile skip logic into new fields
- expose new `/generateDailyChallenge` endpoint
- permit reading/writing `challengeHistory` subcollection in Firestore rules

## Testing
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_6858d971649c83308dbd88e3a7eb0076