### PR TITLE
Fix login navigation and uid flow

### DIFF
--- a/App/hooks/useAuth.ts
+++ b/App/hooks/useAuth.ts
@@ -2,7 +2,8 @@ import { useAuthStore } from '@/state/authStore';
 
 export function useAuth() {
   const uid = useAuthStore((s) => s.uid);
+  const idToken = useAuthStore((s) => s.idToken);
   const authReady = useAuthStore((s) => s.authReady);
 
-  return { uid, authReady };
+  return { uid, idToken, authReady };
 }

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -8,6 +8,7 @@ import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
 import { loadUser, ensureUserDocExists } from "@/services/userService";
 import { useUserStore } from "@/state/userStore";
+import { useAuthStore } from "@/state/authStore";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTheme } from "@/components/theme/theme";
@@ -21,6 +22,7 @@ export default function LoginScreen() {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const navigation = useNavigation<NavigationProp>();
+  const setUid = useAuthStore.getState().setUid;
   const theme = useTheme();
 
   const handleLogin = async () => {
@@ -28,6 +30,7 @@ export default function LoginScreen() {
     try {
       const result = await login(email, password);
       if (result.localId) {
+        setUid(result.localId);
         const isNew = await ensureUserDocExists(result.localId, result.email);
         // Load the user profile so the root navigator registers authenticated screens
         await loadUser(result.localId);

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -16,13 +16,16 @@ import { ensureUserDocExists, loadUser } from './userService';
 export function initAuthState(): void {
   const setAuthReady = useAuthStore.getState().setAuthReady;
   const setUid = useAuthStore.getState().setUid;
+  const setIdToken = useAuthStore.getState().setIdToken;
   observeAuthState(async (user) => {
     if (user) {
       setUid(user.uid);
+      setIdToken(await fbGetIdToken(true));
       await ensureUserDocExists(user.uid, user.email ?? undefined);
       await loadUser(user.uid);
     } else {
       setUid(null);
+      setIdToken(null);
       useUserStore.getState().clearUser();
     }
     setAuthReady(true);
@@ -32,19 +35,24 @@ export function initAuthState(): void {
 export async function signup(email: string, password: string) {
   const user = await fbSignup(email, password);
   useAuthStore.getState().setUid(user.uid);
-  return { localId: user.uid, email: user.email ?? '' };
+  const token = await fbGetIdToken(true);
+  useAuthStore.getState().setIdToken(token);
+  return { localId: user.uid, email: user.email ?? '', idToken: token };
 }
 
 export async function login(email: string, password: string) {
   const user = await fbLogin(email, password);
   useAuthStore.getState().setUid(user.uid);
-  return { localId: user.uid, email: user.email ?? '' };
+  const idToken = await fbGetIdToken(true);
+  useAuthStore.getState().setIdToken(idToken);
+  return { localId: user.uid, email: user.email ?? '', idToken };
 }
 
 export async function logout(): Promise<void> {
   await fbLogout();
   useUserStore.getState().clearUser();
   useAuthStore.getState().setUid(null);
+  useAuthStore.getState().setIdToken(null);
 }
 
 export function resetPassword(email: string) {

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -25,20 +25,19 @@ export async function ensureUserDocExists(
   email?: string,
 ): Promise<boolean> {
   try {
-    const snap = await getDocument(`users/${uid}`);
-    if (!snap) {
+    await getDocument(`users/${uid}`);
+    console.log("📄 User doc already exists for", uid);
+    return false;
+  } catch (err: any) {
+    if (err?.response?.status === 404) {
       const payload: any = { uid, createdAt: Date.now() };
       if (email) payload.email = email;
       await setDocument(`users/${uid}`, payload);
       console.log("📄 Created user doc for", uid);
-      return true; // new user created
-    } else {
-      console.log("📄 User doc already exists for", uid);
-      return false;
+      return true;
     }
-  } catch (err) {
     console.warn("⚠️ ensureUserDocExists failed", err);
-    return false;
+    throw err;
   }
 }
 

--- a/App/state/authStore.ts
+++ b/App/state/authStore.ts
@@ -2,17 +2,24 @@ import { create } from 'zustand';
 
 interface AuthState {
   uid: string | null;
+  idToken: string | null;
   authReady: boolean;
   setUid: (uid: string | null) => void;
+  setIdToken: (token: string | null) => void;
   setAuthReady: (ready: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   uid: null,
+  idToken: null,
   authReady: false,
   setUid: (uid) => {
     console.log('🔐 setUid', { uid });
     set({ uid });
+  },
+  setIdToken: (idToken) => {
+    console.log('🔐 setIdToken', { idToken });
+    set({ idToken });
   },
   setAuthReady: (authReady) => {
     console.log('✅ authReady', authReady);


### PR DESCRIPTION
## Summary
- track idToken in auth store
- propagate idToken/uid in auth service
- ensure Firestore UID doc check handles 404
- keep uid available on onboarding screen
- update login screen to store uid immediately

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise')*

------
https://chatgpt.com/codex/tasks/task_e_686595677c6c8330a96aa34aff20f4d4