### PR TITLE
Implement multi-day challenge support

### DIFF
--- a/App/services/functionService.ts
+++ b/App/services/functionService.ts
@@ -50,3 +50,11 @@ export async function incrementReligionPoints(
     throw err;
   }
 }
+
+export async function createMultiDayChallenge(prompt: string, days: number) {
+  return await callFunction('createMultiDayChallenge', { prompt, days });
+}
+
+export async function completeChallengeDay() {
+  return await callFunction('completeChallengeDay', {});
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -44,6 +44,14 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // \u{1F4C5} Active multi-day challenge
+    match /users/{userId}/activeChallenge {
+      allow read: if request.auth != null && request.auth.uid == userId;
+    }
+    match /users/{userId}/activeChallenge/challengeLogs/{logId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+    }
+
     // \u{1FA99} Legacy token docs
     match /tokens/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;


### PR DESCRIPTION
## Summary
- add Firestore rules for active challenges
- introduce `createMultiDayChallenge` and `completeChallengeDay` cloud functions
- expose new helpers in `functionService`
- update Challenge screen UI to start and track multi-day challenges

## Testing
- `npm run build` in `functions`
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react-native')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858e24abfec8330ad46d8f47070ecd3