### PR TITLE
Add RawBodyRequest type for Stripe webhooks

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -2,6 +2,7 @@ import * as functions from "firebase-functions";
 import { auth, db } from "./firebase";
 import * as admin from "firebase-admin";
 import { Request, Response } from "express";
+import { RawBodyRequest } from "./types";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import Stripe from "stripe";
 import * as dotenv from "dotenv";
@@ -969,7 +970,7 @@ export const startCheckoutSession = functions
 
 export const handleStripeWebhookV2 = functions
   .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+  .https.onRequest(async (req: RawBodyRequest, res: Response) => {
   console.log('💰 Gus Bug Webhook triggered. No auth needed!');
   const sig = req.headers['stripe-signature'] as string | undefined;
   if (!sig) {

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -1,0 +1,5 @@
+import { Request } from 'express';
+
+export interface RawBodyRequest extends Request {
+  rawBody: Buffer;
+}


### PR DESCRIPTION
## Summary
- introduce `RawBodyRequest` interface extending Express `Request`
- use `RawBodyRequest` in Stripe webhook handler

## Testing
- `npm run build` *(fails: Property 'region' does not exist on type 'typeof import(".../firebase-functions/lib/v2/index")')*

------
https://chatgpt.com/codex/tasks/task_e_686551aed0f08330bee19e1eb5d591f3