### PR TITLE
Fix auth UID state and navigation reset

### DIFF
--- a/App/components/common/Header.tsx
+++ b/App/components/common/Header.tsx
@@ -6,6 +6,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from '@/components/theme/theme';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
 import { logout } from '@/services/authService';
+import { resetToLogin } from '@/navigation/navigationRef';
 
 export default function Header() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -42,7 +43,7 @@ export default function Header() {
         onPress: async () => {
           try {
             await logout();
-            navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+            resetToLogin();
           } catch (err) {
             console.error('\u274C Sign out failed:', err);
             Alert.alert('Logout Error', 'Could not sign out. Please try again.');

--- a/App/screens/profile/SettingsScreen.tsx
+++ b/App/screens/profile/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import Constants from 'expo-constants';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from "@/components/common/Button";
 import { logout, changePassword } from "@/services/authService";
+import { resetToLogin } from "@/navigation/navigationRef";
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -72,7 +73,7 @@ export default function SettingsScreen() {
     try {
       await logout();
       clearUser();
-      navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+      resetToLogin();
     } catch (err) {
       console.error('\u274C Sign out failed:', err);
       Alert.alert('Logout Error', 'Could not sign out. Please try again.');

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -31,11 +31,13 @@ export function initAuthState(): void {
 
 export async function signup(email: string, password: string) {
   const user = await fbSignup(email, password);
+  useAuthStore.getState().setUid(user.uid);
   return { localId: user.uid, email: user.email ?? '' };
 }
 
 export async function login(email: string, password: string) {
   const user = await fbLogin(email, password);
+  useAuthStore.getState().setUid(user.uid);
   return { localId: user.uid, email: user.email ?? '' };
 }
 


### PR DESCRIPTION
## Summary
- ensure UID is recorded in auth store during login/signup
- use `resetToLogin` helper when signing out

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68658602b74883308d5fe7159e83ef55