### PR TITLE
Fix leaderboard query

### DIFF
--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -6,7 +6,7 @@ import {
   ActivityIndicator,
   ScrollView
 } from 'react-native';
-import { getDocument, setDocument } from '@/services/firestoreService';
+import { fetchTopUsersByPoints } from '@/services/firestoreService';
 import { showGracefulError } from '@/utils/gracefulError';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
@@ -75,30 +75,20 @@ export default function LeaderboardScreen() {
     setLoading(true);
     setNoData(false);
     try {
-      const uid = await ensureAuth();
-      if (!uid) {
+      const authedUid = await ensureAuth();
+      if (!authedUid) {
         setLoading(false);
         return;
       }
 
-      const data = await getDocument('leaderboards/global');
-      console.log('🏆 Loaded leaderboard doc', data);
-      if (!data) {
+      const top = await fetchTopUsersByPoints(10);
+      console.log('🏆 Leaderboard results', top);
+      if (!top || top.length === 0) {
         setNoData(true);
-        const seed = { individuals: [], religions: [], organizations: [] };
-        try {
-          await setDocument('leaderboards/global', seed);
-        } catch (err: any) {
-          console.error('🔥 Failed to seed leaderboard:', err?.response?.data || err?.message);
-        }
         setIndividuals([]);
-        setReligions([]);
-        setOrganizations([]);
       } else {
         setNoData(false);
-        setIndividuals((data.individuals || []).slice(0, 10));
-        setReligions((data.religions || []).slice(0, 10));
-        setOrganizations((data.organizations || []).slice(0, 10));
+        setIndividuals(top);
       }
     } catch (err: any) {
       console.error('🔥 Error loading leaderboards:', err?.response?.data || err?.message || err);

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -13,6 +13,7 @@ export interface FirestoreUser {
   religion: string;
   region?: string;
   organizationId?: string;
+  individualPoints?: number;
   isSubscribed: boolean;
   onboardingComplete: boolean;
   createdAt: number;
@@ -31,7 +32,7 @@ export async function ensureUserDocExists(
     return false;
   } catch (err: any) {
     if (err?.response?.status === 404) {
-      const payload: any = { uid, createdAt: Date.now() };
+      const payload: any = { uid, createdAt: Date.now(), individualPoints: 0 };
       if (email) payload.email = email;
       await setDocument(`users/${uid}`, payload);
       console.log("📄 Created user doc for", uid);
@@ -120,6 +121,7 @@ export async function createUserProfile({
     displayName,
     religion,
     region,
+    individualPoints: 0,
     isSubscribed: false,
     onboardingComplete: false,
     createdAt: now,

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,9 +2,12 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // 🔐 Users - only the owner can read/write their document
+    // 🔐 Users collection
+    // Allow all authenticated users to read basic user info (for leaderboards)
+    // but restrict writes to the owner of the document
     match /users/{userId} {
-      allow create, read, update, delete: if request.auth != null && request.auth.uid == userId;
+      allow read: if request.auth != null;
+      allow create, update, delete: if request.auth != null && request.auth.uid == userId;
     }
 
     // 💬 Religion Chats


### PR DESCRIPTION
## Summary
- adjust firestore rules so anyone logged in can read user docs
- store `individualPoints` on user doc creation
- query top users by points with Firestore REST API
- display leaderboard using queried users

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_686743733678833088ccecbdb32f0a62