### PR TITLE
Fix require cycle and navigation

### DIFF
--- a/App/config/firebaseApp.ts
+++ b/App/config/firebaseApp.ts
@@ -1,4 +1,4 @@
 // Firebase API helper utilities
 export const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
 
-export { getAuthHeader, getAuthHeaders } from '@/utils/TokenManager';
+export { getAuthHeader, getAuthHeaders } from '@/utils/authUtils';

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -135,11 +135,7 @@ export default function JournalScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     async function authenticateAndLoad() {
       try {
         const hasHardware = await LocalAuthentication.hasHardwareAsync();

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -111,11 +111,7 @@ export default function ReligionAIScreen() {
   const { authReady, uid } = useAuth();
 
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     const loadHistory = async () => {
       const firebaseUid = await getCurrentUserId();
       if (!firebaseUid) {

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -330,11 +330,7 @@ export default function ChallengeScreen() {
   };
 
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     syncStreak();
     fetchChallenge();
   }, [authReady, uid]);

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -22,11 +22,7 @@ export default function HomeScreen({ navigation }: Props) {
   const theme = useTheme();
   const { authReady, uid } = useAuth();
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     const loadData = async () => {
       const t = await getTokenCount();
       await syncSubscriptionStatus(); // updates Firestore token state

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -88,7 +88,6 @@ export default function SubmitProofScreen() {
       await getAuthHeaders();
     } catch {
       Alert.alert('Login Required', 'Please log in again.');
-      navigation.replace('Login');
       return;
     }
 

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -56,7 +56,6 @@ export default function UpgradeScreen({ navigation }: Props) {
         await getAuthHeaders();
       } catch {
         Alert.alert('Login Required', 'Please log in again.');
-        navigation.replace('Login');
         return;
       }
 

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -60,11 +60,7 @@ export default function JoinOrganizationScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     fetchOrgs();
   }, [authReady, uid]);
 
@@ -74,7 +70,6 @@ export default function JoinOrganizationScreen() {
         await getAuthHeaders();
       } catch {
         Alert.alert('Login Required', 'Please log in again.');
-        navigation.replace('Login');
         return;
       }
 
@@ -104,7 +99,6 @@ export default function JoinOrganizationScreen() {
       await getAuthHeaders();
     } catch {
       Alert.alert('Login Required', 'Please log in again.');
-      navigation.replace('Login');
       return;
     }
     const uid = await ensureAuth(user.uid);

--- a/App/screens/profile/OrganizationManagmentScreen.tsx
+++ b/App/screens/profile/OrganizationManagmentScreen.tsx
@@ -84,11 +84,7 @@ export default function OrganizationManagementScreen() {
   }, []);
 
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     if (user) loadOrg();
   }, [authReady, uid, user]);
 
@@ -98,7 +94,6 @@ export default function OrganizationManagementScreen() {
       await getAuthHeaders();
     } catch {
       Alert.alert('Login Required', 'Please log in again.');
-      navigation.replace('Login');
       return;
     }
     const uid = await ensureAuth(user.uid);
@@ -125,7 +120,6 @@ export default function OrganizationManagementScreen() {
       await getAuthHeaders();
     } catch {
       Alert.alert('Login Required', 'Please log in again.');
-      navigation.replace('Login');
       return;
     }
     const authUid = await ensureAuth(user?.uid);

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -54,11 +54,7 @@ export default function ProfileScreen() {
   );
 
   useEffect(() => {
-    if (!authReady) return;
-    if (!uid) {
-      navigation.replace('Login');
-      return;
-    }
+    if (!authReady || !uid) return;
     loadData();
   }, [authReady, uid]);
 

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { STRIPE_CHECKOUT_URL } from '@/config/apiConfig';
 import { STRIPE_SUCCESS_URL, STRIPE_CANCEL_URL } from '@/config/stripeConfig';
-import { getAuthHeaders } from '@/utils/TokenManager';
+import { getAuthHeaders } from '@/utils/authUtils';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 import { logTokenIssue } from '@/services/authService';
 import { showPermissionDenied } from '@/utils/gracefulError';

