### PR TITLE
Implement centralized auth flow with NavigatorWrapper

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,297 +1,53 @@
-import React, { useEffect, useState } from "react";
-import { View, ActivityIndicator, Text } from "react-native";
-import * as Sentry from "@sentry/react-native";
-import ErrorBoundary from "./App/components/common/ErrorBoundary";
-import { useFonts, Poppins_600SemiBold } from "@expo-google-fonts/poppins";
-import { Merriweather_400Regular } from "@expo-google-fonts/merriweather";
-import * as SecureStore from "expo-secure-store";
-import { NavigationContainer } from "@react-navigation/native";
-import { navigationRef } from "./App/navigation/navigationRef";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { useUser } from "@/hooks/useUser";
-import { useAuth } from "@/hooks/useAuth";
-import { useAuthStore } from "@/state/authStore";
-import { initAuthState } from "./App/services/authService";
-import StartupAnimation from "./App/components/common/StartupAnimation";
-import Constants from "expo-constants";
-
-import { RootStackParamList } from "./App/navigation/RootStackParamList";
-import { useTheme } from "./App/components/theme/theme";
-
-// Auth Screens
-import LoginScreen from "./App/screens/auth/LoginScreen";
-import SignupScreen from "./App/screens/auth/SignupScreen";
-import WelcomeScreen from "./App/screens/auth/WelcomeScreen";
-import ForgotPasswordScreen from "./App/screens/auth/ForgotPasswordScreen";
-import ForgotUsernameScreen from "./App/screens/auth/ForgotUsernameScreen";
-import OnboardingScreen from "./App/screens/auth/OnboardingScreen";
-import SelectReligionScreen from "./App/screens/auth/SelectReligionScreen";
-
-const isExpoGo = Constants.appOwnership === "expo";
-import OrganizationSignupScreen from "./App/screens/auth/OrganizationSignupScreen";
-
-// Dashboard Screens
-import HomeScreen from "./App/screens/dashboard/HomeScreen";
-import ChallengeScreen from "./App/screens/dashboard/ChallengeScreen";
-import UpgradeScreen from "./App/screens/dashboard/UpgradeScreen";
-import LeaderboardsScreen from "./App/screens/dashboard/LeaderboardScreen";
-import TriviaScreen from "./App/screens/dashboard/TriviaScreen";
-import SubmitProofScreen from "./App/screens/dashboard/SubmitProofScreen";
-
-// Profile Screens
-import ProfileScreen from "./App/screens/profile/ProfileScreen";
-import SettingsScreen from "./App/screens/profile/SettingsScreen";
-import OrganizationManagementScreen from "./App/screens/profile/OrganizationManagmentScreen";
-import JoinOrganizationScreen from "./App/screens/profile/JoinOrganizationScreen";
-import ChangePasswordScreen from "./App/screens/profile/ChangePasswordScreen";
-
-// Root-Level Screens
-import QuoteScreen from "./App/screens/QuoteScreen";
-import ReligionAIScreen from "./App/screens/ReligionAIScreen";
-import JournalScreen from "./App/screens/JournalScreen";
-import ConfessionalScreen from "./App/screens/ConfessionalScreen";
-import BuyTokensScreen from "./App/screens/BuyTokensScreen";
-import GiveBackScreen from "./App/screens/GiveBackScreen";
+import React, { useEffect, useState } from 'react';
+import { View, ActivityIndicator } from 'react-native';
+import * as Sentry from '@sentry/react-native';
+import ErrorBoundary from './App/components/common/ErrorBoundary';
+import { useFonts, Poppins_600SemiBold } from '@expo-google-fonts/poppins';
+import { Merriweather_400Regular } from '@expo-google-fonts/merriweather';
+import NavigatorWrapper from './App/navigation/NavigatorWrapper';
+import StartupAnimation from './App/components/common/StartupAnimation';
+import Constants from 'expo-constants';
+import { useTheme } from './App/components/theme/theme';
 
 const dsn = process.env.SENTRY_DSN || process.env.EXPO_PUBLIC_SENTRY_DSN;
