### PR TITLE
Remove Firestore SDK usage

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -83,7 +83,10 @@ export default function OnboardingScreen() {
           region: check?.region,
           religion: check?.religion,
         });
-        navigation.reset({ index: 0, routes: [{ name: SCREENS.MAIN.HOME }] });
+        navigation.reset({
+          index: 0,
+          routes: [{ name: 'Home' as keyof RootStackParamList }],
+        });
       }
     } catch (err: any) {
       Alert.alert(

--- a/utils/firestoreHelpers.ts
+++ b/utils/firestoreHelpers.ts
@@ -1,5 +1,6 @@
-import { doc, setDoc } from "firebase/firestore";
-import { auth, db } from "../lib/firebase";
+import axios from 'axios';
+import { API_URL, getAuthHeaders } from '../App/config/firebaseApp';
+import { getCurrentUserId } from '../App/utils/authUtils';
 
 // 🚨 Centralized user update function. All profile field changes must go through here.
 export async function updateUserProfile(
@@ -7,9 +8,11 @@ export async function updateUserProfile(
   maybeFields?: Record<string, any>,
 ) {
   const uid =
-    typeof uidOrFields === "string" ? uidOrFields : auth.currentUser?.uid;
+    typeof uidOrFields === 'string'
+      ? uidOrFields
+      : await getCurrentUserId();
   const fields =
-    typeof uidOrFields === "string" ? maybeFields || {} : uidOrFields;
+    typeof uidOrFields === 'string' ? maybeFields || {} : uidOrFields;
 
   if (!uid) {
     console.warn("\u274C No UID available for user update.");
@@ -17,9 +20,10 @@ export async function updateUserProfile(
   }
 
   try {
-    await setDoc(doc(db, "users", uid), fields, { merge: true });
-    console.log("\u2705 Profile updated:", fields);
+    const headers = await getAuthHeaders();
+    await axios.patch(`${API_URL}/users/${uid}`, fields, { headers });
+    console.log('✅ Profile updated:', fields);
   } catch (error) {
-    console.error("\uD83D\uDD25 Failed to update user profile:", error);
+    console.error('🔥 Failed to update user profile:', error);
   }
 }


### PR DESCRIPTION
## Summary
- switch `updateUserProfile` to use REST API instead of Firestore SDK
- type navigation reset call in `OnboardingScreen`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b259732208330a27fe7bfa12f975b