### PR TITLE
Update Gradle wrapper and plugins

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.8.10'
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.24'
 
         ndkVersion = "25.1.8937393"
     }
@@ -15,9 +15,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.3'
-        classpath('com.android.tools.build:gradle:7.4.1')
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
+        classpath 'com.google.gms:google-services:4.4.3'
+        classpath('com.android.tools.build:gradle:8.3.0')
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
         classpath('com.facebook.react:react-native-gradle-plugin')
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/app.config.js
+++ b/app.config.js
@@ -33,8 +33,8 @@ export default ({ config }) => ({
       "expo-build-properties",
       {
         android: {
-          kotlinVersion: "1.8.10",
-          gradlePluginVersion: "7.4.1",
+          kotlinVersion: "1.9.24",
+          gradlePluginVersion: "8.3.0",
         },
       },
     ],


### PR DESCRIPTION
## Summary
- upgrade Gradle wrapper to 8.3
- use AGP 8.3.0, Kotlin 1.9.24 and google-services 4.4.3
- update expo-build-properties versions in config

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: could not evaluate settings due to missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_6864d0bac3548330a146fb3ad0c0f0ae