### PR TITLE
Handle missing active challenge doc

### DIFF
--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -105,7 +105,17 @@ export default function ChallengeScreen() {
 
       const uid = await ensureAuth(await getCurrentUserId());
 
-      const active = await getDocument(`users/${uid}/activeChallenge/current`);
+      let active: any | null = null;
+      try {
+        active = await getDocument(`users/${uid}/activeChallenge/current`);
+      } catch (err: any) {
+        if (err?.response?.status === 404) {
+          await setDocument(`users/${uid}/activeChallenge/current`, {});
+          active = null;
+        } else {
+          throw err;
+        }
+      }
       if (active && !active.isComplete) {
         setActiveMulti(active);
         setLoading(false);
@@ -351,7 +361,9 @@ export default function ChallengeScreen() {
         ) : loading ? (
           <ActivityIndicator size="large" color={theme.colors.primary} />
         ) : (
-          <CustomText style={styles.challenge}>{challenge}</CustomText>
+          <CustomText style={styles.challenge}>
+            {challenge || 'No challenge available.'}
+          </CustomText>
         )}
         <View style={styles.buttonWrap}>
           {!activeMulti && canSkip && (


### PR DESCRIPTION
## Summary
- prevent 404 errors when reading `users/{uid}/activeChallenge/current`
- show a fallback message when there's no daily challenge text

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6865e9b6f1bc8330ad20462badf16ae4