### PR TITLE
Check uid/religion before AI calls

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -98,7 +98,11 @@ export default function ConfessionalScreen() {
       console.log('Using token', token.slice(0, 10));
 
       const userData = await getDocument(`users/${uid}`);
-      const religion = userData?.religion ?? 'SpiritGuide';
+      const religion = userData?.religion;
+      if (!uid || !religion) {
+        console.warn('⚠️ Confessional blocked — missing uid or religion', { uid, religion });
+        return;
+      }
       const role = getPersonaPrompt(religion);
       console.log('👤 Persona resolved', { religionId: religion, role });
 

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -183,6 +183,10 @@ export default function JournalScreen() {
       console.log('Firebase currentUser:', await getCurrentUserId());
       const token = await getToken(true);
       console.log('ID Token:', token);
+      if (!uid || !religion) {
+        console.warn('⚠️ askGemini blocked — missing uid or religion', { uid, religion });
+        return;
+      }
       const answer = await sendGeminiPrompt({
         url: ASK_GEMINI_SIMPLE,
         prompt,

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -183,7 +183,12 @@ export default function ReligionAIScreen() {
       setIsSubscribed(subscribed);
       console.log('💎 OneVine+ Status:', subscribed);
 
-      const religion = userData?.religion ?? 'SpiritGuide';
+      const religion = userData?.religion;
+      if (!uid || !religion) {
+        console.warn('⚠️ askGemini blocked — missing uid or religion', { uid, religion });
+        setLoading(false);
+        return;
+      }
       const promptRole = getPersonaPrompt(religion);
       console.log('👤 Persona resolved', { religion, promptRole });
 

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -82,11 +82,20 @@ export default function ChallengeScreen() {
         streakMilestones: { ...granted, [key]: true },
       });
 
+      const religion = userData?.religion;
+      if (!uid || !religion) {
+        console.warn('⚠️ Challenge generation blocked — missing uid or religion', {
+          uid,
+          religion,
+        });
+        return;
+      }
+
       const blessing = await sendGeminiPrompt({
         url: ASK_GEMINI_SIMPLE,
-        prompt: `Provide a short blessing for a user who reached a ${current}-day spiritual challenge streak in the ${userData?.religion ?? 'SpiritGuide'} tradition.`,
+        prompt: `Provide a short blessing for a user who reached a ${current}-day spiritual challenge streak in the ${religion} tradition.`,
         history: [],
-        religion: userData?.religion ?? 'SpiritGuide',
+        religion,
       });
       if (blessing) {
         Alert.alert('Blessing!', `${blessing}\nYou earned ${reward} Grace Tokens.`);
@@ -141,7 +150,12 @@ export default function ChallengeScreen() {
         return;
       }
 
-      const religion = userData?.religion ?? 'SpiritGuide';
+      const religion = userData?.religion;
+      if (!uid || !religion) {
+        console.warn('⚠️ Challenge generation blocked — missing uid or religion', { uid, religion });
+        setLoading(false);
+        return;
+      }
 
       const prompt =
         `Give me a short daily challenge for the ${religion} faith on ${new Date().toDateString()}.`;
@@ -225,7 +239,11 @@ export default function ChallengeScreen() {
 
     try {
       const userData = (await getDocument(`users/${uid}`)) || {};
-      const religion = userData?.religion ?? 'SpiritGuide';
+      const religion = userData?.religion;
+      if (!uid || !religion) {
+        console.warn('⚠️ Challenge generation blocked — missing uid or religion', { uid, religion });
+        return;
+      }
       await createMultiDayChallenge('Provide a 3-day gratitude challenge.', 3, religion);
       fetchChallenge(true);
     } catch (err) {

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -89,11 +89,18 @@ export default function TriviaScreen() {
     setAnswer('');
 
     try {
+      const religion = user?.religion;
+      if (!uid || !religion) {
+        console.warn('⚠️ askGemini blocked — missing uid or religion', { uid, religion });
+        setLoading(false);
+        return;
+      }
+
       const data = await sendGeminiPrompt({
         url: ASK_GEMINI_SIMPLE,
         prompt: `Give me a short moral story originally from any major world religion. Replace all real names and locations with fictional ones so that it seems to come from a different culture. Keep the meaning and lesson intact. After the story, add two lines: RELIGION: <religion> and STORY: <story name>.`,
         history: [],
-        religion: user?.religion ?? 'SpiritGuide',
+        religion,
       });
       if (!data) {
         Alert.alert('Error', 'Could not load trivia. Please try again later.');


### PR DESCRIPTION
## Summary
- add guard clauses for user id and religion before generating challenges
- stop AI calls in ReligionAI, Journal, Confessional, Trivia, and Challenge screens when info is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b07939b708330bea770086300034e