### PR TITLE
Switch religion list to Firestore REST

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -17,6 +17,7 @@ import { useTheme } from "@/components/theme/theme";
 import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
 import { queryCollection } from "@/services/firestoreService";
+import { fetchReligionList } from "../../../religionRest";
 
 type OnboardingScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -55,9 +56,9 @@ export default function OnboardingScreen() {
         setRegions([{ name: 'Unknown', code: 'UNKNOWN' }]);
       }
 
-      console.log('➡️ fetching religions');
+      console.log('➡️ fetching religions via REST');
       try {
-        const rels = await queryCollection('religions');
+        const rels = await fetchReligionList();
         console.log(`✅ fetched ${rels.length} religions`);
         if (!rels.length) console.error('❌ Religions list was empty');
         rels.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -9,6 +9,7 @@ import { useUser } from '@/hooks/useUser';
 import { useUserStore } from '@/state/userStore';
 import { getTokenCount } from '@/utils/TokenManager';
 import { getDocument, setDocument, queryCollection } from '@/services/firestoreService';
+import { fetchReligionList } from '../../../religionRest';
 import { updateUserFields } from '@/services/userService';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
@@ -75,7 +76,7 @@ export default function ProfileScreen() {
         setRegion('Unknown');
       }
       try {
-        const rels = await queryCollection('religions');
+        const rels = await fetchReligionList();
         rels.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
         setReligions(rels);
         if (!religion && rels.length) setReligion(rels[0].id || rels[0].name);

--- a/authRest.ts
+++ b/authRest.ts
@@ -1,0 +1,9 @@
+import { getIdToken as getTokenFromAuth } from './App/lib/auth';
+
+export async function getIdToken(forceRefresh = false): Promise<string> {
+  const token = await getTokenFromAuth(forceRefresh);
+  if (!token) {
+    throw new Error('No ID token available');
+  }
+  return token;
+}

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -4,7 +4,7 @@ const API_KEY = process.env.EXPO_PUBLIC_FIREBASE_API_KEY || '';
 const PROJECT_ID = process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || '';
 
 const ID_BASE = `https://identitytoolkit.googleapis.com/v1`;
-const FIRESTORE_BASE = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
+export const FIRESTORE_BASE = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
 
 export interface AuthResponse {
   idToken: string;

--- a/religionRest.ts
+++ b/religionRest.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { FIRESTORE_BASE } from './firebaseRest';
+import { getIdToken } from './authRest';
+
+export interface ReligionItem {
+  id: string;
+  name: string;
+}
+
+export async function fetchReligionList(): Promise<ReligionItem[]> {
+  const idToken = await getIdToken();
+  const url = `${FIRESTORE_BASE}/religions`;
+
+  try {
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+      },
+    });
+
+    const docs = response.data.documents || [];
+
+    const religions: ReligionItem[] = docs.map((doc: any) => {
+      const id = doc.name.split('/').pop() || '';
+      const fields = doc.fields || {};
+      const name = fields.name?.stringValue || 'Unnamed';
+      return { id, name };
+    });
+
+    return religions;
+  } catch (err: any) {
+    console.error('❌ Failed to fetch religion list via REST:', err.message);
+    throw new Error('Unable to fetch religions');
+  }
+}


### PR DESCRIPTION
## Summary
- expose `FIRESTORE_BASE` from `firebaseRest`
- add REST helpers for auth token and religion list fetching
- use `fetchReligionList` in Onboarding and Profile screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686832bf638083308d145a67732ca7f7