### PR TITLE
Fix streak path and update leaderboard rules

### DIFF
--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -86,7 +86,11 @@ export default function LeaderboardScreen() {
       if (!data) {
         setNoData(true);
         const seed = { individuals: [], religions: [], organizations: [] };
-        await setDocument('leaderboards/global', seed);
+        try {
+          await setDocument('leaderboards/global', seed);
+        } catch (err: any) {
+          console.error('🔥 Failed to seed leaderboard:', err?.response?.data || err?.message);
+        }
         setIndividuals([]);
         setReligions([]);
         setOrganizations([]);

--- a/firestore.rules
+++ b/firestore.rules
@@ -59,7 +59,8 @@ service cloud.firestore {
     }
 
     // 📝 Journal streak tracking (per user)
-    match /users/{userId}/journalStreak {
+    // Document stored under users/{uid}/journalStreak/current
+    match /users/{userId}/journalStreak/{docId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
@@ -101,8 +102,9 @@ service cloud.firestore {
     }
 
     // 🏆 Leaderboards
+    // Allow all authenticated users to read and write the global leaderboard
     match /leaderboards/global {
-      allow read: if request.auth != null;
+      allow read, write: if request.auth != null;
     }
     match /leaderboards/{docId} {
       allow read: if request.auth != null;

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -113,7 +113,10 @@ async function deductTokens(uid: string, amount: number): Promise<boolean> {
 
 async function updateStreakAndXPInternal(uid: string, type: string) {
   const baseRef = db.collection("users").doc(uid);
-  const ref = type === "journal" ? db.doc(`users/${uid}/journalStreak`) : baseRef;
+  const ref =
+    type === "journal"
+      ? db.doc(`users/${uid}/journalStreak/current`)
+      : baseRef;
 
   await db.runTransaction(async (t) => {
     const snap = await t.get(ref);
@@ -788,10 +791,10 @@ export const startSubscriptionCheckout = functions
   const { userId, priceId, success_url, cancel_url } = req.body || {};
   if (!userId || !priceId || !success_url || !cancel_url) {
     logger.warn("⚠️ Missing fields", {
-      userId: !!userId,
-      priceId: !!priceId,
-      success_url: !!success_url,
-      cancel_url: !!cancel_url,
+      userId,
+      priceId,
+      success_url,
+      cancel_url,
     });
     res.status(400).json({ error: "Missing required fields" });
     return;
@@ -847,10 +850,10 @@ export const startOneTimeTokenCheckout = functions
   const { userId, priceId, success_url, cancel_url } = req.body || {};
   if (!userId || !priceId || !success_url || !cancel_url) {
     logger.warn("⚠️ Missing fields", {
-      userId: !!userId,
-      priceId: !!priceId,
-      success_url: !!success_url,
-      cancel_url: !!cancel_url,
+      userId,
+      priceId,
+      success_url,
+      cancel_url,
     });
     res.status(400).json({ error: "Missing required fields" });
     return;
@@ -955,6 +958,7 @@ export const startCheckoutSession = functions
   .region("us-central1")
   .https.onRequest(withCors(async (req: Request, res: Response) => {
   logger.info("📦 startCheckoutSession payload", req.body);
+  logger.debug("startCheckoutSession headers", req.headers);
   logger.info(
     "🔐 Stripe Secret:",
     STRIPE_SECRET_KEY ? "\u2713 set" : "\u2717 missing",
@@ -962,10 +966,10 @@ export const startCheckoutSession = functions
   const { userId, priceId, success_url, cancel_url, mode = "payment" } = req.body || {};
   if (!userId || !priceId || !success_url || !cancel_url) {
     logger.warn("⚠️ Missing fields", {
-      userId: !!userId,
-      priceId: !!priceId,
-      success_url: !!success_url,
-      cancel_url: !!cancel_url,
+      userId,
+      priceId,
+      success_url,
+      cancel_url,
     });
     res.status(400).json({ error: "Missing required fields" });
     return;
@@ -1125,6 +1129,11 @@ export const seedFirestore = functions
       ensureDocument('completedChallenges/dummy', { placeholder: true }),
       ensureDocument('religion/dummy', { name: 'Dummy Religion' }),
       ensureDocument('organizations/dummy', { name: 'Dummy Org' }),
+      ensureDocument('leaderboards/global', {
+        individuals: [],
+        religions: [],
+        organizations: [],
+      }),
       ensureDocument(
         'religionChats/seed-user/messages/welcome',
         { text: 'Welcome to religion chat!' },


### PR DESCRIPTION
## Summary
- fix doc path in streak updater and add log output for Stripe checkout requests
- handle seeding failure for missing leaderboard document
- seed leaderboards/global in dev script
- update Firestore rules for journalStreak and leaderboards/global

## Testing
- `npm --prefix functions install`
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_6866031a83508330a3106d4ec82fff7a