### PR TITLE
Enforce daily challenge limits

### DIFF
--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -13,6 +13,7 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
 import { ASK_GEMINI_SIMPLE, GENERATE_CHALLENGE_URL } from "@/utils/constants";
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { canLoadNewChallenge } from '@/services/challengeLimitService';
 import { completeChallengeWithStreakCheck } from '@/services/challengeStreakService';
 import {
   callFunction,
@@ -128,6 +129,12 @@ export default function ChallengeScreen() {
       if (!forceNew && lastChallenge && now.getTime() - lastChallenge.getTime() < oneDay) {
         setChallenge(userData.lastChallengeText || '');
         setCanSkip(false);
+        setLoading(false);
+        return;
+      }
+
+      const allowed = await canLoadNewChallenge();
+      if (!allowed) {
         setLoading(false);
         return;
       }

--- a/App/services/challengeLimitService.ts
+++ b/App/services/challengeLimitService.ts
@@ -1,0 +1,52 @@
+import { Alert } from 'react-native';
+import { getDocument, setDocument } from '@/services/firestoreService';
+import { getCurrentUserId } from '@/utils/TokenManager';
+import { ensureAuth } from '@/utils/authGuard';
+
+/**
+ * Check if the current user can load a new challenge.
+ * - Free users get 3 free challenges per day
+ * - After the limit, 5 tokens are required per challenge
+ * - dailyChallengeCount and lastChallengeLoadDate are stored in users/{uid}
+ */
+export async function canLoadNewChallenge(): Promise<boolean> {
+  const uid = await ensureAuth(await getCurrentUserId());
+  if (!uid) return false;
+
+  const userData = (await getDocument(`users/${uid}`)) || {};
+  const isSubscribed = userData.isSubscribed || false;
+  const tokens = userData.tokens || 0;
+  let dailyChallengeCount = userData.dailyChallengeCount || 0;
+  const lastDate = userData.lastChallengeLoadDate
+    ? new Date(userData.lastChallengeLoadDate).toISOString().split('T')[0]
+    : null;
+  const today = new Date().toISOString().split('T')[0];
+
+  if (lastDate !== today) {
+    dailyChallengeCount = 0;
+  }
+
+  if (isSubscribed || dailyChallengeCount < 3) {
+    await setDocument(`users/${uid}`, {
+      dailyChallengeCount: dailyChallengeCount + 1,
+      lastChallengeLoadDate: new Date().toISOString(),
+    });
+    return true;
+  }
+
+  if (tokens < 5) {
+    Alert.alert(
+      'Out of challenges',
+      'You\u2019ve reached your daily free limit. Earn or purchase more tokens to continue.'
+    );
+    return false;
+  }
+
+  await setDocument(`users/${uid}`, {
+    tokens: tokens - 5,
+    dailyChallengeCount: dailyChallengeCount + 1,
+    lastChallengeLoadDate: new Date().toISOString(),
+  });
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add challengeLimitService with token logic
- use canLoadNewChallenge in ChallengeScreen

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_6867da4633c88330803aae13ea689ca1