### PR TITLE
Fix native Android config for EAS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'com.lysara.onevine'
-    compileSdkVersion = 34
+    compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
         applicationId 'com.lysara.onevine'
-        minSdkVersion 23
-        targetSdkVersion 34
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName '1.0.0'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,12 @@ buildscript {
     }
 }
 
+ext {
+    compileSdkVersion = 34
+    targetSdkVersion = 34
+    minSdkVersion = 24
+}
+
 allprojects {
     repositories {
         google()

--- a/app.config.js
+++ b/app.config.js
@@ -4,39 +4,7 @@ export default ({ config }) => ({
   slug: "onevine-app",
   version: "1.0.0",
   runtimeVersion: "1.0.0",
-  orientation: "portrait",
-  icon: "./assets/icon.png",
-  splash: {
-    image: "./assets/splash.png",
-    resizeMode: "contain",
-    backgroundColor: "#ffffff",
-  },
-  userInterfaceStyle: "light",
   assetBundlePatterns: ["**/*"],
-  ios: {
-    supportsTablet: true,
-  },
-  android: {
-    package: "com.lysara.onevine",
-    googleServicesFile:
-      process.env.GOOGLE_SERVICES_JSON || "./android/app/google-services.json",
-  },
-  plugins: [
-    "expo-dev-client",
-    "expo-font",
-    "expo-secure-store",
-    "expo-system-ui",
-    "expo-web-browser",
-    [
-      "expo-build-properties",
-      {
-        android: {
-          kotlinVersion: "1.9.24",
-          gradlePluginVersion: "8.4.1",
-        },
-      },
-    ],
-  ],
   extra: {
     eas: {
       projectId: "bbf209be-1b48-4f76-a496-9d4fcd8339fd",


### PR DESCRIPTION
## Summary
- clean up Expo config to avoid native conflicts
- pin Android compile/target/min SDK versions for EAS Build
- use ext SDK variables in app `build.gradle`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68667c1650988330b73e65e6b1b5bd6a