### PR TITLE
Add Trivia button on Home screen

### DIFF
--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -105,6 +105,8 @@ export default function HomeScreen({ navigation }: Props) {
           <View style={styles.spacer} />
           <Button title="Journal" onPress={() => navigation.navigate('Journal')} />
           <View style={styles.spacer} />
+          <Button title="Trivia" onPress={() => navigation.navigate('Trivia')} />
+          <View style={styles.spacer} />
           <Button title="Leaderboards" onPress={() => navigation.navigate('Leaderboards')} />
         </View>
       </ScrollView>

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -24,6 +24,9 @@ import { useAuth } from '@/hooks/useAuth';
 export default function TriviaScreen() {
   const theme = useTheme();
   const { authReady, uid } = useAuth();
+  useEffect(() => {
+    console.log('📚 Trivia screen opened');
+  }, []);
   const styles = React.useMemo(
     () =>
       StyleSheet.create({


### PR DESCRIPTION
## Summary
- enable navigation to Trivia screen from Home
- log when Trivia opens

## Testing
- `npx tsc --noEmit` *(fails: expo types missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865dc1e5ea88330938f229a6e37b8f3