### PR TITLE
Fix Kotlin/Gradle mismatch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath('com.android.tools.build:gradle')
+        classpath('com.android.tools.build:gradle:7.4.1')
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
         classpath('com.facebook.react:react-native-gradle-plugin')
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/app.config.js
+++ b/app.config.js
@@ -33,8 +33,8 @@ export default ({ config }) => ({
       "expo-build-properties",
       {
         android: {
-          kotlinVersion: "1.9.24",
-          gradlePluginVersion: "8.5.0",
+          kotlinVersion: "1.8.10",
+          gradlePluginVersion: "7.4.1",
         },
       },
     ],


### PR DESCRIPTION
## Summary
- set expo-build-properties to Kotlin `1.8.10` and Android Gradle Plugin `7.4.1`
- enforce the same versions in `android/build.gradle`
- use Gradle `7.5.1` wrapper

## Testing
- `npm install --ignore-scripts`
- `npx tsc --noEmit` *(fails: cannot find modules, implicit any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864cd71259c8330a6979e6a0438aa91