### PR TITLE
Add TypeScript paths mapping

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,14 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
-  }
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./App/*"]
+    }
+  },
+  "include": [
+    "App/**/*",
+    "App.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- configure TypeScript to recognize `@/*` alias used throughout the Expo app
- limit the project scope to the Expo sources

## Testing
- `npm install --ignore-scripts`
- `npx tsc --noEmit` *(fails: various strict type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68658e3714e483309ecc8c165650a3ea