### PR TITLE
Initialize user data and use safe profile values

### DIFF
--- a/App/config/constants.ts
+++ b/App/config/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_RELIGION = 'Christian'
+export const DEFAULT_RELIGION = 'SpiritGuide'
 export const MAX_FREE_CHALLENGES = 1

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -97,7 +97,7 @@ export default function ConfessionalScreen() {
       console.log('Using token', token ? token.slice(0, 10) : 'none');
 
       const userData = await getDocument(`users/${uid}`);
-      const religion = userData.religion;
+      const religion = userData?.religion ?? 'SpiritGuide';
       const role = getPersonaPrompt(religion);
       console.log('👤 Persona resolved', { religionId: religion, role });
 

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -183,7 +183,7 @@ export default function ReligionAIScreen() {
       setIsSubscribed(subscribed);
       console.log('💎 OneVine+ Status:', subscribed);
 
-      const religion = userData.religion || 'Spiritual Guide';
+      const religion = userData?.religion ?? 'SpiritGuide';
       const promptRole = getPersonaPrompt(religion);
       console.log('👤 Persona resolved', { religion, promptRole });
 

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -18,6 +18,8 @@ import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
 import { getDocument } from "@/services/firestoreService";
 import { useLookupLists } from "@/hooks/useLookupLists";
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 
 type OnboardingScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -68,10 +70,10 @@ export default function OnboardingScreen() {
       if (uid) {
         await saveUsernameAndProceed(username.trim());
         await updateUserFields(uid, {
-          religion,
           region,
           organizationId: organization || undefined,
         });
+        await updateDoc(doc(db, 'users', uid), { religion });
         await completeOnboarding(uid);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         useUserStore.getState().updateUser({

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -84,9 +84,9 @@ export default function ChallengeScreen() {
 
       const blessing = await sendGeminiPrompt({
         url: ASK_GEMINI_SIMPLE,
-        prompt: `Provide a short blessing for a user who reached a ${current}-day spiritual challenge streak in the ${userData.religion || 'Christian'} tradition.`,
+        prompt: `Provide a short blessing for a user who reached a ${current}-day spiritual challenge streak in the ${userData?.religion ?? 'SpiritGuide'} tradition.`,
         history: [],
-        religion: userData.religion,
+        religion: userData?.religion ?? 'SpiritGuide',
       });
       if (blessing) {
         Alert.alert('Blessing!', `${blessing}\nYou earned ${reward} Grace Tokens.`);
@@ -141,7 +141,7 @@ export default function ChallengeScreen() {
         return;
       }
 
-      const religion = userData.religion || 'spiritual';
+      const religion = userData?.religion ?? 'SpiritGuide';
 
       const prompt =
         `Give me a short daily challenge for the ${religion} faith on ${new Date().toDateString()}.`;

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -93,7 +93,7 @@ export default function TriviaScreen() {
         url: ASK_GEMINI_SIMPLE,
         prompt: `Give me a short moral story originally from any major world religion. Replace all real names and locations with fictional ones so that it seems to come from a different culture. Keep the meaning and lesson intact. After the story, add two lines: RELIGION: <religion> and STORY: <story name>.`,
         history: [],
-        religion: user?.religion,
+        religion: user?.religion ?? 'SpiritGuide',
       });
       if (!data) {
         Alert.alert('Error', 'Could not load trivia. Please try again later.');

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -9,9 +9,6 @@ import { useUser } from '@/hooks/useUser';
 import { useUserStore } from '@/state/userStore';
 import { getTokenCount } from '@/utils/TokenManager';
 import { getDocument, setDocument } from '@/services/firestoreService';
-import axios from 'axios';
-import { FIRESTORE_BASE } from '../../../firebaseRest';
-import { getIdToken } from '@/utils/authUtils';
 import { useLookupLists } from '@/hooks/useLookupLists';
 import { updateUserFields } from '@/services/userService';
 import { useTheme } from '@/components/theme/theme';
@@ -21,6 +18,8 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
 import AuthGate from '@/components/AuthGate';
 import { useAuth } from '@/hooks/useAuth';
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 
 export default function ProfileScreen() {
   const { user } = useUser();
@@ -105,14 +104,9 @@ export default function ProfileScreen() {
     if (!uidVal) return;
     setReligionUpdating(true);
     console.log('➡️ Updating religion to', value);
-    const body = { fields: { religion: { stringValue: value } } };
     try {
-      const token = await getIdToken(true);
-      const url = `${FIRESTORE_BASE}/users/${uidVal}`;
-      const res = await axios.patch(url, body, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      console.log('✅ Religion update response', res.data);
+      await updateDoc(doc(db, 'users', uidVal), { religion: value });
+      console.log('✅ Religion updated');
       updateUser({ religion: value });
       await setDocument(`users/${uidVal}`, { lastChallenge: null });
       Alert.alert('Religion Updated');

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -115,7 +115,7 @@ export async function loadUser(uid: string): Promise<void> {
       username: user.username ?? '',
       displayName: user.displayName ?? "",
       isSubscribed: user.isSubscribed,
-      religion: user.religion,
+      religion: user?.religion ?? 'SpiritGuide',
       region: user.region ?? "",
       organizationId: user.organizationId,
       onboardingComplete: user.onboardingComplete,
@@ -134,7 +134,7 @@ export async function createUserProfile({
   email,
   displayName,
   username,
-  religion = "Christian",
+  religion = "SpiritGuide",
   region = "",
   organizationId,
 }: {

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -230,7 +230,7 @@ export const awardPointsToUser = functions
           return;
         }
         const userData = userSnap.data() || {};
-        const religionId = userData.religion;
+        const religionId = userData?.religion ?? "SpiritGuide";
         const organizationId = userData.organizationId;
 
         await db.runTransaction(async (t) => {
@@ -802,7 +802,7 @@ export const skipDailyChallenge = functions
         weekStart = now;
       }
       cost = newSkipCount === 0 ? 0 : Math.pow(2, newSkipCount);
-      const tokens = data.tokens || 0;
+      const tokens = data?.tokens ?? 0;
       if (tokens < cost) {
         return false;
       }
@@ -1455,12 +1455,14 @@ export const onUserCreate = functions
   .user()
   .onCreate(async (user: admin.auth.UserRecord) => {
     const uid = user.uid;
-    logger.info(`onUserCreate triggered for ${uid}`);
+    console.log(`onUserCreate triggered for ${uid}`);
     try {
       const timestamp = admin.firestore.FieldValue.serverTimestamp();
       await db.collection("users").doc(uid).set({
         uid,
         email: user.email || "",
+        displayName: user.displayName || "New User",
+        emailVerified: user.emailVerified || false,
         createdAt: timestamp,
         isSubscribed: false,
         lastFreeAsk: timestamp,
@@ -1475,15 +1477,15 @@ export const onUserCreate = functions
       });
 
       await Promise.all([
-        db.collection("journalEntries").doc(uid).set({ entries: [] }),
-        db.collection("confessionalSessions").doc(uid).set({ messages: [] }),
+        db.collection("journalEntries").doc(uid).set({ placeholder: true }),
+        db.collection("confessionalSessions").doc(uid).set({ placeholder: true }),
         db.collection("dailyChallenges").doc(uid).set({ seenChallenges: [] }),
         db.collection("leaderboards").doc(uid).set({ score: 0 }),
         db.collection("tokens").doc(uid).set({ earned: 0, spent: 0 }),
       ]);
 
-      logger.info(`onUserCreate completed for ${uid}`);
+      console.log(`onUserCreate completed for ${uid}`);
     } catch (err) {
-      logger.error(`onUserCreate failed for ${uid}`, err);
+      console.error(`onUserCreate failed for ${uid}`, err);
     }
   });


### PR DESCRIPTION
## Summary
- seed user document with default fields and related collections when a Firebase Auth user is created
- read religion and other fields safely throughout the app
- update onboarding and profile flows to set religion with `updateDoc`
- default religion constant switched to `SpiritGuide`

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686a0ce5e9748330b23d39456932f054