### PR TITLE
Improve Firestore error logging

### DIFF
--- a/App/lib/logging.ts
+++ b/App/lib/logging.ts
@@ -1,0 +1,10 @@
+export function logFirestoreError(operation: string, path: string, error: any) {
+  const status = error?.response?.status ?? 'unknown';
+  const msg =
+    error?.response?.data?.error?.message ?? error.message ?? 'Unknown error';
+
+  console.error(`🔥 Firestore ${operation} failed on ${path}`, {
+    status,
+    message: msg,
+  });
+}

--- a/App/screens/dashboard/LeaderboardScreen.tsx
+++ b/App/screens/dashboard/LeaderboardScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import axios from 'axios';
 import { fetchTopUsersByPoints } from '@/services/firestoreService';
+import { logFirestoreError } from '@/lib/logging';
 import { showGracefulError } from '@/utils/gracefulError';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
@@ -18,59 +19,65 @@ import { useAuth } from '@/hooks/useAuth';
 const PROJECT_ID = process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || '';
 
 async function fetchTopReligions(idToken: string) {
-  const response = await axios.post(
-    `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`,
-    {
-      structuredQuery: {
-        from: [{ collectionId: 'religions' }],
-        orderBy: [
-          { field: { fieldPath: 'totalPoints' }, direction: 'DESCENDING' },
-        ],
-        limit: 10,
-      },
+  const url = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`;
+  const payload = {
+    structuredQuery: {
+      from: [{ collectionId: 'religions' }],
+      orderBy: [
+        { field: { fieldPath: 'totalPoints' }, direction: 'DESCENDING' },
+      ],
+      limit: 10,
     },
-    {
+  };
+  try {
+    const response = await axios.post(url, payload, {
       headers: {
         Authorization: `Bearer ${idToken}`,
       },
-    }
-  );
+    });
 
-  return response.data
-    .map((doc: any) => doc.document)
-    .filter(Boolean)
-    .map((doc: any) => ({
-      name: doc.fields?.name?.stringValue,
-      totalPoints: parseInt(doc.fields?.totalPoints?.integerValue || '0'),
-    }));
+    return response.data
+      .map((doc: any) => doc.document)
+      .filter(Boolean)
+      .map((doc: any) => ({
+        name: doc.fields?.name?.stringValue,
+        totalPoints: parseInt(doc.fields?.totalPoints?.integerValue || '0'),
+      }));
+  } catch (err: any) {
+    logFirestoreError('QUERY', 'runQuery religions', err);
+    throw err;
+  }
 }
 
 async function fetchTopOrganizations(idToken: string) {
-  const response = await axios.post(
-    `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`,
-    {
-      structuredQuery: {
-        from: [{ collectionId: 'organizations' }],
-        orderBy: [
-          { field: { fieldPath: 'totalPoints' }, direction: 'DESCENDING' },
-        ],
-        limit: 10,
-      },
+  const url = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`;
+  const payload = {
+    structuredQuery: {
+      from: [{ collectionId: 'organizations' }],
+      orderBy: [
+        { field: { fieldPath: 'totalPoints' }, direction: 'DESCENDING' },
+      ],
+      limit: 10,
     },
-    {
+  };
+  try {
+    const response = await axios.post(url, payload, {
       headers: {
         Authorization: `Bearer ${idToken}`,
       },
-    }
-  );
+    });
 
-  return response.data
-    .map((doc: any) => doc.document)
-    .filter(Boolean)
-    .map((doc: any) => ({
-      name: doc.fields?.name?.stringValue,
-      totalPoints: parseInt(doc.fields?.totalPoints?.integerValue || '0'),
-    }));
+    return response.data
+      .map((doc: any) => doc.document)
+      .filter(Boolean)
+      .map((doc: any) => ({
+        name: doc.fields?.name?.stringValue,
+        totalPoints: parseInt(doc.fields?.totalPoints?.integerValue || '0'),
+      }));
+  } catch (err: any) {
+    logFirestoreError('QUERY', 'runQuery organizations', err);
+    throw err;
+  }
 }
 
 export default function LeaderboardScreen() {

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { logFirestoreError } from './App/lib/logging';
 
 const API_KEY = process.env.EXPO_PUBLIC_FIREBASE_API_KEY || '';
 const PROJECT_ID = process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || '';
@@ -40,9 +41,15 @@ export async function signInWithEmailAndPassword(email: string, password: string
 }
 
 export async function getUserData(uid: string, idToken: string) {
-  const url = `${FIRESTORE_BASE}/users/${uid}`;
-  const res = await axios.get(url, { headers: { Authorization: `Bearer ${idToken}` } });
-  return res.data;
+  const path = `users/${uid}`;
+  const url = `${FIRESTORE_BASE}/${path}`;
+  try {
+    const res = await axios.get(url, { headers: { Authorization: `Bearer ${idToken}` } });
+    return res.data;
+  } catch (err: any) {
+    logFirestoreError('GET', path, err);
+    throw err;
+  }
 }
 
 function toFirestoreFields(obj: any): any {
@@ -58,10 +65,16 @@ function toFirestoreFields(obj: any): any {
 }
 
 export async function saveJournalEntry(uid: string, data: Record<string, any>, idToken: string) {
-  const url = `${FIRESTORE_BASE}/journalEntries/${uid}/entries`;
+  const path = `journalEntries/${uid}/entries`;
+  const url = `${FIRESTORE_BASE}/${path}`;
   const body = { fields: toFirestoreFields(data) };
-  const res = await axios.post(url, body, { headers: { Authorization: `Bearer ${idToken}` } });
-  return res.data;
+  try {
+    const res = await axios.post(url, body, { headers: { Authorization: `Bearer ${idToken}` } });
+    return res.data;
+  } catch (err: any) {
+    logFirestoreError('POST', path, err);
+    throw err;
+  }
 }
 
 export const FIREBASE_ENDPOINTS = {

--- a/religionRest.ts
+++ b/religionRest.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { FIRESTORE_BASE } from './firebaseRest';
 import { getIdToken } from './authRest';
+import { logFirestoreError } from './App/lib/logging';
 
 export interface ReligionItem {
   id: string;
@@ -29,7 +30,7 @@ export async function fetchReligionList(): Promise<ReligionItem[]> {
 
     return religions;
   } catch (err: any) {
-    console.error('❌ Failed to fetch religion list via REST:', err.message);
+    logFirestoreError('GET', 'religions', err);
     throw new Error('Unable to fetch religions');
   }
 }


### PR DESCRIPTION
## Summary
- add shared `logFirestoreError` helper
- integrate logging into Firestore service methods
- log Firestore errors in REST helpers
- wrap leaderboard queries with new logging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686834b2ee5c8330a997cd4981fc3e07