### PR TITLE
Use REST for dropdown values

### DIFF
--- a/App/hooks/useLookupLists.ts
+++ b/App/hooks/useLookupLists.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { fetchRegionList, RegionItem } from '../../regionRest';
+import { fetchReligionList, ReligionItem } from '../../religionRest';
+
+const FALLBACK_REGION: RegionItem = { id: 'unknown', name: 'Unknown' };
+const FALLBACK_RELIGION: ReligionItem = { id: 'spiritual', name: 'Spiritual Guide' };
+
+export function useLookupLists() {
+  const [regions, setRegions] = useState<RegionItem[]>([]);
+  const [religions, setReligions] = useState<ReligionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      try {
+        const [rgns, rels] = await Promise.all([
+          fetchRegionList(),
+          fetchReligionList(),
+        ]);
+        if (!isMounted) return;
+        console.log('📖 Fetched regions', rgns);
+        console.log('📖 Fetched religions', rels);
+        setRegions(rgns.length ? rgns : [FALLBACK_REGION]);
+        setReligions(rels.length ? rels : [FALLBACK_RELIGION]);
+      } catch (err) {
+        if (isMounted) {
+          console.warn('Failed to load reference lists', err);
+          setRegions([FALLBACK_REGION]);
+          setReligions([FALLBACK_RELIGION]);
+        }
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { regions, religions, loading };
+}

--- a/regionRest.ts
+++ b/regionRest.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import { FIRESTORE_BASE } from './firebaseRest';
+import { getIdToken } from './authRest';
+import { logFirestoreError } from './App/lib/logging';
+
+export interface RegionItem {
+  id: string;
+  name: string;
+}
+
+export async function fetchRegionList(): Promise<RegionItem[]> {
+  const idToken = await getIdToken();
+  const url = `${FIRESTORE_BASE}/regions`;
+  try {
+    const res = await axios.get(url, {
+      headers: { Authorization: `Bearer ${idToken}` },
+    });
+    const docs = res.data.documents || [];
+    return docs.map((doc: any) => {
+      const id = doc.name.split('/').pop() || '';
+      const fields = doc.fields || {};
+      const name = fields.name?.stringValue || 'Unnamed';
+      return { id, name };
+    });
+  } catch (err: any) {
+    logFirestoreError('GET', 'regions', err);
+    throw new Error('Unable to fetch regions');
+  }
+}


### PR DESCRIPTION
## Summary
- add regionRest helper for Firestore REST calls
- create `useLookupLists` hook to fetch regions and religions
- update onboarding and profile screens to load dropdown data via REST
- show loading indicator while fetching

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683ba23790833085b602cc12926b32