### PR TITLE
Fix Stripe session validation

### DIFF
--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -69,6 +69,13 @@ export default function BuyTokensScreen({ navigation }: Props) {
           : amount === 15
           ? PRICE_IDS.TOKENS_50
           : PRICE_IDS.TOKENS_100;
+      if (!user.uid || !priceId) {
+        console.warn('Missing uid or priceId when starting Stripe checkout', {
+          uid: user.uid,
+          priceId,
+        });
+        return;
+      }
       const url = await createStripeCheckout(user.uid, user.email, {
         type: 'tokens',
         priceId,

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -65,6 +65,14 @@ export default function UpgradeScreen({ navigation }: Props) {
         return;
       }
 
+      if (!user.uid || !PRICE_IDS.SUBSCRIPTION) {
+        console.warn('Missing uid or priceId when starting Stripe checkout', {
+          uid: user.uid,
+          priceId: PRICE_IDS.SUBSCRIPTION,
+        });
+        return;
+      }
+
       const url = await createStripeCheckout(user.uid, user.email, {
         type: 'subscription',
         priceId: PRICE_IDS.SUBSCRIPTION,

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -21,6 +21,19 @@ export async function createStripeCheckout(
     returnUrl?: string;
   }
 ): Promise<string> {
+  if (
+    typeof uid !== 'string' || !uid.trim() ||
+    typeof options.priceId !== 'string' || !options.priceId.trim()
+  ) {
+    console.warn('Missing uid or priceId for createStripeCheckout', {
+      uid,
+      priceId: options.priceId,
+    });
+    throw new Error('Missing uid or priceId');
+  }
+
+  console.log('Creating Stripe session with:', { uid, priceId: options.priceId });
+
   let headers;
   try {
     headers = await getAuthHeaders();

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1129,6 +1129,15 @@ export const createStripeCheckout = functions
   logger.info("🛒 createStripeCheckout payload", req.body);
   const { uid, email, priceId, type, quantity, returnUrl } = req.body || {};
 
+  if (typeof uid !== "string" || !uid.trim() ||
+      typeof priceId !== "string" || !priceId.trim()) {
+    logger.warn("⚠️ Missing uid or priceId", { uid, priceId });
+    res.status(400).json({ error: "Missing uid or priceId" });
+    return;
+  }
+
+  logger.debug("Creating Stripe session with", { uid, priceId });
+
   const missing: string[] = [];
   if (!uid) missing.push("uid");
   if (!email) missing.push("email");


### PR DESCRIPTION
## Summary
- validate uid and priceId in `createStripeCheckout` cloud function
- warn on invalid parameters before requesting checkout
- add client checks before Stripe calls
- log debug info when creating sessions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a6ba37988330857f93f218cc1220