### PR TITLE
Support region selection on login

### DIFF
--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -58,6 +58,8 @@ export default function ForgotUsernameScreen() {
         if (!region && list.length) setRegion(list[0].name);
       } catch (err) {
         console.warn('Failed to load regions', err);
+        setRegions([{ name: 'Unknown', code: 'UNKNOWN' }]);
+        setRegion('Unknown');
       }
     };
     load();

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -48,7 +48,8 @@ export default function LoginScreen() {
           });
         }
         const profileValid = profile?.uid === result.localId;
-        const needsOnboarding = isNew || !profileValid;
+        const missingInfo = !profile?.username || !profile?.region;
+        const needsOnboarding = isNew || !profileValid || missingInfo;
         console.log(
           "🧭 Post-login route",
           needsOnboarding ? SCREENS.AUTH.ONBOARDING : SCREENS.MAIN.HOME,

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -48,6 +48,8 @@ export default function OnboardingScreen() {
         if (!region && list.length) setRegion(list[0].name);
       } catch (err) {
         console.warn('Failed to load regions', err);
+        setRegions([{ name: 'Unknown', code: 'UNKNOWN' }]);
+        setRegion('Unknown');
       }
     };
     load();

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -70,6 +70,8 @@ export default function ProfileScreen() {
         if (!region && list.length) setRegion(list[0].name);
       } catch (err) {
         console.warn('Failed to load regions', err);
+        setRegions([{ name: 'Unknown', code: 'UNKNOWN' }]);
+        setRegion('Unknown');
       }
     };
     loadRegions();

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ The export command creates `PromptLibrary.md` with prompts grouped by category.
 Run `npx ts-node seedRegions.ts` from the `functions` directory to populate the
 `regions` collection with default entries used by the app.
 
+The mobile app pulls these documents via the Firestore REST API to populate the
+region picker on the onboarding and profile screens. The selected region value
+is saved back to `users/{uid}` so that returning users can skip onboarding.
+
 ## ✅ Test Readiness Checklist
 
 - Clean EAS build completes without native errors


### PR DESCRIPTION
## Summary
- skip onboarding only if username and region are both present
- handle region query failures on onboarding, profile, and forgot username screens
- note Firestore regions setup in README

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6867612201748330af81af46f3c1a866