### PR TITLE
Fix navigation naming and add debugging logs

### DIFF
--- a/App/navigation/MainTabNavigator.tsx
+++ b/App/navigation/MainTabNavigator.tsx
@@ -12,7 +12,7 @@ import ConfessionalScreen from "@/screens/ConfessionalScreen";
 import ProfileScreen from "@/screens/profile/ProfileScreen";
 import SettingsScreen from "@/screens/profile/SettingsScreen";
 import TriviaScreen from "@/screens/dashboard/TriviaScreen";
-import LeaderboardsScreen from "@/screens/dashboard/LeaderboardScreen";
+import LeaderboardScreen from "@/screens/dashboard/LeaderboardScreen";
 
 const Tab = createBottomTabNavigator();
 
@@ -62,7 +62,7 @@ export default function MainTabNavigator() {
       <Tab.Screen name="Challenge" component={ChallengeScreen as React.ComponentType<any>} />
       <Tab.Screen name="Confessional" component={ConfessionalScreen as React.ComponentType<any>} />
       <Tab.Screen name="Trivia" component={TriviaScreen as React.ComponentType<any>} />
-      <Tab.Screen name="Leaderboards" component={LeaderboardsScreen as React.ComponentType<any>} />
+      <Tab.Screen name="Leaderboards" component={LeaderboardScreen as React.ComponentType<any>} />
       <Tab.Screen name="Profile" component={ProfileScreen as React.ComponentType<any>} />
       <Tab.Screen name="Settings" component={SettingsScreen as React.ComponentType<any>} />
     </Tab.Navigator>

--- a/App/navigation/NavigatorWrapper.tsx
+++ b/App/navigation/NavigatorWrapper.tsx
@@ -25,7 +25,7 @@ import OrganizationSignupScreen from '@/screens/auth/OrganizationSignupScreen';
 import HomeScreen from '@/screens/dashboard/HomeScreen';
 import ChallengeScreen from '@/screens/dashboard/ChallengeScreen';
 import UpgradeScreen from '@/screens/dashboard/UpgradeScreen';
-import LeaderboardsScreen from '@/screens/dashboard/LeaderboardScreen';
+import LeaderboardScreen from '@/screens/dashboard/LeaderboardScreen';
 import TriviaScreen from '@/screens/dashboard/TriviaScreen';
 import SubmitProofScreen from '@/screens/dashboard/SubmitProofScreen';
 
@@ -59,7 +59,9 @@ export default function NavigatorWrapper() {
   useEffect(() => {
     async function verify() {
       if (!authReady) return;
+      console.log('🔍 verify auth', { uid, hasToken: !!idToken });
       if (!uid || !idToken) {
+        console.log('➡️ route -> Login');
         setInitialRoute('Login');
         return;
       }
@@ -76,13 +78,21 @@ export default function NavigatorWrapper() {
           onboardingComplete: profile.onboardingComplete,
           tokens: 0,
         });
+        console.log('➡️ route -> Home');
         setInitialRoute('Home');
       } else {
+        console.log('➡️ route -> Onboarding');
         setInitialRoute('Onboarding');
       }
     }
     verify();
   }, [authReady, uid, idToken]);
+
+  useEffect(() => {
+    if (initialRoute) {
+      console.log('🧭 initialRoute set', { initialRoute });
+    }
+  }, [initialRoute]);
 
   if (!authReady || !initialRoute) {
     return (
@@ -129,7 +139,7 @@ export default function NavigatorWrapper() {
             <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Change Password' }} />
             <Stack.Screen name="Settings" component={SettingsScreen} />
             <Stack.Screen name="Trivia" component={TriviaScreen} options={{ title: 'Trivia Challenge' }} />
-            <Stack.Screen name="Leaderboards" component={LeaderboardsScreen} options={{ title: 'Leaderboards' }} />
+            <Stack.Screen name="Leaderboards" component={LeaderboardScreen} options={{ title: 'Leaderboards' }} />
             <Stack.Screen name="SubmitProof" component={SubmitProofScreen} options={{ title: 'Submit Proof' }} />
             <Stack.Screen name="OrganizationManagement" component={OrganizationManagementScreen} options={{ title: 'Manage Organization' }} />
             <Stack.Screen name="JoinOrganization" component={JoinOrganizationScreen} options={{ title: 'Join Organization' }} />

--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -14,7 +14,7 @@ import { ensureAuth } from '@/utils/authGuard';
 import AuthGate from '@/components/AuthGate';
 import { useAuth } from '@/hooks/useAuth';
 
-export default function LeaderboardsScreen() {
+export default function LeaderboardScreen() {
   const theme = useTheme();
   const { authReady, uid } = useAuth();
   const styles = React.useMemo(


### PR DESCRIPTION
## Summary
- standardize Leaderboard screen name
- log auth verification and initial route selection
- update screen imports in navigators

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6865b86351d08330b830b6e86a0558ef