### PR TITLE
Add app.json for Metro compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Stripe subscription flow is being integrated with Firebase webhook handling
 
 Onboarding uses anonymous login, upgraded to email if subscribed
 
+Note: Even when using `app.config.js` in the bare workflow, keep a minimal
+`app.json` alongside it so Metro and other legacy tools can resolve the app
+name during builds.
+
 ### Firebase REST Endpoints
 
 The app communicates with Firebase using the following REST endpoints:

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "onevine-app",
+  "displayName": "OneVine"
+}


### PR DESCRIPTION
## Summary
- add bare workflow `app.json` for Metro bundler
- document the need for `app.json` alongside `app.config.js`

## Testing
- `npx expo export:embed . --platform android` *(fails: Unknown argument)*
- `npx eas-cli --version` *(fails to install)*

------
https://chatgpt.com/codex/tasks/task_e_6864c08e77008330a3f1718a35c39718