### PR TITLE
Ensure REST-based onboarding uses religion field

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -66,6 +66,7 @@ export default function OnboardingScreen() {
         const fields = {
           displayName: username.trim(),
           region,
+          religion,
           religionSlug: religion,
           onboardingComplete: true,
         };


### PR DESCRIPTION
## Summary
- add religion field to onboarding payload so both `religion` and `religionSlug` reach the server
- repository already confirms REST-only Firestore access and increments leaderboard points

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b383b5570833082ece9cafb343482