--- a/App/services/firestoreService.ts
+++ b/App/services/firestoreService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getIdToken } from '@/utils/TokenManager';
+import { getIdToken } from '@/utils/authUtils';
 import { showPermissionDenied } from '@/utils/gracefulError';
 
 const PROJECT_ID = process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || '';

--- a/App/services/geminiService.ts
+++ b/App/services/geminiService.ts
@@ -1,7 +1,7 @@
 import { GEMINI_API_URL } from '@/config/apiConfig';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 import { useAuthStore } from '@/state/authStore';
-import { getIdToken } from '@/utils/TokenManager';
+import { getIdToken } from '@/utils/authUtils';
 
 export type GeminiMessage = { role: 'user' | 'assistant'; text: string };
 

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,6 +1,5 @@
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { ensureAuth } from '@/utils/authGuard';
-import { getIdToken as fbGetIdToken, getCurrentUserId as fbGetCurrentUserId } from '@/lib/auth';
 
 export const getTokenCount = async () => {
   const uid = await ensureAuth();
@@ -64,28 +63,7 @@ export const syncSubscriptionStatus = async () => {
   }
 };
 
-export async function getIdToken(forceRefresh = false) {
-  return fbGetIdToken(forceRefresh);
-}
-
-export async function getCurrentUserId(): Promise<string | null> {
-  return fbGetCurrentUserId();
-}
-
-export async function getAuthHeader() {
-  const token = await getIdToken(true);
-  if (!token) throw new Error('Unable to refresh ID token');
-  return { Authorization: `Bearer ${token}` };
-}
-
-export async function getAuthHeaders() {
-  const { Authorization } = await getAuthHeader();
-  return { Authorization, 'Content-Type': 'application/json' };
-}
-
-export async function getToken(forceRefresh = false) {
-  return getIdToken(forceRefresh);
-}
+export { getIdToken, getCurrentUserId, getAuthHeader, getAuthHeaders, getToken } from './authUtils';
 
 export function init() {
   console.log('✅ TokenManager initialized');

--- a/App/utils/authUtils.ts
+++ b/App/utils/authUtils.ts
@@ -1,0 +1,24 @@
+import { getIdToken as fbGetIdToken, getCurrentUserId as fbGetCurrentUserId } from '@/lib/auth';
+
+export async function getIdToken(forceRefresh = false) {
+  return fbGetIdToken(forceRefresh);
+}
+
+export async function getCurrentUserId(): Promise<string | null> {
+  return fbGetCurrentUserId();
+}
+
+export async function getAuthHeader() {
+  const token = await getIdToken(true);
+  if (!token) throw new Error('Unable to refresh ID token');
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function getAuthHeaders() {
+  const { Authorization } = await getAuthHeader();
+  return { Authorization, 'Content-Type': 'application/json' };
+}
+
+export async function getToken(forceRefresh = false) {
+  return getIdToken(forceRefresh);
+}

--- a/App/utils/firebaseRequest.ts
+++ b/App/utils/firebaseRequest.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { logTokenIssue } from '@/services/authService';
-import { getIdToken } from '@/utils/TokenManager';
+import { getIdToken } from '@/utils/authUtils';
 import { useAuthStore } from '@/state/authStore';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
 

--- a/App/utils/gusBugLogger.ts
+++ b/App/utils/gusBugLogger.ts
@@ -1,5 +1,5 @@
 import { signOutAndRetry, logTokenIssue } from '@/services/authService';
-import { getIdToken } from '@/utils/TokenManager';
+import { getIdToken } from '@/utils/authUtils';
 import { showPermissionDenied } from '@/utils/gracefulError';
 import { useAuthStore } from '@/state/authStore';
 


### PR DESCRIPTION
## Summary
- move token helpers to `authUtils`
- adjust `TokenManager` to re-export token helpers
- update services to use `authUtils`
- remove manual Login redirects in authenticated screens

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68654eac02e88330a4c56966c3dc1bce