### PR TITLE
Implement challenge streak persistence

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -67,6 +67,12 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // 🏆 Challenge streak tracking (per user)
+    // Document stored under users/{uid}/challengeStreak/current
+    match /users/{userId}/challengeStreak/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // 🔁 Active Challenge (per user)
     // Allows read/write access to documents under
     // `users/{uid}/activeChallenge`, including the `current` doc


### PR DESCRIPTION
## Summary
- persist streak in `users/{uid}` under `challengeStreak`
- read streak on challenge screen load
- update streak after completing a challenge
- allow Firestore access to `challengeStreak` document

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867d703ff688330b7729b58abb64ce0