### PR TITLE
Add duplicate challenge alert

### DIFF
--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -283,6 +283,11 @@ export default function ChallengeScreen() {
     }
 
     const updated = await completeChallengeWithStreakCheck();
+    const todayStr = new Date().toISOString().split('T')[0];
+    const lastStr = lastCompletedDate
+      ? lastCompletedDate.toISOString().split('T')[0]
+      : null;
+
     if (updated != null) {
       if (updated > streakCount) {
         await checkMilestoneReward(updated);
@@ -304,7 +309,14 @@ export default function ChallengeScreen() {
       console.error('🔥 Backend error:', err.response?.data || err.message);
     }
 
-    Alert.alert('Great job!', 'Challenge completed.');
+    if (updated != null && updated === streakCount && lastStr === todayStr) {
+      Alert.alert(
+        'Challenge Already Completed',
+        "You've already completed your challenge for today. Come back tomorrow to continue your streak and grow even stronger."
+      );
+    } else {
+      Alert.alert('Great job!', 'Challenge completed.');
+    }
     const shouldGenerateNew = useToken || history.completed < limit;
     fetchChallenge(shouldGenerateNew);
   };


### PR DESCRIPTION
## Summary
- show a friendly alert when the same day's challenge is completed twice

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f78d711883309e77e8a370ede733