### PR TITLE
Improve signup logging and validation

### DIFF
--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -22,6 +22,16 @@ export default function SignupScreen() {
   const theme = useTheme();
 
   const handleSignup = async () => {
+    if (!email || !/^\S+@\S+\.\S+$/.test(email)) {
+      Alert.alert('Invalid Email', 'Please enter a valid email address.');
+      return;
+    }
+    if (!password || password.length < 6) {
+      Alert.alert('Invalid Password', 'Password must be at least 6 characters long.');
+      return;
+    }
+    const requestPayload = { email, password };
+    console.log('➡️ signup payload', requestPayload);
     setLoading(true);
     try {
       const result = await signup(email, password);
@@ -36,7 +46,11 @@ export default function SignupScreen() {
       await loadUser(result.localId);
       navigation.replace('Onboarding');
     } catch (err: any) {
-      Alert.alert('Signup Failed', err.message);
+      console.error('❌ signup failed', err?.response?.data || err);
+      const message = err?.response?.status === 400
+        ? err?.response?.data?.message || err.message
+        : err.message;
+      Alert.alert('Signup Failed', message);
     } finally {
       setLoading(false);
     }

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -15,8 +15,22 @@ export interface AuthResponse {
 
 export async function signUpWithEmailAndPassword(email: string, password: string): Promise<AuthResponse> {
   const url = `${ID_BASE}/accounts:signUp?key=${API_KEY}`;
-  const res = await axios.post(url, { email, password, returnSecureToken: true });
-  return res.data;
+  const payload = { email, password, returnSecureToken: true };
+  console.log('➡️ signup request', { url, payload });
+  try {
+    const res = await axios.post(url, payload, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    console.log('✅ signup response', res.data);
+    return res.data;
+  } catch (err: any) {
+    if (err.response) {
+      console.error('❌ signup error response', err.response.data);
+    } else {
+      console.error('❌ signup error', err.message);
+    }
+    throw err;
+  }
 }
 
 export async function signInWithEmailAndPassword(email: string, password: string): Promise<AuthResponse> {


### PR DESCRIPTION
## Summary
- log request and response details around Firebase signup
- validate form client-side before signup
- surface server error message from 400 responses

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686826bc3a1883308d470d67c69df038