### PR TITLE
Fix leaderboards for religions and organizations

### DIFF
--- a/App/lib/firebase.ts
+++ b/App/lib/firebase.ts
@@ -1,0 +1,16 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MSG_SENDER_ID,
+  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID,
+};
+
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+
+export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- add Firebase client to access Firestore
- fetch religion and organization leaderboard data directly from Firestore

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867f900179c8330acc0a7ee4a0a09a7