### PR TITLE
Add in-memory cache for religion list

### DIFF
--- a/App/hooks/useLookupLists.ts
+++ b/App/hooks/useLookupLists.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchRegionList, RegionItem } from '../../regionRest';
-import { fetchReligionList, ReligionItem } from '../../religionRest';
+import { getReligions, ReligionItem } from '../../religionRest';
 
 const FALLBACK_REGION: RegionItem = { id: 'unknown', name: 'Unknown' };
 const FALLBACK_RELIGION: ReligionItem = { id: 'spiritual', name: 'Spiritual Guide' };
@@ -17,7 +17,7 @@ export function useLookupLists() {
       try {
         const [rgns, rels] = await Promise.all([
           fetchRegionList(),
-          fetchReligionList(),
+          getReligions(),
         ]);
         if (!isMounted) return;
         console.log('📖 Fetched regions', rgns);

--- a/religionRest.ts
+++ b/religionRest.ts
@@ -8,7 +8,30 @@ export interface ReligionItem {
   name: string;
 }
 
-export async function fetchReligionList(): Promise<ReligionItem[]> {
+let cachedReligions: ReligionItem[] | null = null;
+
+/**
+ * Retrieve the list of religions, using an in-memory cache to avoid
+ * unnecessary network calls within the app session.
+ */
+export async function getReligions(): Promise<ReligionItem[]> {
+  if (cachedReligions) {
+    console.log('📦 Religions served from cache');
+    return cachedReligions;
+  }
+
+  try {
+    const rels = await fetchReligionList();
+    cachedReligions = rels;
+    return rels;
+  } catch (err) {
+    console.error('getReligions failed', err);
+    console.log('⚠️ Returning empty religion list');
+    return [];
+  }
+}
+
+async function fetchReligionList(): Promise<ReligionItem[]> {
   const idToken = await getIdToken();
   const url = `${FIRESTORE_BASE}/religion`;
 


### PR DESCRIPTION
## Summary
- add in-memory caching to religionRest and expose `getReligions`
- update lookup hook to use cached religions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68687e598d6483308caa3cda30b412df