### PR TITLE
Add EAS pre-install script

### DIFF
--- a/eas-build-pre-install.sh
+++ b/eas-build-pre-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running eas-build-pre-install.sh" 
+
+if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
+  echo "GOOGLE_SERVICES_JSON environment variable is missing" >&2
+  exit 1
+fi
+
+OUTPUT_DIR="android/app"
+mkdir -p "$OUTPUT_DIR"
+
+echo "$GOOGLE_SERVICES_JSON" | base64 --decode > "$OUTPUT_DIR/google-services.json"
+
+echo "google-services.json written to $OUTPUT_DIR/google-services.json"
+


### PR DESCRIPTION
## Summary
- add `eas-build-pre-install.sh` for decoding the google services secret

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac25dde1c8330b81cecbe854011d9