### PR TITLE
Fix shared icon path

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -3,9 +3,11 @@ export default ({ config }) => ({
   name: "OneVine",
   slug: "onevine-app",
   version: "1.0.0",
-  icon: "./app/assets/icon.png",
+  // Use the shared logo for both platforms
+  icon: "./assets/icon.png",
   runtimeVersion: "1.0.0",
-  assetBundlePatterns: ["**/*"],
+  // Include bundled assets (e.g. icon)
+  assetBundlePatterns: ["assets/*"],
   android: {
     package: "com.whippybuckle.onevineapp"
   },


### PR DESCRIPTION
## Summary
- fix icon path in `app.config.js`
- ensure app assets are bundled correctly

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686829253f98833097dd0d1267b96403