### PR TITLE
Skip onboarding for returning users

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { View, ActivityIndicator, Text } from "react-native";
-import * as Sentry from '@sentry/react-native';
+import * as Sentry from "@sentry/react-native";
 import ErrorBoundary from "./App/components/common/ErrorBoundary";
 import { useFonts, Poppins_600SemiBold } from "@expo-google-fonts/poppins";
 import { Merriweather_400Regular } from "@expo-google-fonts/merriweather";
-import * as SecureStore from 'expo-secure-store';
+import * as SecureStore from "expo-secure-store";
 import { NavigationContainer } from "@react-navigation/native";
 import { navigationRef } from "./App/navigation/navigationRef";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
@@ -54,12 +54,11 @@ import BuyTokensScreen from "./App/screens/BuyTokensScreen";
 import GiveBackScreen from "./App/screens/GiveBackScreen";
 
 const dsn = process.env.SENTRY_DSN || process.env.EXPO_PUBLIC_SENTRY_DSN;
-if (!dsn || dsn.includes('your-key')) {
-  console.warn('Sentry DSN not configured. Skipping Sentry initialization.');
+if (!dsn || dsn.includes("your-key")) {
+  console.warn("Sentry DSN not configured. Skipping Sentry initialization.");
 } else {
   Sentry.init({ dsn });
 }
-
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -83,7 +82,6 @@ export default function App() {
       );
     }
   }, []);
