### PR TITLE
Add guided journal stages and store entries

### DIFF
--- a/App/types/Journal.ts
+++ b/App/types/Journal.ts
@@ -1,0 +1,16 @@
+export type JournalStage =
+  | 'reflection'
+  | 'gratitude'
+  | 'spiritual'
+  | 'forgiveness'
+  | 'compassion';
+
+export interface JournalEntry {
+  id?: string;
+  stage: JournalStage;
+  aiPrompt: string;
+  aiResponse: string;
+  userEntry: string;
+  timestamp: string;
+  tokensUsed?: number;
+}

--- a/App/types/index.ts
+++ b/App/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./user";
 export * from "./Challenge";
 export * from "./Organization";
+export * from "./Journal";

--- a/App/utils/journalStages.ts
+++ b/App/utils/journalStages.ts
@@ -1,0 +1,19 @@
+import type { JournalStage } from '@/types';
+
+export const JOURNAL_STAGES: { key: JournalStage; label: string }[] = [
+  { key: 'reflection', label: 'Daily Reflection' },
+  { key: 'gratitude', label: 'Gratitude Practice' },
+  { key: 'spiritual', label: 'Spiritual Insight' },
+  { key: 'forgiveness', label: 'Forgiveness / Letting Go' },
+  { key: 'compassion', label: 'Compassion for Others' },
+];
+
+export const JOURNAL_PROMPTS: Record<JournalStage, string> = {
+  reflection: 'Help me reflect honestly on today.',
+  gratitude:
+    "Guide me to reflect on something I'm deeply grateful for today. Help me open my heart.",
+  spiritual: 'Share a brief spiritual insight to inspire me.',
+  forgiveness: 'Invite me to release resentment and practice forgiveness.',
+  compassion: 'Help me see how I can show compassion to someone today.',
+};
+

--- a/firestore.rules
+++ b/firestore.rules
@@ -6,6 +6,9 @@ service cloud.firestore {
     match /users/{userId}/journals/{journalId} {
       allow read, write: if request.auth.uid == userId;
     }
+    match /users/{userId}/journalEntries/{entryId} {
+      allow read, write: if request.auth.uid == userId;
+    }
 
     // \u{1F5E3} ReligionAI chat history
     match /users/{userId}/religionAI/history {

--- a/functions/firestore.rules
+++ b/functions/firestore.rules
@@ -5,6 +5,9 @@ service cloud.firestore {
     match /users/{userId}/journals/{journalId} {
       allow read, write: if request.auth.uid == userId;
     }
+    match /users/{userId}/journalEntries/{entryId} {
+      allow read, write: if request.auth.uid == userId;
+    }
 
     match /users/{userId}/religionAI/history {
       allow read, write: if request.auth != null && request.auth.uid == userId;


### PR DESCRIPTION
## Summary
- add `JournalStage` types and stage prompt constants
- update journaling screen with stage picker and Gemini prompt fallback
- save entries under `journalEntries` collection
- update Firestore rules for new collection

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*
- `npx eslint . --ext .ts,.tsx` *(fails: couldn't find eslint config)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6858dcd74cf88330af0bfbdc5fae9022