### PR TITLE
Implement streak + XP system

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -16,7 +16,7 @@ import { useTheme } from "@/components/theme/theme";
 import { showGracefulError } from '@/utils/gracefulError';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { querySubcollection, addDocument, getDocument, setDocument } from '@/services/firestoreService';
-import { incrementReligionPoints } from '@/services/functionService';
+import { callFunction, incrementReligionPoints } from '@/services/functionService';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { ensureAuth } from '@/utils/authGuard';
 import * as SafeStore from '@/utils/secureStore';
@@ -246,6 +246,12 @@ export default function JournalScreen() {
       await setDocument(`users/${uid}`, {
         individualPoints: (userData.individualPoints || 0) + 2,
       });
+
+      try {
+        await callFunction('updateStreakAndXP', { type: 'journal' });
+      } catch (err) {
+        console.error('Streak update failed:', err);
+      }
 
       if (userData.religion) {
         try {

--- a/firestore.rules
+++ b/firestore.rules
@@ -24,8 +24,14 @@ service cloud.firestore {
     match /users/{userId} {
       // Public read access for leaderboards
       allow read: if true;
-      // Only the owner may write their data
-      allow write: if request.auth != null && request.auth.uid == userId;
+      // Allow document creation/deletion by the owner
+      allow create, delete: if request.auth != null && request.auth.uid == userId;
+      // Updates are allowed only if protected fields are unchanged
+      allow update: if request.auth != null && request.auth.uid == userId
+        && request.resource.data.xpPoints == resource.data.xpPoints
+        && request.resource.data.streakCount == resource.data.streakCount
+        && request.resource.data.lastCheckIn == resource.data.lastCheckIn
+        && request.resource.data.longestStreak == resource.data.longestStreak;
     }
 
     // \u{1FA99} Token docs inside user


### PR DESCRIPTION
## Summary
- handle daily streak and XP on the backend
- add `updateStreakAndXP` helper + endpoint
- update challenge and journal flows to use new backend logic
- restrict protected fields in Firestore rules

## Testing
- `npm run build` in `functions`

------
https://chatgpt.com/codex/tasks/task_e_6858dfe4f2c08330ac3ba04445799890