### PR TITLE
Fix Firebase v2 syntax

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,4 +1,5 @@
-import * as functions from "firebase-functions";
+import { onRequest } from "firebase-functions/v2/https";
+import * as functions from "firebase-functions/v1";
 import { auth, db } from "./firebase";
 import * as admin from "firebase-admin";
 import { Request, Response } from "express";
@@ -139,9 +140,11 @@ async function updateStreakAndXPInternal(uid: string, type: string) {
   });
 }
 
-export const incrementReligionPoints = functions
-  .region("us-central1")
-  .https.onRequest(
+export const incrementReligionPoints = onRequest(
+  {
+    region: "us-central1",
+  },
+  
     withCors(async (req: Request, res: Response) => {
       try {
         const { uid } = await verifyIdToken(req);
@@ -173,9 +176,11 @@ export const incrementReligionPoints = functions
     })
   );
 
-export const completeChallenge = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const completeChallenge = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -196,9 +201,11 @@ export const completeChallenge = functions
   }
 });
 
-export const createMultiDayChallenge = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const createMultiDayChallenge = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -269,9 +276,11 @@ export const createMultiDayChallenge = functions
   }
 });
 
-export const completeChallengeDay = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const completeChallengeDay = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -358,9 +367,11 @@ export const completeChallengeDay = functions
   }
 });
 
-export const askGeminiSimple = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const askGeminiSimple = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -405,9 +416,11 @@ export const askGeminiSimple = functions
   }
 });
 
-export const askGeminiV2 = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const askGeminiV2 = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   console.log("🔍 Headers received:", req.headers);
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   logger.debug(`Token prefix: ${idToken ? idToken.slice(0, 10) : "none"}`);
@@ -465,9 +478,11 @@ export const askGeminiV2 = functions
   }
 });
 
-export const generateChallenge = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const generateChallenge = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -540,9 +555,11 @@ export const generateChallenge = functions
   }
 });
 
-export const generateDailyChallenge = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const generateDailyChallenge = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -642,9 +659,11 @@ export const generateDailyChallenge = functions
   }
 });
 
-export const skipDailyChallenge = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const skipDailyChallenge = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -764,9 +783,11 @@ export const skipDailyChallenge = functions
 
 // TODO: startSubscriptionCheckout is unused in the current frontend. Consider
 // removing or wiring it up in a future release.
-export const startSubscriptionCheckout = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const startSubscriptionCheckout = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   logger.info("📦 startSubscriptionCheckout payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -815,9 +836,11 @@ export const startSubscriptionCheckout = functions
 
 // TODO: startOneTimeTokenCheckout is unused in the current frontend. Consider
 // removing or wiring it up in a future release.
-export const startOneTimeTokenCheckout = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const startOneTimeTokenCheckout = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   logger.info("📦 startOneTimeTokenCheckout payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -864,9 +887,11 @@ export const startOneTimeTokenCheckout = functions
   }
 });
 
-export const startDonationCheckout = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const startDonationCheckout = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   logger.info("💖 startDonationCheckout payload", req.body);
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
@@ -919,9 +944,11 @@ export const startDonationCheckout = functions
   }
 });
 
-export const startCheckoutSession = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const startCheckoutSession = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   logger.info("📦 startCheckoutSession payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -968,9 +995,11 @@ export const startCheckoutSession = functions
   }
 });
 
-export const handleStripeWebhookV2 = functions
-  .region("us-central1")
-  .https.onRequest(async (req: RawBodyRequest, res: Response) => {
+export const handleStripeWebhookV2 = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: RawBodyRequest, res: Response) => {
   console.log('💰 Gus Bug Webhook triggered. No auth needed!');
   const sig = req.headers['stripe-signature'] as string | undefined;
   if (!sig) {
@@ -1023,9 +1052,11 @@ export const handleStripeWebhookV2 = functions
   res.status(200).send({ received: true });
 });
 
-export const updateStreakAndXP = functions
-  .region("us-central1")
-  .https.onRequest(async (req: Request, res: Response) => {
+export const updateStreakAndXP = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (req: Request, res: Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -1053,9 +1084,11 @@ async function ensureDocument(
   }
 }
 
-export const seedFirestore = functions
-  .region("us-central1")
-  .https.onRequest(async (_req, res) => {
+export const seedFirestore = onRequest(
+  {
+    region: "us-central1",
+  },
+  async (_req, res) => {
   try {
     await Promise.all([
       ensureDocument('users/seed-user', { initialized: true }),


### PR DESCRIPTION
## Summary
- update functions to use `onRequest` from v2
- keep auth signup handler on v1 API

## Testing
- `npm run build` *(fails: RequestHandler types missing)*

------
https://chatgpt.com/codex/tasks/task_e_686554ff8d70833096315c0ff516435f