### PR TITLE
Remove region function call to fix deployment error

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1134,7 +1134,6 @@ export const seedFirestore = onRequest(
 });
 
 export const createSubscriptionOnSignup = functions
-  .region("us-central1")
   .auth
   .user()
   .onCreate(async (user: admin.auth.UserRecord) => {


### PR DESCRIPTION
## Summary
- avoid using `functions.region` in auth onCreate trigger

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68655ac4c8d88330b19762815fab63fa