-if (!dsn || dsn.includes("your-key")) {
-  console.warn("Sentry DSN not configured. Skipping Sentry initialization.");
+if (!dsn || dsn.includes('your-key')) {
+  console.warn('Sentry DSN not configured. Skipping Sentry initialization.');
 } else {
   Sentry.init({ dsn });
 }
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const isExpoGo = Constants.appOwnership === 'expo';
 
 export default function App() {
-  const { user } = useUser();
   const theme = useTheme();
   const [fontsLoaded] = useFonts({
     Poppins_600SemiBold,
     Merriweather_400Regular,
   });
-  const [initialRoute, setInitialRoute] = useState<
-    keyof RootStackParamList | undefined
-  >();
-  const { authReady } = useAuth();
   const [showAnim, setShowAnim] = useState(true);
 
   useEffect(() => {
     if (isExpoGo) {
       console.warn(
-        "⚠️ Running in Expo Go. Push notifications and Firebase Auth may not work as expected.",
+        '⚠️ Running in Expo Go. Push notifications and Firebase Auth may not work as expected.',
       );
     }
   }, []);
 
-  useEffect(() => {
-    if (fontsLoaded) {
-      console.log("✅ Fonts loaded");
-    }
-  }, [fontsLoaded]);
-
-  useEffect(() => {
-    initAuthState();
-  }, []);
-
-  // Fallback to avoid indefinite spinner during testing
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (!useAuthStore.getState().authReady) {
-        console.warn("⏰ authReady fallback");
-        useAuthStore.getState().setAuthReady(true);
-      }
-      if (!initialRoute) {
-        console.warn("⏰ initialRoute fallback -> Login");
-        setInitialRoute("Login");
-      }
-    }, 15000);
-    return () => clearTimeout(timer);
-  }, [initialRoute]);
-
-  useEffect(() => {
-    if (user) {
-      console.log("🙋 User state updated:", user.uid);
-      (async () => {
-        let seen = await SecureStore.getItemAsync(
-          `hasSeenOnboarding-${user.uid}`,
-        );
-        if (seen === null && user.onboardingComplete) {
-          seen = "true";
-          await SecureStore.setItemAsync(
-            `hasSeenOnboarding-${user.uid}`,
-            "true",
-          );
-        }
-        setInitialRoute(seen === "true" ? "Home" : "Onboarding");
-      })();
-    } else if (authReady) {
-      setInitialRoute("Login");
-    }
-  }, [user, authReady]);
-
-  if (!fontsLoaded || !authReady || (!initialRoute && user)) {
+  if (!fontsLoaded) {
     return (
       <View
-        style={{
-          flex: 1,
-          justifyContent: "center",
-          alignItems: "center",
-          backgroundColor: theme.colors.background,
-        }}
+        style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background }}
       >
         <ActivityIndicator size="large" color={theme.colors.primary} />
       </View>
     );
   }
 
