### PR TITLE
Fix auth cycles, add token helpers & clean dev client

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -53,11 +53,12 @@ import ConfessionalScreen from "./App/screens/ConfessionalScreen";
 import BuyTokensScreen from "./App/screens/BuyTokensScreen";
 import GiveBackScreen from "./App/screens/GiveBackScreen";
 
-Sentry.init({
-  dsn: 'https://your-key@o123456.ingest.sentry.io/your-project-id',
-  tracesSampleRate: 1.0, // Optional, helps capture performance issues
-  debug: __DEV__,        // Only logs debug info in development
-});
+const dsn = process.env.SENTRY_DSN || process.env.EXPO_PUBLIC_SENTRY_DSN;
+if (!dsn || dsn.includes('your-key')) {
+  console.warn('Sentry DSN not configured. Skipping Sentry initialization.');
+} else {
+  Sentry.init({ dsn });
+}
 
 
 const Stack = createNativeStackNavigator<RootStackParamList>();

--- a/App/config/firebaseApp.ts
+++ b/App/config/firebaseApp.ts
@@ -1,23 +1,4 @@
 // Firebase API helper utilities
 export const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
 
-import { useAuthStore } from '@/state/authStore';
-import { getIdToken } from '@/services/authService';
-
-export async function getAuthHeader() {
-  const { authReady, uid } = useAuthStore.getState();
-
-  if (!authReady) throw new Error('Auth not ready');
-
-  const token = await getIdToken(true);
-  console.warn('🪪 ID Token for API access:', token?.slice(0, 20));
-  console.warn('👤 Current auth UID:', uid);
-  if (!token) throw new Error('Unable to refresh ID token');
-
-  return { Authorization: `Bearer ${token}` };
-}
-
-export async function getAuthHeaders() {
-  const { Authorization } = await getAuthHeader();
-  return { Authorization, 'Content-Type': 'application/json' };
-}
+export { getAuthHeader, getAuthHeaders } from '@/utils/TokenManager';

