### PR TITLE
Implement Firestore religion helper

### DIFF
--- a/App/hooks/useLookupLists.ts
+++ b/App/hooks/useLookupLists.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchRegionList, RegionItem } from '../../regionRest';
-import { getReligions, ReligionItem } from '../../religionRest';
+import { getReligions, ReligionItem } from '../../firebase/religion';
 
 const FALLBACK_REGION: RegionItem = { id: 'unknown', name: 'Unknown' };
 const FALLBACK_RELIGION: ReligionItem = { id: 'spiritual', name: 'Spiritual Guide' };

--- a/firebase/religion.ts
+++ b/firebase/religion.ts
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import { getIdToken } from '../authRest';
+
+export interface ReligionItem {
+  id: string;
+  name: string;
+  aiVoice: string;
+  defaultChallenges: string[];
+  totalPoints: number;
+  language: string;
+}
+
+let religionsCache: ReligionItem[] = [];
+
+export async function getReligions(forceRefresh = false): Promise<ReligionItem[]> {
+  if (!forceRefresh && religionsCache.length) return religionsCache;
+
+  const token = await getIdToken();
+  const url = `https://firestore.googleapis.com/v1/projects/wwjd-app/databases/(default)/documents/religion`;
+
+  try {
+    const res = await axios.get(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    religionsCache = (res.data.documents || []).map((doc: any) => ({
+      id: doc.name.split('/').pop(),
+      name: doc.fields.name?.stringValue ?? '',
+      aiVoice: doc.fields.aiVoice?.stringValue ?? '',
+      defaultChallenges:
+        doc.fields.defaultChallenges?.arrayValue?.values?.map((v: any) => v.stringValue) ?? [],
+      totalPoints: Number(doc.fields.totalPoints?.integerValue ?? 0),
+      language: doc.fields.language?.stringValue ?? '',
+    }));
+
+    console.log('📖 Religions fetched:', religionsCache.map((r) => r.name));
+    return religionsCache;
+  } catch (err: any) {
+    console.error('🔥 Failed to fetch religions:', err.response?.data || err);
+    return [];
+  }
+}
+
+export async function updateReligionPoints(religionId: string, pointsToAdd: number) {
+  const token = await getIdToken();
+  const docPath = `projects/wwjd-app/databases/(default)/documents/religion/${religionId}`;
+
+  const current = religionsCache.find((r) => r.id === religionId)?.totalPoints ?? 0;
+  const newTotal = current + pointsToAdd;
+
+  try {
+    await axios.patch(
+      `https://firestore.googleapis.com/v1/${docPath}?updateMask.fieldPaths=totalPoints`,
+      {
+        fields: {
+          totalPoints: { integerValue: newTotal },
+        },
+      },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    console.log(`✅ Religion ${religionId} updated with totalPoints = ${newTotal}`);
+    return true;
+  } catch (err: any) {
+    console.error('🔥 Failed to update religion points:', err.response?.data || err);
+    return false;
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -115,6 +115,12 @@ service cloud.firestore {
       allow read: if request.auth != null;
     }
 
+    // ✅ Allow authed read + patch on religion docs
+    match /religion/{religionId} {
+      allow read: if request.auth != null;
+      allow update: if request.auth != null;
+    }
+
     // 🛐 Public religion content
     match /religions/{religionId} {
       allow read: if true;


### PR DESCRIPTION
## Summary
- allow authed read/update for `religion` docs in Firestore rules
- add REST helper under `firebase/religion.ts`
- use the new helper in `useLookupLists`

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686881e9d7c883309a3178c62e2d9f76