### PR TITLE
Remove Firebase SDK usage from onboarding/profile screens

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -18,8 +18,6 @@ import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
 import { getDocument } from "@/services/firestoreService";
 import { useLookupLists } from "@/hooks/useLookupLists";
-import { doc, updateDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
 
 type OnboardingScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -71,9 +69,9 @@ export default function OnboardingScreen() {
         await saveUsernameAndProceed(username.trim());
         await updateUserFields(uid, {
           region,
+          religion,
           organizationId: organization || undefined,
         });
-        await updateDoc(doc(db, 'users', uid), { religion });
         await completeOnboarding(uid);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         useUserStore.getState().updateUser({

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -18,8 +18,6 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
 import AuthGate from '@/components/AuthGate';
 import { useAuth } from '@/hooks/useAuth';
-import { doc, updateDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
 
 export default function ProfileScreen() {
   const { user } = useUser();
@@ -105,7 +103,7 @@ export default function ProfileScreen() {
     setReligionUpdating(true);
     console.log('➡️ Updating religion to', value);
     try {
-      await updateDoc(doc(db, 'users', uidVal), { religion: value });
+      await updateUserFields(uidVal, { religion: value });
       console.log('✅ Religion updated');
       updateUser({ religion: value });
       await setDocument(`users/${uidVal}`, { lastChallenge: null });


### PR DESCRIPTION
## Summary
- remove `firebase/firestore` imports from onboarding and profile screens
- update onboarding and profile flows to use `updateUserFields` REST call for updating religion

## Testing
- `npx jest --runInBand` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686a1630d274833081add5fd8e6c5f2b