### PR TITLE
Fix onboarding religion choices from Firestore

### DIFF
--- a/App/hooks/useLookupLists.ts
+++ b/App/hooks/useLookupLists.ts
@@ -13,6 +13,7 @@ export function useLookupLists() {
   useEffect(() => {
     let isMounted = true;
     const load = async () => {
+      console.log('⏬ Loading region and religion lists');
       try {
         const [rgns, rels] = await Promise.all([
           fetchRegionList(),
@@ -28,6 +29,7 @@ export function useLookupLists() {
           console.warn('Failed to load reference lists', err);
           setRegions([FALLBACK_REGION]);
           setReligions([FALLBACK_RELIGION]);
+          console.log('🕳️ Using fallback reference lists');
         }
       } finally {
         if (isMounted) setLoading(false);

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -18,6 +18,7 @@ import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { showGracefulError } from '@/utils/gracefulError';
 import axios from 'axios';
 import type { GeminiMessage } from '@/services/geminiService';
+import { getPersonaPrompt } from '@/utils/religionPersona';
 import { CONFESSIONAL_AI_URL } from '@/utils/constants';
 import { useAuth } from '@/hooks/useAuth';
 import {
@@ -114,12 +115,8 @@ export default function ConfessionalScreen() {
 
       const userData = await getDocument(`users/${uid}`);
       const religion = userData.religion || 'Spiritual Guide';
-      const role = religion === 'Christianity' ? 'Pastor' :
-                   religion === 'Islam' ? 'Imam' :
-                   religion === 'Hinduism' ? 'Guru' :
-                   religion === 'Buddhism' ? 'Teacher' :
-                   religion === 'Judaism' ? 'Rabbi' :
-                   'Spiritual Guide';
+      const role = getPersonaPrompt(religion);
+      console.log('👤 Persona resolved', { religion, role });
 
       await saveConfessionalMessage(uid, 'user', text);
 

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -38,6 +38,7 @@ import {
   checkIfUserIsSubscribed,
 } from '@/services/chatHistoryService';
 import { showInterstitialAd } from '@/services/adService';
+import { getPersonaPrompt } from '@/utils/religionPersona';
 
 export default function ReligionAIScreen() {
   const theme = useTheme();
@@ -183,12 +184,8 @@ export default function ReligionAIScreen() {
       console.log('💎 OneVine+ Status:', subscribed);
 
       const religion = userData.religion || 'Spiritual Guide';
-      const promptRole = religion === 'Christianity' ? 'Jesus' :
-                         religion === 'Islam' ? 'Imam' :
-                         religion === 'Hinduism' ? 'Guru' :
-                         religion === 'Buddhism' ? 'Teacher' :
-                         religion === 'Judaism' ? 'Rabbi' :
-                         'Spiritual Guide';
+      const promptRole = getPersonaPrompt(religion);
+      console.log('👤 Persona resolved', { religion, promptRole });
 
       if (!subscribed) {
         if (!canAskFree) {

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -39,6 +39,10 @@ export default function OnboardingScreen() {
   const [saving, setSaving] = useState(false);
   const [religionError, setReligionError] = useState("");
 
+  React.useEffect(() => {
+    console.log('📋 Available religions', religions);
+  }, [religions]);
+
   const handleContinue = async () => {
     const uid = user?.uid || uidFromAuth;
     if (!uid) {
@@ -59,6 +63,7 @@ export default function OnboardingScreen() {
     }
 
     setSaving(true);
+    console.log('💾 Submitting onboarding', { username, region, religion });
     try {
       if (uid) {
         await saveUsernameAndProceed(username.trim());
@@ -163,7 +168,10 @@ export default function OnboardingScreen() {
       <View style={styles.pickerWrapper}>
         <Picker
           selectedValue={region}
-          onValueChange={(val) => setRegion(val)}
+          onValueChange={(val) => {
+            console.log('📍 Region selected', val);
+            setRegion(val);
+          }}
           style={styles.picker}
         >
           <Picker.Item label="Select your region" value="" />
@@ -180,12 +188,15 @@ export default function OnboardingScreen() {
       <View style={styles.pickerWrapper}>
         <Picker
           selectedValue={religion}
-          onValueChange={(itemValue) => setReligion(itemValue)}
+          onValueChange={(itemValue) => {
+            console.log('🙏 Religion selected', itemValue);
+            setReligion(itemValue);
+          }}
           style={styles.picker}
         >
           <Picker.Item label="Select your spiritual lens" value="" />
           {religions.map((r) => (
-            <Picker.Item key={r.id || r.name} label={r.name} value={r.id || r.name} />
+            <Picker.Item key={r.id} label={r.id} value={r.id} />
           ))}
         </Picker>
       </View>

--- a/App/utils/religionPersona.ts
+++ b/App/utils/religionPersona.ts
@@ -1,0 +1,22 @@
+export function getPersonaPrompt(religion?: string | null): string {
+  switch (religion) {
+    case 'Buddhism':
+      return 'Buddhist monk';
+    case 'Christianity':
+      return 'Christian pastor or spiritual father';
+    case 'Islam':
+      return 'Muslim imam';
+    case 'Judaism':
+      return 'Jewish rabbi';
+    case 'Atheist':
+      return 'Moral philosopher or rationalist';
+    case 'Agnostic':
+      return 'Contemplative seeker or humanist';
+    case 'Pagan':
+      return 'Earth-based spiritual guide';
+    case 'Hinduism':
+      return 'Hindu sage or guru';
+    default:
+      return 'Spiritual guide';
+  }
+}

--- a/religionRest.ts
+++ b/religionRest.ts
@@ -10,7 +10,9 @@ export interface ReligionItem {
 
 export async function fetchReligionList(): Promise<ReligionItem[]> {
   const idToken = await getIdToken();
-  const url = `${FIRESTORE_BASE}/religions`;
+  const url = `${FIRESTORE_BASE}/religion`;
+
+  console.log('➡️ Fetching religions from', url);
 
   try {
     const response = await axios.get(url, {
@@ -20,17 +22,18 @@ export async function fetchReligionList(): Promise<ReligionItem[]> {
     });
 
     const docs = response.data.documents || [];
+    console.log('✅ Religions fetched', docs.map((d: any) => d.name.split('/').pop()));
 
     const religions: ReligionItem[] = docs.map((doc: any) => {
       const id = doc.name.split('/').pop() || '';
       const fields = doc.fields || {};
-      const name = fields.name?.stringValue || 'Unnamed';
+      const name = fields.name?.stringValue || id;
       return { id, name };
     });
 
     return religions;
   } catch (err: any) {
-    logFirestoreError('GET', 'religions', err);
+    logFirestoreError('GET', 'religion', err);
     throw new Error('Unable to fetch religions');
   }
 }


### PR DESCRIPTION
## Summary
- fetch religion IDs from `/religion` collection via REST
- log list loading in useLookupLists
- populate onboarding dropdown using the fetched IDs
- log user selections and submission during onboarding
- centralize persona mapping in `getPersonaPrompt`
- use `getPersonaPrompt` in ReligionAI and Confessional screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686877f783f48330b7523bdae47523d3