### PR TITLE
Ensure OneVine icon used

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>

--- a/app.config.js
+++ b/app.config.js
@@ -8,6 +8,8 @@ export default ({ config }) => ({
   runtimeVersion: "1.0.0",
   // Include bundled assets (e.g. icon)
   assetBundlePatterns: ["assets/*"],
+  // Limit platforms to avoid requiring react-native-web for expo export
+  platforms: ["ios", "android"],
   android: {
     package: "com.whippybuckle.onevineapp"
   },


### PR DESCRIPTION
## Summary
- prevent Android icon override by removing manifest attribute
- limit platforms to iOS/Android so `expo export` works

## Testing
- `npm test --silent`
- `npx expo export --dev`

------
https://chatgpt.com/codex/tasks/task_e_6868365cb95483308ed9c1fab4ed69bb