### PR TITLE
Fix Firebase seeding and null‑safety

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -79,7 +79,7 @@ export default function AuthGate() {
               email: profile.email,
               username: profile.username ?? '',
               displayName: profile.displayName ?? '',
-              religion: profile.religion,
+              religion: profile.religion ?? 'SpiritGuide',
               region: profile.region ?? '',
               organizationId: profile.organizationId,
               isSubscribed: profile.isSubscribed,

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -97,7 +97,7 @@ export default function ConfessionalScreen() {
       console.log('Using token', token ? token.slice(0, 10) : 'none');
 
       const userData = await getDocument(`users/${uid}`);
-      const religion = userData.religion;
+      const religion = userData?.religion ?? 'SpiritGuide';
       const role = getPersonaPrompt(religion);
       console.log('👤 Persona resolved', { religionId: religion, role });
 

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -183,7 +183,7 @@ export default function ReligionAIScreen() {
       setIsSubscribed(subscribed);
       console.log('💎 OneVine+ Status:', subscribed);
 
-      const religion = userData.religion || 'Spiritual Guide';
+      const religion = userData?.religion ?? 'SpiritGuide';
       const promptRole = getPersonaPrompt(religion);
       console.log('👤 Persona resolved', { religion, promptRole });
 

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -41,7 +41,7 @@ export default function LoginScreen() {
             username: profile.username ?? '',
             displayName: profile.displayName ?? '',
             isSubscribed: profile.isSubscribed,
-            religion: profile.religion,
+            religion: profile.religion ?? 'SpiritGuide',
             region: profile.region ?? '',
             organizationId: profile.organizationId,
             onboardingComplete: profile.onboardingComplete,

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -16,7 +16,7 @@ import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
 import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
-import { getDocument } from "@/services/firestoreService";
+import { getDocument, setDocument } from "@/services/firestoreService";
 import { useLookupLists } from "@/hooks/useLookupLists";
 
 type OnboardingScreenProps = NativeStackScreenProps<
@@ -72,6 +72,7 @@ export default function OnboardingScreen() {
           region,
           organizationId: organization || undefined,
         });
+        await setDocument(`users/${uid}`, { religion });
         await completeOnboarding(uid);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         useUserStore.getState().updateUser({

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -84,9 +84,9 @@ export default function ChallengeScreen() {
 
       const blessing = await sendGeminiPrompt({
         url: ASK_GEMINI_SIMPLE,
-        prompt: `Provide a short blessing for a user who reached a ${current}-day spiritual challenge streak in the ${userData.religion || 'Christian'} tradition.`,
+        prompt: `Provide a short blessing for a user who reached a ${current}-day spiritual challenge streak in the ${userData?.religion ?? 'SpiritGuide'} tradition.`,
         history: [],
-        religion: userData.religion,
+        religion: userData?.religion ?? 'SpiritGuide',
       });
       if (blessing) {
         Alert.alert('Blessing!', `${blessing}\nYou earned ${reward} Grace Tokens.`);
@@ -141,7 +141,7 @@ export default function ChallengeScreen() {
         return;
       }
 
-      const religion = userData.religion || 'spiritual';
+      const religion = userData?.religion ?? 'SpiritGuide';
 
       const prompt =
         `Give me a short daily challenge for the ${religion} faith on ${new Date().toDateString()}.`;

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -93,7 +93,7 @@ export default function TriviaScreen() {
         url: ASK_GEMINI_SIMPLE,
         prompt: `Give me a short moral story originally from any major world religion. Replace all real names and locations with fictional ones so that it seems to come from a different culture. Keep the meaning and lesson intact. After the story, add two lines: RELIGION: <religion> and STORY: <story name>.`,
         history: [],
-        religion: user?.religion,
+        religion: user?.religion ?? 'SpiritGuide',
       });
       if (!data) {
         Alert.alert('Error', 'Could not load trivia. Please try again later.');

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -114,6 +114,7 @@ export default function ProfileScreen() {
       });
       console.log('✅ Religion update response', res.data);
       updateUser({ religion: value });
+      await updateUserFields(uidVal, { religion: value });
       await setDocument(`users/${uidVal}`, { lastChallenge: null });
       Alert.alert('Religion Updated');
     } catch (err: any) {

--- a/App/services/geminiService.ts
+++ b/App/services/geminiService.ts
@@ -48,7 +48,8 @@ export async function sendGeminiPrompt({
 
   try {
     console.log('➡️ Gemini request to', url);
-    const finalReligion = religion ?? useUserStore.getState().user?.religion;
+    const finalReligion =
+      religion ?? useUserStore.getState().user?.religion ?? 'SpiritGuide';
     const res = await sendRequestWithGusBugLogging(() =>
       fetch(url, {
         method: 'POST',

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -115,7 +115,7 @@ export async function loadUser(uid: string): Promise<void> {
       username: user.username ?? '',
       displayName: user.displayName ?? "",
       isSubscribed: user.isSubscribed,
-      religion: user.religion,
+      religion: user.religion ?? 'SpiritGuide',
       region: user.region ?? "",
       organizationId: user.organizationId,
       onboardingComplete: user.onboardingComplete,

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1461,6 +1461,8 @@ export const onUserCreate = functions
       await db.collection("users").doc(uid).set({
         uid,
         email: user.email || "",
+        displayName: user.displayName || "",
+        emailVerified: user.emailVerified || false,
         createdAt: timestamp,
         isSubscribed: false,
         lastFreeAsk: timestamp,
@@ -1475,8 +1477,8 @@ export const onUserCreate = functions
       });
 
       await Promise.all([
-        db.collection("journalEntries").doc(uid).set({ entries: [] }),
-        db.collection("confessionalSessions").doc(uid).set({ messages: [] }),
+        db.collection("journalEntries").doc(uid).set({ placeholder: true }),
+        db.collection("confessionalSessions").doc(uid).set({ placeholder: true }),
         db.collection("dailyChallenges").doc(uid).set({ seenChallenges: [] }),
         db.collection("leaderboards").doc(uid).set({ score: 0 }),
         db.collection("tokens").doc(uid).set({ earned: 0, spent: 0 }),


### PR DESCRIPTION
## Summary
- seed new users with all profile fields
- write defaults for related user collections
- use `profile.religion ?? 'SpiritGuide'` across the app
- persist religion updates in onboarding and profile screens
- default religion for AI prompts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0b9546a08330854366c9c5c97bfc