### PR TITLE
Fix auth guard to lookup UID

### DIFF
--- a/App/utils/authGuard.ts
+++ b/App/utils/authGuard.ts
@@ -2,10 +2,13 @@
  * Ensure a UID value is present.
  * Returns the UID when valid, otherwise throws an error.
  */
+import { getCurrentUserId } from './authUtils';
+
 export async function ensureAuth(uid?: string | null): Promise<string> {
-  if (!uid) {
-    throw new Error("Unauthorized – No user ID.");
+  const resolvedUid = uid ?? (await getCurrentUserId());
+  if (!resolvedUid) {
+    throw new Error('Unauthorized – No user ID.');
   }
 
-  return uid;
+  return resolvedUid;
 }


### PR DESCRIPTION
## Summary
- patch `ensureAuth` to pull the current UID if no UID is passed

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_686566ffcd0483308f09a1d2b3b71e39