### PR TITLE
Implement OneVine+ persistent chat

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,6 +30,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // \u{1F54C} Temporary ReligionAI chat for free users
+    match /tempReligionChat/{userId}/messages/{msgId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // \u{1F3C6} Challenge + profile data
     match /users/{userId} {
       // Public read access for leaderboards


### PR DESCRIPTION
## Summary
- support per-user subscription check in `chatHistoryService`
- store messages in a temporary collection for free users
- automatically clear temp chat when a free user leaves the screen
- show upgrade CTA when not subscribed
- allow clearing either persistent or temporary chat
- add Firestore rules for `tempReligionChat`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_6858e7da394c8330b2bd199fbdc0dc6f