### PR TITLE
Implement persistent confessional chat

### DIFF
--- a/App/services/confessionalChatService.ts
+++ b/App/services/confessionalChatService.ts
@@ -1,0 +1,38 @@
+import { addDocument, querySubcollection } from '@/services/firestoreService';
+import { ensureAuth } from '@/utils/authGuard';
+
+export interface ConfessionalMessage {
+  id?: string;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt?: string;
+}
+
+export async function saveConfessionalMessage(
+  uid: string,
+  role: 'user' | 'assistant',
+  content: string,
+): Promise<void> {
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return;
+  console.warn('🔥 Attempting Firestore access:', `confessionalChats/${storedUid}/messages`);
+  console.warn('👤 Using UID:', storedUid);
+  await addDocument(`confessionalChats/${storedUid}/messages`, {
+    role,
+    content,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+export async function fetchConfessionalHistory(uid: string): Promise<ConfessionalMessage[]> {
+  const storedUid = await ensureAuth(uid);
+  if (!storedUid) return [];
+  console.warn('🔥 Attempting Firestore access:', `confessionalChats/${storedUid}/messages`);
+  console.warn('👤 Using UID:', storedUid);
+  return await querySubcollection(
+    `confessionalChats/${storedUid}`,
+    'messages',
+    'createdAt',
+    'ASCENDING',
+  );
+}

--- a/App/services/firestoreService.ts
+++ b/App/services/firestoreService.ts
@@ -200,7 +200,20 @@ export async function fetchTopUsersByPoints(limit = 10): Promise<any[]> {
   return runStructuredQuery(query);
 }
 
-export async function querySubcollection(parentPath: string, collectionName: string): Promise<any[]> {
+export async function querySubcollection(
+  parentPath: string,
+  collectionName: string,
+  orderByField?: string,
+  direction: 'ASCENDING' | 'DESCENDING' = 'ASCENDING',
+): Promise<any[]> {
   console.log('➡️ Firestore SUBQUERY', `${parentPath}/${collectionName}`);
-  return queryCollection(`${parentPath}/${collectionName}`);
+  if (!orderByField) {
+    return queryCollection(`${parentPath}/${collectionName}`);
+  }
+  const query = {
+    parent: `projects/${PROJECT_ID}/databases/(default)/documents/${parentPath}`,
+    from: [{ collectionId: collectionName }],
+    orderBy: [{ field: { fieldPath: orderByField }, direction }],
+  };
+  return runStructuredQuery(query);
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,6 +25,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // ✝️ Confessional Chats (persistent)
+    match /confessionalChats/{userId}/messages/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // 💳 Subscriptions
     match /subscriptions/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;


### PR DESCRIPTION
## Summary
- store confessional chat history under `confessionalChats/{uid}/messages`
- load saved history on Confessional screen
- persist new messages and AI replies to Firestore
- allow ordering queries in `firestoreService`
- update Firestore rules for new collection

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867dbcbad548330a20df5ace777f452