### PR TITLE
Final sweep: onboarding slug + logging

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -66,7 +66,7 @@ export default function OnboardingScreen() {
         const fields = {
           displayName: username.trim(),
           region,
-          religion,
+          religionSlug: religion,
           onboardingComplete: true,
         };
         console.log('🔧 updateUserProfile', { uid, ...fields });

--- a/server/leaderboard.ts
+++ b/server/leaderboard.ts
@@ -9,6 +9,8 @@ export async function incrementUserReligionOrgPoints(uid: string, points: number
   const religion = data.religion as string | undefined;
   const organizationId = data.organizationId as string | undefined;
 
+  console.log('➡️ incrementUserReligionOrgPoints', { uid, points, religion, organizationId });
+
   await db.runTransaction(async (t: any) => {
     if (religion) {
       const ref = db.collection('religions').doc(religion);
@@ -23,4 +25,6 @@ export async function incrementUserReligionOrgPoints(uid: string, points: number
       t.set(ref, { name: organizationId, totalPoints: current + points }, { merge: true });
     }
   });
+
+  console.log('✅ incrementUserReligionOrgPoints complete', { uid, points });
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -84,6 +84,7 @@ app.patch('/users/:uid', verifyFirebaseIdToken, async (req: AuthedRequest, res) 
 
   const { religionId, religionSlug, ...fields } = req.body || {};
   try {
+    console.log('➡️ /users PATCH', { uid, religionId, religionSlug, fields });
     let relId = religionId as string | undefined;
     if (!relId && religionSlug) {
       const q = await db.collection('religions').where('slug', '==', religionSlug).limit(1).get();
@@ -97,6 +98,7 @@ app.patch('/users/:uid', verifyFirebaseIdToken, async (req: AuthedRequest, res) 
     }
 
     await db.collection('users').doc(uid).set(fields, { merge: true });
+    console.log('✅ user updated', { uid, fields });
     res.json({ success: true });
   } catch (err) {
     console.error('update user failed', err);

--- a/utils/firestoreHelpers.ts
+++ b/utils/firestoreHelpers.ts
@@ -21,6 +21,7 @@ export async function updateUserProfile(
 
   try {
     const headers = await getAuthHeaders();
+    console.log('➡️ PATCH /users', { uid, fields });
     await axios.patch(`${API_URL}/users/${uid}`, fields, { headers });
     console.log('✅ Profile updated:', fields);
   } catch (error) {


### PR DESCRIPTION
## Summary
- pass religionSlug in OnboardingScreen so backend resolves the reference
- log REST patch calls from `updateUserProfile`
- log before/after `/users/:uid` patch on the server
- add logging around religion/org point increments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3699a1208330963ef6ed37de501a