### PR TITLE
Fix confessional AI endpoint

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -128,7 +128,13 @@ export default function ConfessionalScreen() {
         text: m.content,
       }));
 
-      const response = await axios.post(`${process.env.EXPO_PUBLIC_API_URL}/confessionalAI`, { history: historyMsgs });
+      const response = await axios.post(
+        `${process.env.EXPO_PUBLIC_API_URL}/confessionalAI`,
+        {
+          history: historyMsgs,
+          uid,
+        },
+      );
       const answer = response.data?.reply || "I’m here with you.";
 
       console.log('✝️ Confessional input:', text);


### PR DESCRIPTION
## Summary
- update ConfessionalScreen to include the uid in the request body when calling the confessionalAI function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867f63726488330817bca54b2969f2e