### PR TITLE
Fix Stripe checkout integration

### DIFF
--- a/App/config/apiConfig.ts
+++ b/App/config/apiConfig.ts
@@ -1,5 +1,5 @@
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
 export const GEMINI_API_URL = `${API_URL}/askGeminiV2`;
-export const STRIPE_CHECKOUT_URL = `${API_URL}/startCheckoutSession`;
+export const STRIPE_CHECKOUT_URL = `${API_URL}/createStripeCheckout`;
 export const INCREMENT_RELIGION_POINTS_URL = `${API_URL}/incrementReligionPoints`;

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -69,9 +69,10 @@ export default function BuyTokensScreen({ navigation }: Props) {
           : amount === 15
           ? PRICE_IDS.TOKENS_50
           : PRICE_IDS.TOKENS_100;
-      const url = await createStripeCheckout(user.uid, {
-        type: 'one-time',
+      const url = await createStripeCheckout(user.uid, user.email, {
+        type: 'tokens',
         priceId,
+        quantity: amount,
       });
       if (url) {
         await WebBrowser.openBrowserAsync(url);

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -65,7 +65,7 @@ export default function UpgradeScreen({ navigation }: Props) {
         return;
       }
 
-      const url = await createStripeCheckout(user.uid, {
+      const url = await createStripeCheckout(user.uid, user.email, {
         type: 'subscription',
         priceId: PRICE_IDS.SUBSCRIPTION,
       });

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -13,7 +13,13 @@ type StripeCheckoutResponse = {
 
 export async function createStripeCheckout(
   uid: string,
-  options: { type: 'subscription' | 'one-time'; priceId: string }
+  email: string,
+  options: {
+    type: 'subscription' | 'tokens';
+    priceId: string;
+    quantity?: number;
+    returnUrl?: string;
+  }
 ): Promise<string> {
   let headers;
   try {
@@ -24,18 +30,17 @@ export async function createStripeCheckout(
   }
   try {
     const payload = {
-      userId: uid,
+      uid,
+      email,
       priceId: options.priceId,
-      mode: options.type === 'subscription' ? 'subscription' : 'payment',
-      success_url: STRIPE_SUCCESS_URL,
-      cancel_url: STRIPE_CANCEL_URL,
+      type: options.type,
+      quantity: options.quantity,
+      returnUrl: options.returnUrl ?? STRIPE_SUCCESS_URL,
     };
     const res = await sendRequestWithGusBugLogging(() =>
-      axios.post<StripeCheckoutResponse>(
-        STRIPE_CHECKOUT_URL,
-        payload,
-        { headers },
-      )
+      axios.post<StripeCheckoutResponse>(STRIPE_CHECKOUT_URL, payload, {
+        headers,
+      })
     );
     return res.data.url;
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- update API endpoint for Stripe checkout
- send user email and token info when creating checkout sessions
- implement `createStripeCheckout` Cloud Function to validate request and create Stripe sessions

## Testing
- `npm test` *(fails: Missing script)*
- `npm install --prefix functions`
- `npx tsc -p functions/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686741b5ccc4833091c862ae1990b026