### PR TITLE
Centralize user profile writes

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -16,6 +16,7 @@ import { useTheme } from "@/components/theme/theme";
 import { showGracefulError } from '@/utils/gracefulError';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { querySubcollection, addDocument, getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { callFunction, awardPointsToUser } from '@/services/functionService';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { ensureAuth } from '@/utils/authGuard';
@@ -237,7 +238,7 @@ export default function JournalScreen() {
       });
       console.log('✅ Journal entry saved');
 
-      await setDocument(`users/${uid}`, {
+      await updateUserProfile(uid, {
         individualPoints: (userData.individualPoints || 0) + 2,
       });
 

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -19,6 +19,7 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
 import { ASK_GEMINI_V2 } from "@/utils/constants";
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { useUser } from '@/hooks/useUser';
 import { ensureAuth } from '@/utils/authGuard';
 import { getToken, getCurrentUserId } from '@/utils/TokenManager';
@@ -219,7 +220,7 @@ export default function ReligionAIScreen() {
 
           await setTokenCount(tokens - cost);
         } else {
-          await setDocument(`users/${uid}`, { lastFreeAsk: new Date().toISOString() });
+          await updateUserProfile(uid, { lastFreeAsk: new Date().toISOString() });
         }
       }
 

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -12,6 +12,7 @@ import { useTheme } from "@/components/theme/theme";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useUser } from "@/hooks/useUser";
 import { setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { ensureAuth } from '@/utils/authGuard';
@@ -71,7 +72,7 @@ export default function SelectReligionScreen({ navigation }: Props) {
     if (!uid) return;
 
     try {
-      await setDocument(`users/${uid}`, { religion: selected });
+      await updateUserProfile(uid, { religion: selected });
 
       navigation.replace('Quote');
     } catch (err) {

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -17,6 +17,7 @@ import {
   setDocument,
   getOrCreateActiveChallenge,
 } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { canLoadNewChallenge } from '@/services/challengeLimitService';
 import { completeChallengeWithStreakCheck } from '@/services/challengeStreakService';
 import {
@@ -78,7 +79,7 @@ export default function ChallengeScreen() {
       const reward = current >= 30 ? 10 : current >= 14 ? 7 : 5;
       const tokens = await getTokenCount();
       await setTokenCount(tokens + reward);
-      await setDocument(`users/${uid}`, {
+      await updateUserProfile(uid, {
         streakMilestones: { ...granted, [key]: true },
       });
 
@@ -181,7 +182,7 @@ export default function ChallengeScreen() {
         setChallenge(newChallenge);
       }
 
-      await setDocument(`users/${uid}`, {
+      await updateUserProfile(uid, {
         lastChallenge: new Date().toISOString(),
         lastChallengeText: newChallenge || '',
       });
@@ -220,7 +221,7 @@ export default function ChallengeScreen() {
     }
 
     try {
-      await setDocument(`users/${uid}`, {
+      await updateUserProfile(uid, {
         tokens: tokens - skipCost,
         dailySkipCount: dailySkipCount + 1,
         lastSkipDate: new Date().toISOString(),
@@ -301,7 +302,7 @@ export default function ChallengeScreen() {
     }
 
     history.completed += 1;
-    await setDocument(`users/${uid}`, { dailyChallengeHistory: history });
+    await updateUserProfile(uid, { dailyChallengeHistory: history });
     try {
       console.log('Current user:', await getCurrentUserId());
       const cfToken = await getToken(true);
@@ -328,7 +329,7 @@ export default function ChallengeScreen() {
     const currentTokens = await getTokenCount();
     await setTokenCount(currentTokens + 1);
 
-    await setDocument(`users/${uid}`, {
+    await updateUserProfile(uid, {
       individualPoints: (userData.individualPoints || 0) + 2,
     });
 

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -16,6 +16,7 @@ import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { callFunction, awardPointsToUser } from '@/services/functionService';
 import { ensureAuth } from '@/utils/authGuard';
 import AuthGate from '@/components/AuthGate';
@@ -138,7 +139,7 @@ export default function TriviaScreen() {
       const earned = (religionCorrect ? 1 : 0) + (storyCorrect ? 5 : 0);
 
       if (earned > 0) {
-        await setDocument(`users/${uid}`, {
+        await updateUserProfile(uid, {
           individualPoints: (userData.individualPoints || 0) + earned,
         });
 

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -12,6 +12,7 @@ import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { queryCollection, setDocument, getDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { getAuthHeaders } from '@/utils/TokenManager';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';
@@ -100,7 +101,7 @@ export default function JoinOrganizationScreen() {
     const uid = await ensureAuth(user.uid);
     if (!uid) return;
     try {
-      await setDocument(`users/${uid}`, {
+      await updateUserProfile(uid, {
         organizationId: null,
         organizationName: null,
       });
@@ -151,7 +152,7 @@ export default function JoinOrganizationScreen() {
     }
 
     try {
-      await setDocument(`users/${uid}`, {
+      await updateUserProfile(uid, {
         organizationId: org.id,
         organizationName: org.name,
       });

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -106,7 +106,7 @@ export default function ProfileScreen() {
       await updateUserProfile({ religion: value });
       console.log('✅ Religion updated');
       updateUser({ religion: value });
-      await setDocument(`users/${uidVal}`, { lastChallenge: null });
+      await updateUserProfile(uidVal, { lastChallenge: null });
       Alert.alert('Religion Updated');
     } catch (err: any) {
       console.error('Religion update failed', err);

--- a/App/services/challengeLimitService.ts
+++ b/App/services/challengeLimitService.ts
@@ -1,5 +1,6 @@
 import { Alert } from 'react-native';
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { getCurrentUserId } from '@/utils/TokenManager';
 import { ensureAuth } from '@/utils/authGuard';
 
@@ -27,7 +28,7 @@ export async function canLoadNewChallenge(): Promise<boolean> {
   }
 
   if (isSubscribed || dailyChallengeCount < 3) {
-    await setDocument(`users/${uid}`, {
+    await updateUserProfile(uid, {
       dailyChallengeCount: dailyChallengeCount + 1,
       lastChallengeLoadDate: new Date().toISOString(),
     });
@@ -42,7 +43,7 @@ export async function canLoadNewChallenge(): Promise<boolean> {
     return false;
   }
 
-  await setDocument(`users/${uid}`, {
+  await updateUserProfile(uid, {
     tokens: tokens - 5,
     dailyChallengeCount: dailyChallengeCount + 1,
     lastChallengeLoadDate: new Date().toISOString(),

--- a/App/services/challengeStreakService.ts
+++ b/App/services/challengeStreakService.ts
@@ -1,4 +1,5 @@
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { getCurrentUserId } from '@/utils/TokenManager';
 import { ensureAuth } from '@/utils/authGuard';
 
@@ -21,7 +22,7 @@ export async function completeChallengeWithStreakCheck(): Promise<number | null>
     newCount += 1;
   }
 
-  await setDocument(`users/${userId}`, {
+  await updateUserProfile(userId, {
     challengeStreak: {
       count: newCount,
       lastCompletedDate: new Date().toISOString(),

--- a/App/services/onboardingService.ts
+++ b/App/services/onboardingService.ts
@@ -1,10 +1,11 @@
 import { navigationRef } from '@/navigation/navigationRef';
 import { setDocument, getDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { ensureAuth } from '@/utils/authGuard';
 
 export async function saveUsernameAndProceed(username: string): Promise<void> {
   const uid = await ensureAuth();
-  await setDocument(`users/${uid}`, { username });
+  await updateUserProfile(uid, { username });
   if (navigationRef.isReady()) {
     navigationRef.reset({ index: 0, routes: [{ name: 'Home' }] });
   }

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -1,4 +1,5 @@
 import { getDocument, setDocument } from "@/services/firestoreService";
+import { updateUserProfile } from "@/utils/firestoreHelpers";
 import { useUserStore } from "@/state/userStore";
 import { ensureAuth } from "@/utils/authGuard";
 
@@ -51,7 +52,7 @@ export async function initializeUserDataIfNeeded(uid: string): Promise<void> {
   }
 
   if (Object.keys(payload).length > 0) {
-    await setDocument(`users/${uid}`, payload);
+    await updateUserProfile(uid, payload);
   }
 }
 
@@ -70,7 +71,7 @@ export async function ensureUserDocExists(
     if (err?.response?.status === 404) {
       const payload: any = { uid, createdAt: Date.now(), individualPoints: 0 };
       if (email) payload.email = email;
-      await setDocument(`users/${uid}`, payload);
+      await updateUserProfile(uid, payload);
       console.log("📄 Created user doc for", uid);
       return true;
     }
@@ -173,7 +174,7 @@ export async function createUserProfile({
     (userData as any).organizationId = organizationId;
   }
 
-  await setDocument(`users/${storedUid}`, userData);
+  await updateUserProfile(storedUid, userData);
 }
 
 /**
@@ -183,6 +184,6 @@ export async function completeOnboarding(uid: string) {
   const storedUid = await ensureAuth(uid);
   if (!storedUid) return;
 
-  await setDocument(`users/${storedUid}`, { onboardingComplete: true });
+  await updateUserProfile(storedUid, { onboardingComplete: true });
 }
 

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { ensureAuth } from '@/utils/authGuard';
 
 interface ChallengeStore {
@@ -53,9 +54,11 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
 
     const { lastCompleted, streak } = get();
     const payload = {
-      lastStreakDate: lastCompleted ? new Date(lastCompleted).toISOString() : new Date().toISOString(),
+      lastStreakDate: lastCompleted
+        ? new Date(lastCompleted).toISOString()
+        : new Date().toISOString(),
       streak,
     };
-    await setDocument(`users/${uid}`, payload);
+    await updateUserProfile(uid, payload);
   },
 }));

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,4 +1,5 @@
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { updateUserProfile } from '@/utils/firestoreHelpers';
 import { ensureAuth } from '@/utils/authGuard';
 
 export const getTokenCount = async () => {
@@ -19,7 +20,7 @@ export const setTokenCount = async (count: number) => {
   const uid = await ensureAuth();
   if (!uid) return;
 
-  await setDocument(`users/${uid}`, { tokens: count });
+  await updateUserProfile(uid, { tokens: count });
   console.log('🪙 Token count:', count);
 };
 
@@ -59,7 +60,7 @@ export const syncSubscriptionStatus = async () => {
   const isSubscribed = !!sub && sub.active === true;
   console.log('💎 OneVine+ Status:', isSubscribed);
   if (isSubscribed) {
-    await setDocument(`users/${uid}`, { tokens: 9999 });
+    await updateUserProfile(uid, { tokens: 9999 });
   }
 };
 

--- a/utils/firestoreHelpers.ts
+++ b/utils/firestoreHelpers.ts
@@ -1,8 +1,16 @@
 import { doc, setDoc } from "firebase/firestore";
 import { auth, db } from "../lib/firebase";
 
-export async function updateUserProfile(fields: Record<string, any>) {
-  const uid = auth.currentUser?.uid;
+// 🚨 Centralized user update function. All profile field changes must go through here.
+export async function updateUserProfile(
+  uidOrFields: string | Record<string, any>,
+  maybeFields?: Record<string, any>,
+) {
+  const uid =
+    typeof uidOrFields === "string" ? uidOrFields : auth.currentUser?.uid;
+  const fields =
+    typeof uidOrFields === "string" ? maybeFields || {} : uidOrFields;
+
   if (!uid) {
     console.warn("\u274C No UID available for user update.");
     return;


### PR DESCRIPTION
## Summary
- add UID param support to `updateUserProfile` and mark as centralized helper
- refactor all user profile updates in services and screens to use `updateUserProfile`
- remove direct calls to `setDocument` on `/users/{uid}` docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b10a1ae88833080c78eb84621cfdc