### PR TITLE
Fix onboarding username check

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -102,8 +102,13 @@ export default function AuthGate() {
         return;
       }
 
-      console.log('➡️ route -> Home');
-      setInitialRoute('Home');
+      if (profile.username) {
+        console.log('➡️ route -> Home');
+        setInitialRoute('Home');
+      } else {
+        console.log('➡️ route -> Onboarding');
+        setInitialRoute('Onboarding');
+      }
       setChecking(false);
     }
     verify();

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -6,10 +6,10 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from "@/components/common/Button";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { updateUserFields, completeOnboarding } from "@/services/userService";
 import {
-  completeOnboarding,
-  updateUserFields,
-} from "@/services/userService";
+  saveUsernameAndProceed,
+} from "@/services/onboardingService";
 import { useUserStore } from "@/state/userStore";
 import { useAuthStore } from "@/state/authStore";
 import { SCREENS } from "@/navigation/screens";
@@ -62,35 +62,28 @@ export default function OnboardingScreen() {
       return;
     }
 
-    if (!username.trim() || !region.trim()) {
-      Alert.alert("Missing Info", "Username and region are required.");
+    if (!username.trim()) {
+      Alert.alert('Missing Info', 'Username is required.');
       return;
     }
 
     setLoading(true);
     try {
       if (uid) {
+        await saveUsernameAndProceed(username.trim());
         await updateUserFields(uid, {
           religion,
-          username,
-          displayName: username,
           region,
           organizationId: organization || undefined,
-          uid,
         });
         await completeOnboarding(uid);
-        await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, "true");
+        await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         useUserStore.getState().updateUser({
           onboardingComplete: true,
-          username,
-          displayName: username,
+          username: username.trim(),
+          displayName: username.trim(),
           region,
           religion,
-        });
-
-        navigation.reset({
-          index: 0,
-          routes: [{ name: SCREENS.MAIN.HOME as keyof RootStackParamList }],
         });
       }
     } catch (err: any) {

--- a/App/services/onboardingService.ts
+++ b/App/services/onboardingService.ts
@@ -1,0 +1,20 @@
+import { navigationRef } from '@/navigation/navigationRef';
+import { setDocument, getDocument } from '@/services/firestoreService';
+import { ensureAuth } from '@/utils/authGuard';
+
+export async function saveUsernameAndProceed(username: string): Promise<void> {
+  const uid = await ensureAuth();
+  await setDocument(`users/${uid}`, { username });
+  if (navigationRef.isReady()) {
+    navigationRef.reset({ index: 0, routes: [{ name: 'Home' }] });
+  }
+}
+
+export async function checkIfUserIsNewAndRoute(): Promise<void> {
+  const uid = await ensureAuth();
+  const profile = await getDocument(`users/${uid}`);
+  const hasUsername = !!profile?.username;
+  if (navigationRef.isReady()) {
+    navigationRef.reset({ index: 0, routes: [{ name: hasUsername ? 'Home' : 'Onboarding' }] });
+  }
+}


### PR DESCRIPTION
## Summary
- add `onboardingService` with username utilities
- save username during onboarding and update region/religion
- after login or on app load, route based on username presence

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fb49bb2483308ce07f4551e9e815