### PR TITLE
Graceful leaderboard fetch

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -101,6 +101,9 @@ service cloud.firestore {
     }
 
     // 🏆 Leaderboards
+    match /leaderboards/global {
+      allow read: if request.auth != null;
+    }
     match /leaderboards/{docId} {
       allow read: if request.auth != null;
       allow write: if false;


### PR DESCRIPTION
## Summary
- handle missing leaderboard doc on dashboard
- update Firestore rules for global leaderboard
- seed empty leaderboard and show fallback text

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: couldn't find config)*
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_6865fc91b448833097e8ae51e10e1c84