### PR TITLE
Fix Firestore patch errors

### DIFF
--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -105,7 +105,7 @@ export default function ChallengeScreen() {
 
       const uid = await ensureAuth(await getCurrentUserId());
 
-      const active = await getDocument(`users/${uid}/activeChallenge`);
+      const active = await getDocument(`users/${uid}/activeChallenge/current`);
       if (active && !active.isComplete) {
         setActiveMulti(active);
         setLoading(false);

--- a/App/services/firestoreService.ts
+++ b/App/services/firestoreService.ts
@@ -64,7 +64,7 @@ export async function setDocument(path: string, data: any): Promise<void> {
   warnIfInvalidPath(path, true);
   try {
     const body = { fields: toFirestoreFields(data) };
-    await axios.patch(`${BASE}/${path}?allowMissing=true`, body, { headers: await authHeaders() });
+    await axios.patch(`${BASE}/${path}`, body, { headers: await authHeaders() });
   } catch (err: any) {
     console.warn(`❌ Firestore REST error on ${path}:`, err.response?.data || err.message);
     if (err.response?.status === 403) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -58,7 +58,7 @@ service cloud.firestore {
     }
 
     // 🔁 Active Challenge (per user)
-    match /users/{userId}/activeChallenge {
+    match /users/{userId}/activeChallenge/{docId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -215,7 +215,7 @@ export const createMultiDayChallenge = functions
     const decoded = await auth.verifyIdToken(idToken);
     const uid = decoded.uid;
     const userRef = db.collection("users").doc(uid);
-    const challengeRef = db.doc(`users/${uid}/activeChallenge`);
+    const challengeRef = db.doc(`users/${uid}/activeChallenge/current`);
 
     const basePrompt =
       prompt.trim() ||
@@ -281,7 +281,7 @@ export const completeChallengeDay = functions
   try {
     const decoded = await auth.verifyIdToken(idToken);
     const uid = decoded.uid;
-    const challengeRef = db.doc(`users/${uid}/activeChallenge`);
+    const challengeRef = db.doc(`users/${uid}/activeChallenge/current`);
     const userRef = db.collection("users").doc(uid);
 
     let bonus = 0;


### PR DESCRIPTION
## Summary
- remove invalid `allowMissing` parameter in Firestore PATCH helper
- store active challenge data under a document named `current`
- update Firestore rules and Cloud Functions for new path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865648dd1108330b0215205037583a4