--- a/App/hooks/useNotifications.ts
+++ b/App/hooks/useNotifications.ts
@@ -1,11 +1,12 @@
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 
-const isExpoGo = Constants.appOwnership === 'expo';
+const isDevClient = !Constants.appOwnership || Constants.appOwnership === 'expo-dev-client';
 
 export async function scheduleDailyNotification(title: string, body: string) {
-  if (isExpoGo) {
-    console.warn('⚠️ Running in Expo Go. Notification behavior may be limited.');
+  if (!isDevClient) {
+    console.warn('⚠️ Push notifications disabled in Expo Go.');
+    return;
   }
   try {
     await Notifications.scheduleNotificationAsync({

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -16,7 +16,7 @@ import { ASK_GEMINI_SIMPLE } from "@/utils/constants";
 import { getDocument } from '@/services/firestoreService';
 import { useUser } from '@/hooks/useUser';
 import { ensureAuth } from '@/utils/authGuard';
-import { getToken, getCurrentUserId } from '@/services/authService';
+import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { showGracefulError } from '@/utils/gracefulError';
 import { sendGeminiPrompt, type GeminiMessage } from '@/services/geminiService';
 import { useAuth } from '@/hooks/useAuth';

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -19,7 +19,7 @@ import { querySubcollection, addDocument, getDocument, setDocument } from '@/ser
 import { callFunction, incrementReligionPoints } from '@/services/functionService';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { ensureAuth } from '@/utils/authGuard';
-import { getToken, getCurrentUserId } from '@/services/authService';
+import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { sendGeminiPrompt } from '@/services/geminiService';
 import { useAuth } from '@/hooks/useAuth';
 import { useNavigation } from '@react-navigation/native';

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -21,7 +21,7 @@ import { ASK_GEMINI_V2 } from "@/utils/constants";
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { useUser } from '@/hooks/useUser';
 import { ensureAuth } from '@/utils/authGuard';
-import { getToken, getCurrentUserId } from '@/services/authService';
+import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/services/functionService';
 import { useUser } from '@/hooks/useUser';
 import { ensureAuth } from '@/utils/authGuard';
-import { getToken, getCurrentUserId } from '@/services/authService';
+import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/state/authStore';
 import { useChallengeStore } from '@/state/challengeStore';

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -12,7 +12,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { uploadImage } from '@/services/storageService';
 import { addDocument } from '@/services/firestoreService';
 import { useUser } from "@/hooks/useUser";
-import { getAuthHeaders } from '@/config/firebaseApp';
+import { getAuthHeaders } from '@/utils/TokenManager';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { ensureAuth } from '@/utils/authGuard';

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -9,7 +9,7 @@ import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
 import { createStripeCheckout } from '@/services/apiService';
 import { PRICE_IDS } from '@/config/stripeConfig';
-import { getAuthHeaders } from '@/config/firebaseApp';
+import { getAuthHeaders } from '@/utils/TokenManager';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
 

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -12,7 +12,7 @@ import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { queryCollection, setDocument, getDocument } from '@/services/firestoreService';
-import { getAuthHeaders } from '@/config/firebaseApp';
+import { getAuthHeaders } from '@/utils/TokenManager';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -9,7 +9,7 @@ import {
 import Button from '@/components/common/Button';
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { useUser } from '@/hooks/useUser';
-import { getAuthHeaders } from '@/config/firebaseApp';
+import { getAuthHeaders } from '@/utils/TokenManager';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { STRIPE_CHECKOUT_URL } from '@/config/apiConfig';
 import { STRIPE_SUCCESS_URL, STRIPE_CANCEL_URL } from '@/config/stripeConfig';
-import { getAuthHeaders } from '@/config/firebaseApp';
+import { getAuthHeaders } from '@/utils/TokenManager';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 import { logTokenIssue } from '@/services/authService';
 import { showPermissionDenied } from '@/utils/gracefulError';

--- a/App/services/firestoreService.ts
+++ b/App/services/firestoreService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getIdToken } from '@/services/authService';
+import { getIdToken } from '@/utils/TokenManager';
 import { showPermissionDenied } from '@/utils/gracefulError';
 
 const PROJECT_ID = process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || '';

--- a/App/services/geminiService.ts
+++ b/App/services/geminiService.ts
@@ -1,7 +1,7 @@
 import { GEMINI_API_URL } from '@/config/apiConfig';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 import { useAuthStore } from '@/state/authStore';
-import { getIdToken } from '@/services/authService';
+import { getIdToken } from '@/utils/TokenManager';
 
 export type GeminiMessage = { role: 'user' | 'assistant'; text: string };
 

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,5 +1,6 @@
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { ensureAuth } from '@/utils/authGuard';
+import { getIdToken as fbGetIdToken, getCurrentUserId as fbGetCurrentUserId } from '@/lib/auth';
 
 export const getTokenCount = async () => {
   const uid = await ensureAuth();
@@ -62,6 +63,29 @@ export const syncSubscriptionStatus = async () => {
     await setDocument(`users/${uid}`, { tokens: 9999 });
   }
 };
+
+export async function getIdToken(forceRefresh = false) {
+  return fbGetIdToken(forceRefresh);
+}
+
+export async function getCurrentUserId(): Promise<string | null> {
+  return fbGetCurrentUserId();
+}
+
+export async function getAuthHeader() {
+  const token = await getIdToken(true);
+  if (!token) throw new Error('Unable to refresh ID token');
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function getAuthHeaders() {
+  const { Authorization } = await getAuthHeader();
+  return { Authorization, 'Content-Type': 'application/json' };
+}
+
+export async function getToken(forceRefresh = false) {
+  return getIdToken(forceRefresh);
+}
 
 export function init() {
   console.log('✅ TokenManager initialized');

--- a/App/utils/firebaseRequest.ts
+++ b/App/utils/firebaseRequest.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import { logTokenIssue, getIdToken } from '@/services/authService';
+import { logTokenIssue } from '@/services/authService';
+import { getIdToken } from '@/utils/TokenManager';
 import { useAuthStore } from '@/state/authStore';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 

--- a/App/utils/gusBugLogger.ts
+++ b/App/utils/gusBugLogger.ts
@@ -1,4 +1,5 @@
-import { signOutAndRetry, getIdToken, logTokenIssue } from '@/services/authService';
+import { signOutAndRetry, logTokenIssue } from '@/services/authService';
+import { getIdToken } from '@/utils/TokenManager';
 import { showPermissionDenied } from '@/utils/gracefulError';
 import { useAuthStore } from '@/state/authStore';
 

--- a/App/utils/reminderNotification.ts
+++ b/App/utils/reminderNotification.ts
@@ -2,13 +2,14 @@ import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 
-const isExpoGo = Constants.appOwnership === 'expo';
+const isDevClient = !Constants.appOwnership || Constants.appOwnership === 'expo-dev-client';
 
 const STORAGE_KEY = 'reflectionReminderId';
 
 export async function scheduleReflectionReminder(time: string) {
-  if (isExpoGo) {
-    console.warn('⚠️ Running in Expo Go. Notification behavior may be limited.');
+  if (!isDevClient) {
+    console.warn('⚠️ Push notifications disabled in Expo Go.');
+    return;
   }
   try {
     const [hour, minute] = time.split(':').map((t) => parseInt(t, 10));
@@ -23,8 +24,9 @@ export async function scheduleReflectionReminder(time: string) {
 }
 
 export async function cancelReflectionReminder() {
-  if (isExpoGo) {
-    console.warn('⚠️ Running in Expo Go. Notification behavior may be limited.');
+  if (!isDevClient) {
+    console.warn('⚠️ Push notifications disabled in Expo Go.');
+    return;
   }
   try {
     const id = await AsyncStorage.getItem(STORAGE_KEY);

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,6 +1,7 @@
 import * as functions from "firebase-functions";
 import { auth, db } from "./firebase";
 import * as admin from "firebase-admin";
+import { Request, Response } from "express";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import Stripe from "stripe";
 import * as dotenv from "dotenv";
@@ -140,7 +141,7 @@ async function updateStreakAndXPInternal(uid: string, type: string) {
 export const incrementReligionPoints = functions
   .region("us-central1")
   .https.onRequest(
-    withCors(async (req, res) => {
+    withCors(async (req: Request, res: Response) => {
       try {
         const { uid } = await verifyIdToken(req);
         const { religion, points } = req.body;
@@ -173,7 +174,7 @@ export const incrementReligionPoints = functions
 
 export const completeChallenge = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -196,7 +197,7 @@ export const completeChallenge = functions
 
 export const createMultiDayChallenge = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -269,7 +270,7 @@ export const createMultiDayChallenge = functions
 
 export const completeChallengeDay = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -358,7 +359,7 @@ export const completeChallengeDay = functions
 
 export const askGeminiSimple = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -405,7 +406,7 @@ export const askGeminiSimple = functions
 
 export const askGeminiV2 = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   console.log("🔍 Headers received:", req.headers);
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   logger.debug(`Token prefix: ${idToken ? idToken.slice(0, 10) : "none"}`);
@@ -465,7 +466,7 @@ export const askGeminiV2 = functions
 
 export const generateChallenge = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -540,7 +541,7 @@ export const generateChallenge = functions
 
 export const generateDailyChallenge = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -642,7 +643,7 @@ export const generateDailyChallenge = functions
 
 export const skipDailyChallenge = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -764,7 +765,7 @@ export const skipDailyChallenge = functions
 // removing or wiring it up in a future release.
 export const startSubscriptionCheckout = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   logger.info("📦 startSubscriptionCheckout payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -815,7 +816,7 @@ export const startSubscriptionCheckout = functions
 // removing or wiring it up in a future release.
 export const startOneTimeTokenCheckout = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   logger.info("📦 startOneTimeTokenCheckout payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -864,7 +865,7 @@ export const startOneTimeTokenCheckout = functions
 
 export const startDonationCheckout = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   logger.info("💖 startDonationCheckout payload", req.body);
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
@@ -919,7 +920,7 @@ export const startDonationCheckout = functions
 
 export const startCheckoutSession = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   logger.info("📦 startCheckoutSession payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -968,7 +969,7 @@ export const startCheckoutSession = functions
 
 export const handleStripeWebhookV2 = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   console.log('💰 Gus Bug Webhook triggered. No auth needed!');
   const sig = req.headers['stripe-signature'] as string | undefined;
   if (!sig) {
@@ -1023,7 +1024,7 @@ export const handleStripeWebhookV2 = functions
 
 export const updateStreakAndXP = functions
   .region("us-central1")
-  .https.onRequest(async (req, res) => {
+  .https.onRequest(async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onevine-app",
   "version": "1.0.0",
-  "main": "App.tsx",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Summary
- break circular imports by moving auth token helpers to `TokenManager`
- guard notification setup so Expo Go doesn't initialize push
- load Sentry DSN from env and warn when missing
- add proper app entry point and update package.json
- type request handlers in Firebase Functions

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Promise lib & typings issues)*
- `npm run build` in `functions` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_686544699d888330ac8631a1d8a5d805