### PR TITLE
Remove updateUserFields helper and adjust Firestore rules

### DIFF
--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -186,28 +186,3 @@ export async function completeOnboarding(uid: string) {
   await setDocument(`users/${storedUid}`, { onboardingComplete: true });
 }
 
-/**
- * Update religion or subscription status
- */
-export async function updateUserFields(
-  uid: string,
-  updates: Partial<FirestoreUser>,
-) {
-  const storedUid = await ensureAuth(uid);
-  if (!storedUid) return;
-
-  const filtered = Object.fromEntries(
-    Object.entries(updates).filter(([k, v]) => {
-      if (v === undefined) return false;
-      if (k === 'username' && typeof v === 'string' && v.trim() === '') {
-        return false;
-      }
-      if (k === 'region' && typeof v === 'string' && v.trim() === '') {
-        return false;
-      }
-      return true;
-    }),
-  );
-  console.log('➡️ updateUserFields payload', { uid: storedUid, ...filtered });
-  await setDocument(`users/${storedUid}`, filtered);
-}

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,7 @@ service cloud.firestore {
     // but restrict writes to the owner of the document
     match /users/{userId} {
       allow read: if request.auth != null;
-      allow create, update, delete: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
 
     // 💬 Religion Chats


### PR DESCRIPTION
## Summary
- delete unused `updateUserFields` helper
- streamline `/users/{userId}` write rule
- confirm chat and journal rules remain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b0e52f49883309a54d671367c041d