### PR TITLE
Implement religion-based prompts and profile updates

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -63,12 +63,14 @@ export default function OnboardingScreen() {
     console.log('💾 Submitting onboarding', { username, region, religion });
     try {
       if (uid) {
-        await updateUserProfile({
-          username: username.trim(),
+        const fields = {
+          displayName: username.trim(),
           region,
           religion,
           onboardingComplete: true,
-        });
+        };
+        console.log('🔧 updateUserProfile', { uid, ...fields });
+        await updateUserProfile(fields);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         useUserStore.getState().updateUser({
           onboardingComplete: true,

--- a/functions/addReligionPrompts.ts
+++ b/functions/addReligionPrompts.ts
@@ -1,0 +1,31 @@
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+const prompts: Record<string, string> = {
+  christianity:
+    'Respond as a compassionate Christian spiritual guide, with love, grace, and biblical wisdom.',
+  islam:
+    'Respond as a thoughtful Islamic scholar, grounded in the Quran and Hadith, with empathy and care.',
+};
+
+export async function addReligionPrompts() {
+  const ops = Object.entries(prompts).map(([id, prompt]) =>
+    db.collection('religions').doc(id).set({ prompt }, { merge: true })
+  );
+  await Promise.all(ops);
+  console.log('Added prompts for', Object.keys(prompts).length, 'religions');
+}
+
+if (require.main === module) {
+  addReligionPrompts()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error('Failed to add religion prompts', err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- update onboarding profile update call and log
- add PATCH /users/:uid route
- script to seed religion prompts
- use religionRef prompt in chat functions
- increment religion total points during challenge completion

## Testing
- `npx jest` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686b3078b6108330b6aa1305f71cf6d2