### PR TITLE
Implement ephemeral confessional chat

### DIFF
--- a/App/services/confessionalSessionService.ts
+++ b/App/services/confessionalSessionService.ts
@@ -1,0 +1,43 @@
+import { addDocument, querySubcollection, deleteDocument } from './firestoreService';
+import { ensureAuth } from '@/utils/authGuard';
+
+export interface TempMessage {
+  id?: string;
+  role: 'user' | 'assistant';
+  text: string;
+  timestamp?: string;
+}
+
+export async function saveTempMessage(
+  uid: string,
+  role: 'user' | 'assistant',
+  text: string,
+): Promise<void> {
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+  await addDocument(`confessionalSessions/${storedUid}/messages`, {
+    role,
+    text,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export async function fetchTempSession(uid: string): Promise<TempMessage[]> {
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return [];
+  return await querySubcollection(
+    `confessionalSessions/${storedUid}`,
+    'messages',
+    'timestamp',
+    'ASCENDING',
+  );
+}
+
+export async function clearConfessionalSession(uid: string): Promise<void> {
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+  const docs = await querySubcollection(`confessionalSessions/${storedUid}`, 'messages');
+  for (const msg of docs) {
+    await deleteDocument(`confessionalSessions/${storedUid}/messages/${msg.id}`);
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,6 +25,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // \u{1F90D} Ephemeral confessional sessions
+    match /confessionalSessions/{userId}/messages/{msgId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // \u{1F3C6} Challenge + profile data
     match /users/{userId} {
       // Public read access for leaderboards


### PR DESCRIPTION
## Summary
- add ephemeral confessional session service
- store temporary confessional messages in Firestore and clear them on exit
- load and clear session messages in Confessional screen
- update Firestore rules for confessionalSessions path

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858e57a0ce48330a375df87f5316918