### PR TITLE
Fix login gating and token headers

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -71,36 +71,38 @@ export default function AuthGate() {
 
       let profile = useUserStore.getState().user;
       if (!profile || profile.uid !== uid) {
-        profile = await fetchUserProfile(uid);
-        if (profile) {
-          useUserStore.getState().setUser({
-            uid: profile.uid,
-            email: profile.email,
-            displayName: profile.displayName ?? '',
-            religion: profile.religion,
-            region: profile.region ?? '',
-            organizationId: profile.organizationId,
-            isSubscribed: profile.isSubscribed,
-            onboardingComplete: profile.onboardingComplete,
-            tokens: 0,
-          });
+        try {
+          profile = await fetchUserProfile(uid);
+          if (profile) {
+            useUserStore.getState().setUser({
+              uid: profile.uid,
+              email: profile.email,
+              displayName: profile.displayName ?? '',
+              religion: profile.religion,
+              region: profile.region ?? '',
+              organizationId: profile.organizationId,
+              isSubscribed: profile.isSubscribed,
+              onboardingComplete: profile.onboardingComplete,
+              tokens: 0,
+            });
+          }
+        } catch (err) {
+          console.warn('Failed to fetch profile', err);
+          setInitialRoute('Login');
+          setChecking(false);
+          return;
         }
       }
 
       if (!profile) {
-        console.log('➡️ route -> Onboarding');
-        setInitialRoute('Onboarding');
+        console.log('➡️ route -> Login');
+        setInitialRoute('Login');
         setChecking(false);
         return;
       }
 
-      if (profile.onboardingComplete) {
-        console.log('➡️ route -> Home');
-        setInitialRoute('Home');
-      } else {
-        console.log('➡️ route -> Onboarding');
-        setInitialRoute('Onboarding');
-      }
+      console.log('➡️ route -> Home');
+      setInitialRoute('Home');
       setChecking(false);
     }
     verify();
@@ -138,7 +140,6 @@ export default function AuthGate() {
             <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Reset Password' }} />
             <Stack.Screen name="ForgotUsername" component={ForgotUsernameScreen} options={{ title: 'Find Email' }} />
             <Stack.Screen name="OrganizationSignup" component={OrganizationSignupScreen} options={{ title: 'Create Organization' }} />
-            <Stack.Screen name="Onboarding" component={OnboardingScreen} options={{ headerShown: false }} />
           </>
         ) : (
           <>

--- a/App/services/functionService.ts
+++ b/App/services/functionService.ts
@@ -1,10 +1,20 @@
 import axios from 'axios';
+import { getAuthHeaders } from '@/utils/authUtils';
+import { logTokenIssue } from '@/services/authService';
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
 
 export async function callFunction(name: string, data: any): Promise<any> {
+  let headers;
   try {
-    const res = await axios.post(`${API_URL}/${name}`, data);
+    headers = await getAuthHeaders();
+  } catch {
+    logTokenIssue(`function:${name}`);
+    throw new Error('Missing auth token');
+  }
+
+  try {
+    const res = await axios.post(`${API_URL}/${name}`, data, { headers });
     return res.data as any;
   } catch (err: any) {
     console.error('🔥 Function error:', err?.message || err);


### PR DESCRIPTION
## Summary
- fix callFunction to send auth headers
- harden AuthGate user fetching logic and remove onboarding from unauth stack
- always route signed-in users to home

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_6865f639f72883308a5c538539170cf2