### PR TITLE
Fix leaderboard query permissions

### DIFF
--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -6,7 +6,7 @@ import {
   ActivityIndicator,
   ScrollView
 } from 'react-native';
-import { queryCollection } from '@/services/firestoreService';
+import { getDocument } from '@/services/firestoreService';
 import { showGracefulError } from '@/utils/gracefulError';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
@@ -79,13 +79,11 @@ export default function LeaderboardScreen() {
         return;
       }
 
-      const userSnap = await queryCollection('users', 'individualPoints');
-      const religionSnap = await queryCollection('religion', 'totalPoints');
-      const orgSnap = await queryCollection('organizations', 'totalPoints');
-
-      setIndividuals(userSnap.slice(0, 10));
-      setReligions(religionSnap.slice(0, 10));
-      setOrganizations(orgSnap.slice(0, 10));
+      const data = await getDocument('leaderboards/global');
+      console.log('🏆 Loaded leaderboard doc', data);
+      setIndividuals((data?.individuals || []).slice(0, 10));
+      setReligions((data?.religions || []).slice(0, 10));
+      setOrganizations((data?.organizations || []).slice(0, 10));
     } catch (err) {
       console.error('🔥 Error loading leaderboards:', err);
       showGracefulError('Unable to load leaderboard — please try again later');

--- a/firestore.rules
+++ b/firestore.rules
@@ -95,6 +95,12 @@ service cloud.firestore {
       allow read: if true;
     }
 
+    // 🏆 Leaderboards
+    match /leaderboards/{docId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
     // 📸 Challenge Proof submissions
     match /challengeProofs/{proofId} {
       allow write: if request.auth != null && request.resource.data.uid == request.auth.uid;


### PR DESCRIPTION
## Summary
- parse nested Firestore data
- log UID with token for each Firestore request
- allow reading `/leaderboards/{docId}` in Firestore rules
- fetch leaderboards from `/leaderboards/global`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6865ec2f49788330af1c00e19dca3cfc