### PR TITLE
Add user doc fields for streaks and daily limits

### DIFF
--- a/App/types/user.ts
+++ b/App/types/user.ts
@@ -10,6 +10,14 @@ export interface FirestoreUser {
   isSubscribed: boolean;
   onboardingComplete: boolean;
   createdAt: number;
+  challengeStreak?: {
+    count: number;
+    lastCompletedDate: string | null;
+  };
+  dailyChallengeCount?: number;
+  dailySkipCount?: number;
+  lastChallengeLoadDate?: string | null;
+  lastSkipDate?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend `FirestoreUser` interfaces with challenge streak and daily counters
- default these fields when creating a user profile
- add `initializeUserDataIfNeeded` to patch missing fields
- ensure user fields are initialized on user load

## Testing
- `npm exec tsc --noEmit` *(fails: many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867e05b91d08330a3a686b838884085