### PR TITLE
Add Codex prompt library

### DIFF
--- a/PromptLibrary.md
+++ b/PromptLibrary.md
@@ -1,0 +1,10 @@
+## AI
+### Fix Gemini Calls
+Prompt: Resolve issues with Gemini API authentication.
+Tags: [gemini, functions]
+
+## Stripe
+### Token Deduction Logic
+Prompt: Implement token deduction after each daily challenge.
+Tags: [stripe, tokens]
+

--- a/README.md
+++ b/README.md
@@ -119,7 +119,25 @@ All Firebase integrations now use the REST API—see `App/services` for details.
 
 Stripe subscription flow is being integrated with Firebase webhook handling
 
+
 Onboarding uses anonymous login, upgraded to email if subscribed
+
+## 📚 Codex Prompt Library
+
+Prompts used for Codex and Copilot live in the `codexPrompts` Firestore collection.
+You can manage them locally with `functions/codexPrompts.ts`:
+
+```bash
+# Add a new prompt
+cd functions
+npx ts-node codexPrompts.ts add "Fix Gemini Calls" AI "Resolve Gemini auth" "gemini,ai"
+
+# Export all prompts to Markdown
+npm run build
+node lib/codexPrompts.js export ../PromptLibrary.md
+```
+
+The export command creates `PromptLibrary.md` with prompts grouped by category.
 
 🙏 Contributing
 We welcome faith leaders, engineers, designers, and visionaries to collaborate.

--- a/functions/codexPrompts.ts
+++ b/functions/codexPrompts.ts
@@ -1,0 +1,73 @@
+import * as admin from 'firebase-admin';
+import * as fs from 'fs';
+import { db } from './firebase';
+
+export interface CodexPrompt {
+  title: string;
+  category: string;
+  promptText: string;
+  tags: string[];
+  createdAt?: admin.firestore.FieldValue;
+}
+
+export async function addPrompt(data: Omit<CodexPrompt, 'createdAt'>): Promise<string> {
+  const doc = await db.collection('codexPrompts').add({
+    ...data,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  return doc.id;
+}
+
+export async function listPrompts(): Promise<Record<string, any>[]> {
+  const snap = await db.collection('codexPrompts').orderBy('createdAt', 'desc').get();
+  return snap.docs.map(d => ({ id: d.id, ...(d.data() as any) }));
+}
+
+export async function exportMarkdown(filePath = 'PromptLibrary.md'): Promise<void> {
+  const prompts = await listPrompts();
+  const grouped: Record<string, Record<string, any>[]> = {};
+  for (const p of prompts) {
+    const cat = p.category || 'Uncategorized';
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push(p);
+  }
+
+  let md = '';
+  for (const cat of Object.keys(grouped).sort()) {
+    md += `## ${cat}\n`;
+    for (const p of grouped[cat]) {
+      md += `### ${p.title}\n`;
+      md += `Prompt: ${p.promptText}\n`;
+      if (p.tags && p.tags.length) {
+        md += `Tags: [${p.tags.join(', ')}]\n`;
+      }
+      md += '\n';
+    }
+  }
+  fs.writeFileSync(filePath, md, 'utf8');
+}
+
+if (require.main === module) {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === 'export') {
+    const file = args[0] || 'PromptLibrary.md';
+    exportMarkdown(file).then(() => {
+      console.log(`Exported prompts to ${file}`);
+      process.exit(0);
+    });
+  } else if (command === 'add') {
+    const [title, category, promptText, tagStr] = args;
+    if (!title || !category || !promptText) {
+      console.error('Usage: node codexPrompts.js add "Title" "Category" "Prompt" "tag1,tag2"');
+      process.exit(1);
+    }
+    const tags = tagStr ? tagStr.split(',').map(t => t.trim()).filter(Boolean) : [];
+    addPrompt({ title, category, promptText, tags }).then(id => {
+      console.log(`Added prompt ${id}`);
+      process.exit(0);
+    });
+  } else {
+    console.log('Usage: node codexPrompts.js <add|export>');
+    process.exit(1);
+  }
+}

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -10,6 +10,11 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["index.ts", "firebase.ts", "firestoreSeeder.ts"],
+  "include": [
+    "index.ts",
+    "firebase.ts",
+    "firestoreSeeder.ts",
+    "codexPrompts.ts"
+  ],
   "exclude": ["lib", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- create `codexPrompts.ts` helper to store prompts in Firestore and export them to Markdown
- include the new helper in the functions tsconfig
- document how to use the script in README
- provide a starter `PromptLibrary.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858e15d4eb0833097a5d271baf108cc