### PR TITLE
Fix onboarding routing logic

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -102,7 +102,7 @@ export default function AuthGate() {
         return;
       }
 
-      if (profile.username) {
+      if (profile.onboardingComplete) {
         console.log('➡️ route -> Home');
         setInitialRoute('Home');
       } else {

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -16,7 +16,7 @@ import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
 import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
-import { queryCollection } from "@/services/firestoreService";
+import { queryCollection, getDocument } from "@/services/firestoreService";
 import { fetchReligionList } from "../../../religionRest";
 
 type OnboardingScreenProps = NativeStackScreenProps<
@@ -107,6 +107,12 @@ export default function OnboardingScreen() {
           displayName: username.trim(),
           region,
           religion,
+        });
+        const check = await getDocument(`users/${uid}`);
+        console.log('✅ profile after onboarding', {
+          username: check?.username,
+          region: check?.region,
+          religion: check?.religion,
         });
       }
     } catch (err: any) {

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -6,6 +6,7 @@ import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { signup } from "@/services/authService";
 import { createUserProfile, loadUser } from "@/services/userService";
+import { checkIfUserIsNewAndRoute } from "@/services/onboardingService";
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from "@/components/theme/theme";
@@ -44,7 +45,7 @@ export default function SignupScreen() {
         displayName: '',
       });
       await loadUser(result.localId);
-      navigation.replace('Onboarding');
+      await checkIfUserIsNewAndRoute();
     } catch (err: any) {
       console.error('❌ signup failed', err?.response?.data || err);
       const message = err?.response?.status === 400

--- a/App/services/onboardingService.ts
+++ b/App/services/onboardingService.ts
@@ -13,8 +13,10 @@ export async function saveUsernameAndProceed(username: string): Promise<void> {
 export async function checkIfUserIsNewAndRoute(): Promise<void> {
   const uid = await ensureAuth();
   const profile = await getDocument(`users/${uid}`);
-  const hasUsername = !!profile?.username;
+  const completed = !!profile?.onboardingComplete;
   if (navigationRef.isReady()) {
-    navigationRef.reset({ index: 0, routes: [{ name: hasUsername ? 'Home' : 'Onboarding' }] });
+    const initialRoute = completed ? 'Home' : 'Onboarding';
+    console.log('🧭 initialRoute set', { initialRoute });
+    navigationRef.reset({ index: 0, routes: [{ name: initialRoute }] });
   }
 }


### PR DESCRIPTION
## Summary
- update AuthGate to route based on `onboardingComplete`
- fetch and log route in `checkIfUserIsNewAndRoute`
- verify saved profile fields when completing onboarding
- check onboarding state after signup

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6868393c00b083309232c1d591a09105