-  console.log(
-    "🚀 Rendering navigator with initial route",
-    user ? initialRoute : "Login",
-  );
   return (
     <ErrorBoundary>
-      <NavigationContainer ref={navigationRef}>
-        <Stack.Navigator
-          initialRouteName={user ? initialRoute : "Login"}
-          screenOptions={{
-            headerStyle: { backgroundColor: theme.colors.background },
-            headerTintColor: theme.colors.text,
-            headerTitleStyle: {
-              fontWeight: "bold",
-              fontSize: 20,
-              fontFamily: theme.fonts.title,
-            },
-          }}
-        >
-          {!user ? (
-            <>
-              <Stack.Screen
-                name="Welcome"
-                component={WelcomeScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="Login"
-                component={LoginScreen}
-                options={{ title: "Login" }}
-              />
-              <Stack.Screen
-                name="Signup"
-                component={SignupScreen}
-                options={{ title: "Sign Up" }}
-              />
-              <Stack.Screen
-                name="ForgotPassword"
-                component={ForgotPasswordScreen}
-                options={{ title: "Reset Password" }}
-              />
-              <Stack.Screen
-                name="ForgotUsername"
-                component={ForgotUsernameScreen}
-                options={{ title: "Find Email" }}
-              />
-              <Stack.Screen
-                name="OrganizationSignup"
-                component={OrganizationSignupScreen}
-                options={{ title: "Create Organization" }}
-              />
-              {/* Onboarding needs to be accessible immediately after login */}
-              <Stack.Screen
-                name="Onboarding"
-                component={OnboardingScreen}
-                options={{ headerShown: false }}
-              />
-            </>
-          ) : (
-            <>
-              <Stack.Screen
-                name="Onboarding"
-                component={OnboardingScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="Quote"
-                component={QuoteScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="SelectReligion"
-                component={SelectReligionScreen}
-                options={{ title: "Select Religion" }}
-              />
-              <Stack.Screen name="Home" component={HomeScreen} />
-              <Stack.Screen
-                name="ReligionAI"
-                component={ReligionAIScreen}
-                options={{ title: "Religion AI" }}
-              />
-              <Stack.Screen
-                name="Journal"
-                component={JournalScreen}
-                options={{ title: "Quiet Journal" }}
-              />
-              <Stack.Screen
-                name="Challenge"
-                component={ChallengeScreen}
-                options={{ title: "Daily Challenge" }}
-              />
-              <Stack.Screen
-                name="Confessional"
-                component={ConfessionalScreen}
-                options={{ title: "Confessional" }}
-              />
-              <Stack.Screen
-                name="BuyTokens"
-                component={BuyTokensScreen}
-                options={{ title: "Buy Tokens" }}
-              />
-              <Stack.Screen
-                name="Upgrade"
-                component={UpgradeScreen}
-                options={{ title: "Upgrade to OneVine+" }}
-              />
-              <Stack.Screen
-                name="GiveBack"
-                component={GiveBackScreen}
-                options={{ title: "Give Back" }}
-              />
-              <Stack.Screen name="Profile" component={ProfileScreen} />
-              <Stack.Screen
-                name="ChangePassword"
-                component={ChangePasswordScreen}
-                options={{ title: "Change Password" }}
-              />
-              <Stack.Screen name="Settings" component={SettingsScreen} />
-              <Stack.Screen
-                name="Trivia"
-                component={TriviaScreen}
-                options={{ title: "Trivia Challenge" }}
-              />
-              <Stack.Screen
-                name="Leaderboards"
-                component={LeaderboardsScreen}
-                options={{ title: "Leaderboards" }}
-              />
-              <Stack.Screen
-                name="SubmitProof"
-                component={SubmitProofScreen}
-                options={{ title: "Submit Proof" }}
-              />
-              <Stack.Screen
-                name="OrganizationManagement"
-                component={OrganizationManagementScreen}
-                options={{ title: "Manage Organization" }}
-              />
-              <Stack.Screen
-                name="JoinOrganization"
-                component={JoinOrganizationScreen}
-                options={{ title: "Join Organization" }}
-              />
-            </>
-          )}
-        </Stack.Navigator>
-        {showAnim && <StartupAnimation onDone={() => setShowAnim(false)} />}
-      </NavigationContainer>
+      <NavigatorWrapper />
+      {showAnim && <StartupAnimation onDone={() => setShowAnim(false)} />}
     </ErrorBoundary>
   );
 }

--- a/App/navigation/NavigatorWrapper.tsx
+++ b/App/navigation/NavigatorWrapper.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from 'react';
+import { View, ActivityIndicator } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { navigationRef } from './navigationRef';
+import { RootStackParamList } from './RootStackParamList';
+import { useTheme } from '@/components/theme/theme';
+import { useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useUser';
+import { useUserStore } from '@/state/userStore';
+import { initAuthState } from '@/services/authService';
+import { fetchUserProfile } from '@/services/userService';
+
+// Auth Screens
+import LoginScreen from '@/screens/auth/LoginScreen';
+import SignupScreen from '@/screens/auth/SignupScreen';
+import WelcomeScreen from '@/screens/auth/WelcomeScreen';
+import ForgotPasswordScreen from '@/screens/auth/ForgotPasswordScreen';
+import ForgotUsernameScreen from '@/screens/auth/ForgotUsernameScreen';
+import OnboardingScreen from '@/screens/auth/OnboardingScreen';
+import SelectReligionScreen from '@/screens/auth/SelectReligionScreen';
+import OrganizationSignupScreen from '@/screens/auth/OrganizationSignupScreen';
+
+// Dashboard Screens
+import HomeScreen from '@/screens/dashboard/HomeScreen';
+import ChallengeScreen from '@/screens/dashboard/ChallengeScreen';
+import UpgradeScreen from '@/screens/dashboard/UpgradeScreen';
+import LeaderboardsScreen from '@/screens/dashboard/LeaderboardScreen';
+import TriviaScreen from '@/screens/dashboard/TriviaScreen';
+import SubmitProofScreen from '@/screens/dashboard/SubmitProofScreen';
+
+// Profile Screens
+import ProfileScreen from '@/screens/profile/ProfileScreen';
+import SettingsScreen from '@/screens/profile/SettingsScreen';
+import OrganizationManagementScreen from '@/screens/profile/OrganizationManagementScreen';
+import JoinOrganizationScreen from '@/screens/profile/JoinOrganizationScreen';
+import ChangePasswordScreen from '@/screens/profile/ChangePasswordScreen';
+
+// Root-Level Screens
+import QuoteScreen from '@/screens/QuoteScreen';
+import ReligionAIScreen from '@/screens/ReligionAIScreen';
+import JournalScreen from '@/screens/JournalScreen';
+import ConfessionalScreen from '@/screens/ConfessionalScreen';
+import BuyTokensScreen from '@/screens/BuyTokensScreen';
+import GiveBackScreen from '@/screens/GiveBackScreen';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function NavigatorWrapper() {
+  const theme = useTheme();
+  const { uid, idToken, authReady } = useAuth();
+  const { user } = useUser();
+  const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | null>(null);
+
+  useEffect(() => {
+    initAuthState();
+  }, []);
+
+  useEffect(() => {
+    async function verify() {
+      if (!authReady) return;
+      if (!uid || !idToken) {
+        setInitialRoute('Login');
+        return;
+      }
+      const profile = await fetchUserProfile(uid);
+      if (profile && profile.uid === uid) {
+        useUserStore.getState().setUser({
+          uid: profile.uid,
+          email: profile.email,
+          displayName: profile.displayName ?? '',
+          religion: profile.religion,
+          region: profile.region ?? '',
+          organizationId: profile.organizationId,
+          isSubscribed: profile.isSubscribed,
+          onboardingComplete: profile.onboardingComplete,
+          tokens: 0,
+        });
+        setInitialRoute('Home');
+      } else {
+        setInitialRoute('Onboarding');
+      }
+    }
+    verify();
+  }, [authReady, uid, idToken]);
+
+  if (!authReady || !initialRoute) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background }}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <NavigationContainer ref={navigationRef}>
+      <Stack.Navigator
+        initialRouteName={initialRoute}
+        screenOptions={{
+          headerStyle: { backgroundColor: theme.colors.background },
+          headerTintColor: theme.colors.text,
+          headerTitleStyle: { fontWeight: 'bold', fontSize: 20, fontFamily: theme.fonts.title },
+        }}
+      >
+        {!user ? (
+          <>
+            <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
+            <Stack.Screen name="Login" component={LoginScreen} options={{ title: 'Login' }} />
+            <Stack.Screen name="Signup" component={SignupScreen} options={{ title: 'Sign Up' }} />
+            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Reset Password' }} />
+            <Stack.Screen name="ForgotUsername" component={ForgotUsernameScreen} options={{ title: 'Find Email' }} />
+            <Stack.Screen name="OrganizationSignup" component={OrganizationSignupScreen} options={{ title: 'Create Organization' }} />
+            <Stack.Screen name="Onboarding" component={OnboardingScreen} options={{ headerShown: false }} />
+          </>
+        ) : (
+          <>
+            <Stack.Screen name="Onboarding" component={OnboardingScreen} options={{ headerShown: false }} />
+            <Stack.Screen name="Quote" component={QuoteScreen} options={{ headerShown: false }} />
+            <Stack.Screen name="SelectReligion" component={SelectReligionScreen} options={{ title: 'Select Religion' }} />
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="ReligionAI" component={ReligionAIScreen} options={{ title: 'Religion AI' }} />
+            <Stack.Screen name="Journal" component={JournalScreen} options={{ title: 'Quiet Journal' }} />
+            <Stack.Screen name="Challenge" component={ChallengeScreen} options={{ title: 'Daily Challenge' }} />
+            <Stack.Screen name="Confessional" component={ConfessionalScreen} options={{ title: 'Confessional' }} />
+            <Stack.Screen name="BuyTokens" component={BuyTokensScreen} options={{ title: 'Buy Tokens' }} />
+            <Stack.Screen name="Upgrade" component={UpgradeScreen} options={{ title: 'Upgrade to OneVine+' }} />
+            <Stack.Screen name="GiveBack" component={GiveBackScreen} options={{ title: 'Give Back' }} />
+            <Stack.Screen name="Profile" component={ProfileScreen} />
+            <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Change Password' }} />
+            <Stack.Screen name="Settings" component={SettingsScreen} />
+            <Stack.Screen name="Trivia" component={TriviaScreen} options={{ title: 'Trivia Challenge' }} />
+            <Stack.Screen name="Leaderboards" component={LeaderboardsScreen} options={{ title: 'Leaderboards' }} />
+            <Stack.Screen name="SubmitProof" component={SubmitProofScreen} options={{ title: 'Submit Proof' }} />
+            <Stack.Screen name="OrganizationManagement" component={OrganizationManagementScreen} options={{ title: 'Manage Organization' }} />
+            <Stack.Screen name="JoinOrganization" component={JoinOrganizationScreen} options={{ title: 'Join Organization' }} />
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -55,6 +55,7 @@ export default function OnboardingScreen() {
           displayName: username,
           region,
           organizationId: organization || undefined,
+          uid,
         });
         await completeOnboarding(uid);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, "true");

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -42,6 +42,22 @@ export async function ensureUserDocExists(
 }
 
 /**
+ * Fetch a user profile document without creating it
+ */
+export async function fetchUserProfile(
+  uid: string,
+): Promise<FirestoreUser | null> {
+  try {
+    const data = await getDocument(`users/${uid}`);
+    return data as FirestoreUser;
+  } catch (err: any) {
+    if (err?.response?.status === 404) return null;
+    console.warn('⚠️ fetchUserProfile failed', err);
+    throw err;
+  }
+}
+
+/**
  * Get user from Firestore and set into userStore
  */
 export async function loadUser(uid: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add `fetchUserProfile` helper for Firestore uid verification
- include uid when saving onboarding data
- refine login logic to verify fetched profile
- centralize navigation in new `NavigatorWrapper` component
- simplify `App.tsx` to render the wrapper

## Testing
- `npx tsc --noEmit` *(fails: missing expo/tsconfig.base and many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68659962df548330b3854504daa10ef6