### PR TITLE
Implement Stripe subscription checkout

### DIFF
--- a/App/config/apiConfig.ts
+++ b/App/config/apiConfig.ts
@@ -3,4 +3,5 @@ const API_URL = process.env.EXPO_PUBLIC_API_URL;
 export const GEMINI_API_URL = `${API_URL}/askGeminiV2`;
 export const STRIPE_CHECKOUT_URL = `${API_URL}/createStripeCheckout`;
 export const TOKEN_CHECKOUT_URL = `${API_URL}/startTokenCheckout`;
+export const SUBSCRIPTION_CHECKOUT_URL = `${API_URL}/startSubscriptionCheckout`;
 export const INCREMENT_RELIGION_POINTS_URL = `${API_URL}/incrementReligionPoints`;

--- a/App/config/stripeConfig.ts
+++ b/App/config/stripeConfig.ts
@@ -8,3 +8,5 @@ export const PRICE_IDS = {
   TOKENS_100: process.env.EXPO_PUBLIC_STRIPE_100_TOKEN_PRICE_ID || '',
   // Donation price IDs are no longer needed because donations use dynamic amounts
 };
+
+export const ONEVINE_PLUS_PRICE_ID = PRICE_IDS.SUBSCRIPTION;

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import CustomText from '@/components/CustomText';
-import { View, StyleSheet, Alert } from 'react-native';
-import * as WebBrowser from 'expo-web-browser';
+import { View, StyleSheet, Alert, Linking } from 'react-native';
 import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
-import { createStripeCheckout } from '@/services/apiService';
-import { PRICE_IDS } from '@/config/stripeConfig';
+import { startSubscriptionCheckout } from '@/services/apiService';
+import { ONEVINE_PLUS_PRICE_ID } from '@/config/stripeConfig';
 import { getAuthHeaders } from '@/utils/TokenManager';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
@@ -65,20 +64,17 @@ export default function UpgradeScreen({ navigation }: Props) {
         return;
       }
 
-      if (!user.uid || !PRICE_IDS.SUBSCRIPTION) {
+      if (!user.uid || !ONEVINE_PLUS_PRICE_ID) {
         console.warn('Missing uid or priceId when starting Stripe checkout', {
           uid: user.uid,
-          priceId: PRICE_IDS.SUBSCRIPTION,
+          priceId: ONEVINE_PLUS_PRICE_ID,
         });
         return;
       }
 
-      const url = await createStripeCheckout(user.uid, user.email, {
-        type: 'subscription',
-        priceId: PRICE_IDS.SUBSCRIPTION,
-      });
+      const url = await startSubscriptionCheckout(user.uid, ONEVINE_PLUS_PRICE_ID);
       if (url) {
-        await WebBrowser.openBrowserAsync(url);
+        await Linking.openURL(url);
       } else {
         Alert.alert('Checkout Error', 'Unable to start checkout. Please try again later.');
       }
@@ -106,7 +102,7 @@ export default function UpgradeScreen({ navigation }: Props) {
         <CustomText style={styles.price}>$9.99 / month</CustomText>
 
         <View style={styles.buttonWrap}>
-          <Button title="Join OneVine+" onPress={handleUpgrade} disabled={loading} />
+          <Button title="Join OneVine+" onPress={handleUpgrade} disabled={loading} loading={loading} />
         </View>
 
         <View style={styles.buttonWrap}>

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { STRIPE_CHECKOUT_URL, TOKEN_CHECKOUT_URL } from '@/config/apiConfig';
+import { STRIPE_CHECKOUT_URL, TOKEN_CHECKOUT_URL, SUBSCRIPTION_CHECKOUT_URL } from '@/config/apiConfig';
 import { STRIPE_SUCCESS_URL, STRIPE_CANCEL_URL } from '@/config/stripeConfig';
 import { getAuthHeaders } from '@/utils/authUtils';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
@@ -91,6 +91,39 @@ export async function startTokenCheckout(uid: string, priceId: string): Promise<
     return url;
   } catch (err: any) {
     console.warn('❌ Firestore REST error on startTokenCheckout:', err.response?.data || err.message);
+    if (err.response?.status === 403) {
+      console.warn('Firestore 403 – not a session issue', err);
+      showPermissionDenied();
+      throw new Error('Permission denied');
+    }
+    throw new Error(err.response?.data?.error || 'Unable to start checkout.');
+  }
+}
+
+export async function startSubscriptionCheckout(uid: string, priceId: string): Promise<string> {
+  if (typeof uid !== 'string' || !uid.trim() || typeof priceId !== 'string' || !priceId.trim()) {
+    console.warn('Missing uid or priceId for startSubscriptionCheckout', { uid, priceId });
+    throw new Error('Missing uid or priceId');
+  }
+
+  console.log('📦 Starting OneVine+ subscription...', { uid, priceId });
+
+  let headers;
+  try {
+    headers = await getAuthHeaders();
+  } catch {
+    logTokenIssue('startSubscriptionCheckout');
+    throw new Error('Missing auth token');
+  }
+
+  try {
+    const payload = { uid, priceId };
+    const res = await axios.post<StripeCheckoutResponse>(SUBSCRIPTION_CHECKOUT_URL, payload, { headers });
+    const url = (res.data as any).checkoutUrl || res.data.url;
+    console.log('🔗 Redirecting to:', url);
+    return url;
+  } catch (err: any) {
+    console.warn('❌ Firestore REST error on startSubscriptionCheckout:', err.response?.data || err.message);
     if (err.response?.status === 403) {
       console.warn('Firestore 403 – not a session issue', err);
       showPermissionDenied();


### PR DESCRIPTION
## Summary
- add constant for subscription checkout API
- alias ONEVINE_PLUS_PRICE_ID in stripe config
- implement `startSubscriptionCheckout` helper
- wire Upgrade screen to new helper
- expose `/startSubscriptionCheckout` cloud function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ec9533548330b4025d03d4a2bbc0