### PR TITLE
Fix expo web browser plugin

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -26,6 +26,7 @@ export default ({ config }) => ({
     "expo-font",
     "expo-secure-store",
     "expo-system-ui",
+    "expo-web-browser",
     [
       "expo-build-properties",
       {


### PR DESCRIPTION
## Summary
- include `expo-web-browser` plugin in `app.config.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68660165f8ec8330be94dce7456d440f