### PR TITLE
Refine user update security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,7 @@ service cloud.firestore {
     // but restrict writes to the owner of the document
     match /users/{userId} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null && request.auth.uid == userId;
+      allow create, update, delete: if request.auth != null && request.auth.uid == userId;
     }
 
     // 💬 Religion Chats


### PR DESCRIPTION
## Summary
- remove obsolete update function and rely on `updateUserProfile`
- restrict user document writes in Firestore rules to the authenticated owner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0f56f7dc83309879be1bf8ff392e