-
 
   useEffect(() => {
     if (fontsLoaded) {
@@ -114,13 +112,20 @@ export default function App() {
     if (user) {
       console.log("🙋 User state updated:", user.uid);
       (async () => {
-        const seen = await SecureStore.getItemAsync(
+        let seen = await SecureStore.getItemAsync(
           `hasSeenOnboarding-${user.uid}`,
         );
-        setInitialRoute(seen === 'true' ? 'Home' : 'Onboarding');
+        if (seen === null && user.onboardingComplete) {
+          seen = "true";
+          await SecureStore.setItemAsync(
+            `hasSeenOnboarding-${user.uid}`,
+            "true",
+          );
+        }
+        setInitialRoute(seen === "true" ? "Home" : "Onboarding");
       })();
     } else if (authReady) {
-      setInitialRoute('Login');
+      setInitialRoute("Login");
     }
   }, [user, authReady]);
 

--- a/App/hooks/useUser.ts
+++ b/App/hooks/useUser.ts
@@ -1,4 +1,4 @@
-import { useUserStore } from '@/state/userStore';
+import { useUserStore } from "@/state/userStore";
 
 export interface User {
   uid: string;
@@ -8,6 +8,7 @@ export interface User {
   region: string;
   organizationId?: string;
   isSubscribed: boolean;
+  onboardingComplete: boolean;
   tokens: number;
 }
 
@@ -15,4 +16,3 @@ export function useUser(): { user: User | null; loading: boolean } {
   const user = useUserStore((state) => state.user as User | null);
   return { user, loading: false };
 }
-

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -1,42 +1,49 @@
-import React, { useState } from 'react';
-import CustomText from '@/components/CustomText';
-import { View, StyleSheet, Alert, TextInput } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
+import React, { useState } from "react";
+import CustomText from "@/components/CustomText";
+import { View, StyleSheet, Alert, TextInput } from "react-native";
+import * as SecureStore from "expo-secure-store";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from "@/components/common/Button";
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { completeOnboarding, updateUserFields, ensureUserDocExists, loadUser } from "@/services/userService";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import {
+  completeOnboarding,
+  updateUserFields,
+  ensureUserDocExists,
+  loadUser,
+} from "@/services/userService";
 import { useUserStore } from "@/state/userStore";
 import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
-import { Picker } from '@react-native-picker/picker';
+import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
 
-type OnboardingScreenProps = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
+type OnboardingScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  "Onboarding"
+>;
 
-const religions = ['Christian', 'Muslim', 'Jewish', 'Hindu', 'Buddhist'];
+const religions = ["Christian", "Muslim", "Jewish", "Hindu", "Buddhist"];
 
 export default function OnboardingScreen() {
   const user = useUserStore((state: any) => state.user);
-  const navigation = useNavigation<OnboardingScreenProps['navigation']>();
+  const navigation = useNavigation<OnboardingScreenProps["navigation"]>();
   const theme = useTheme();
-  const [religion, setReligion] = useState(user?.religion ?? 'Christian');
-  const [username, setUsername] = useState(user?.displayName ?? '');
-  const [region, setRegion] = useState('');
-  const [organization, setOrganization] = useState('');
+  const [religion, setReligion] = useState(user?.religion ?? "Christian");
+  const [username, setUsername] = useState(user?.displayName ?? "");
+  const [region, setRegion] = useState("");
+  const [organization, setOrganization] = useState("");
   const [loading, setLoading] = useState(false);
-
 
   const handleContinue = async () => {
     if (!user) {
-      Alert.alert('Session expired — please log in again.');
-      navigation.navigate('Login');
+      Alert.alert("Session expired — please log in again.");
+      navigation.navigate("Login");
       return;
     }
 
     if (!username.trim() || !region.trim()) {
-      Alert.alert('Missing Info', 'Username and region are required.');
+      Alert.alert("Missing Info", "Username and region are required.");
       return;
     }
 
@@ -50,18 +57,21 @@ export default function OnboardingScreen() {
           organizationId: organization || undefined,
         });
         await completeOnboarding(user.uid);
-        await SecureStore.setItemAsync(`hasSeenOnboarding-${user.uid}`, 'true');
+        await SecureStore.setItemAsync(`hasSeenOnboarding-${user.uid}`, "true");
+        useUserStore.getState().updateUser({ onboardingComplete: true });
 
         navigation.reset({
           index: 0,
           routes: [{ name: SCREENS.MAIN.HOME as keyof RootStackParamList }],
-
         });
       } else {
-        Alert.alert('Error', 'User ID is missing.');
+        Alert.alert("Error", "User ID is missing.");
       }
     } catch (err: any) {
-      Alert.alert('Error completing onboarding', err.message || 'An unknown error occurred.');
+      Alert.alert(
+        "Error completing onboarding",
+        err.message || "An unknown error occurred.",
+      );
     } finally {
       setLoading(false);
     }
@@ -72,23 +82,23 @@ export default function OnboardingScreen() {
       StyleSheet.create({
         title: {
           fontSize: 24,
-          fontWeight: '700',
+          fontWeight: "700",
           color: theme.colors.text,
           marginBottom: 10,
-          textAlign: 'center',
+          textAlign: "center",
         },
         subtitle: {
           fontSize: 16,
           color: theme.colors.fadedText,
           marginBottom: 20,
-          textAlign: 'center',
+          textAlign: "center",
         },
         pickerWrapper: {
           borderWidth: 1,
           borderColor: theme.colors.border,
           borderRadius: 8,
           marginBottom: 20,
-          overflow: 'hidden',
+          overflow: "hidden",
         },
         picker: {
           height: 50,
@@ -107,7 +117,7 @@ export default function OnboardingScreen() {
         link: {
           color: theme.colors.primary,
           marginTop: 16,
-          textAlign: 'center',
+          textAlign: "center",
         },
       }),
     [theme],
@@ -132,7 +142,9 @@ export default function OnboardingScreen() {
         onChangeText={setRegion}
       />
 
-      <CustomText style={styles.subtitle}>Choose your spiritual lens:</CustomText>
+      <CustomText style={styles.subtitle}>
+        Choose your spiritual lens:
+      </CustomText>
 
       <View style={styles.pickerWrapper}>
         <Picker
@@ -154,7 +166,10 @@ export default function OnboardingScreen() {
       />
 
       <Button title="Continue" onPress={handleContinue} loading={loading} />
-      <CustomText style={styles.link} onPress={() => navigation.navigate('Login')}>
+      <CustomText
+        style={styles.link}
+        onPress={() => navigation.navigate("Login")}
+      >
         Already have an account? Log in
       </CustomText>
     </ScreenContainer>
@@ -162,4 +177,3 @@ export default function OnboardingScreen() {
 }
 
 // styles moved inside component to react to theme
-

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -57,6 +57,7 @@ export async function loadUser(uid: string): Promise<void> {
       religion: user.religion,
       region: user.region ?? "",
       organizationId: user.organizationId,
+      onboardingComplete: user.onboardingComplete,
       tokens: 0, // placeholder
     });
   } else {

--- a/App/state/userStore.ts
+++ b/App/state/userStore.ts
@@ -1,22 +1,23 @@
-import { create } from 'zustand'
+import { create } from "zustand";
 
 interface UserData {
-  uid: string
-  email: string
-  displayName: string
-  religion: string
-  region: string
-  organizationId?: string
-  isSubscribed: boolean
-  tokens: number
+  uid: string;
+  email: string;
+  displayName: string;
+  religion: string;
+  region: string;
+  organizationId?: string;
+  isSubscribed: boolean;
+  onboardingComplete: boolean;
+  tokens: number;
 }
 
 interface UserStore {
-  user: UserData | null
-  setUser: (user: UserData) => void
-  updateUser: (updates: Partial<UserData>) => void
-  clearUser: () => void
-  updateTokens: (tokens: number) => void
+  user: UserData | null;
+  setUser: (user: UserData) => void;
+  updateUser: (updates: Partial<UserData>) => void;
+  clearUser: () => void;
+  updateTokens: (tokens: number) => void;
 }
 
 export const useUserStore = create<UserStore>((set) => ({
@@ -26,15 +27,15 @@ export const useUserStore = create<UserStore>((set) => ({
 
   updateUser: (updates) =>
     set((state) => {
-      if (!state.user) return state
-      return { user: { ...state.user, ...updates } }
+      if (!state.user) return state;
+      return { user: { ...state.user, ...updates } };
     }),
 
   clearUser: () => set({ user: null }),
 
   updateTokens: (tokens) =>
     set((state) => {
-      if (!state.user) return state
-      return { user: { ...state.user, tokens } }
+      if (!state.user) return state;
+      return { user: { ...state.user, tokens } };
     }),
-}))
+}));

--- a/App/types/user.ts
+++ b/App/types/user.ts
@@ -20,5 +20,6 @@ export interface AppUser {
   displayName: string;
   religion: string;
   isSubscribed: boolean;
+  onboardingComplete: boolean;
   tokens: number;
 }


### PR DESCRIPTION
## Summary
- store onboardingComplete in user state
- update onboarding screen to mark state completed
- check onboardingComplete when determining app initial route

## Testing
- `npx tsc -noEmit` *(fails: Cannot find module 'express', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68658a99a5448330bc6df0fc8b613c67