### PR TITLE
Add userProfile helper module

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useUser } from '@/hooks/useUser';
 import { useUserStore } from '@/state/userStore';
 import { initAuthState } from '@/services/authService';
-import { fetchUserProfile } from '@/services/userService';
+import { loadUserProfile } from '../../utils/userProfile';
 
 // Auth Screens
 import LoginScreen from '@/screens/auth/LoginScreen';
@@ -72,7 +72,7 @@ export default function AuthGate() {
       let profile = useUserStore.getState().user;
       if (!profile || profile.uid !== uid) {
         try {
-          const fetched = await fetchUserProfile(uid);
+          const fetched = await loadUserProfile(uid);
           if (fetched) {
             useUserStore.getState().setUser({
               uid: fetched.uid,

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -19,7 +19,7 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
 import { ASK_GEMINI_V2 } from "@/utils/constants";
 import { getDocument, setDocument } from '@/services/firestoreService';
-import { updateUserProfile } from '../../utils/firestoreHelpers';
+import { updateUserProfile, getUserAIPrompt } from '../../utils/userProfile';
 import { useUser } from '@/hooks/useUser';
 import { ensureAuth } from '@/utils/authGuard';
 import { getToken, getCurrentUserId } from '@/utils/TokenManager';
@@ -191,7 +191,8 @@ export default function ReligionAIScreen() {
         return;
       }
       const promptRole = getPersonaPrompt(religion);
-      console.log('👤 Persona resolved', { religion, promptRole });
+      const basePrompt = getUserAIPrompt();
+      console.log('👤 Persona resolved', { religion, promptRole, basePrompt });
 
       if (!subscribed) {
         if (!canAskFree) {
@@ -232,7 +233,7 @@ export default function ReligionAIScreen() {
       }));
 
       const prompt =
-        `You are a ${promptRole} of the ${religion} faith. Answer the user using teachings from that tradition and cite any relevant scriptures.\n${question}`;
+        `${basePrompt || `You are a ${promptRole} of the ${religion} faith. Answer the user using teachings from that tradition and cite any relevant scriptures.`}\n${question}`;
       console.log('📡 Sending Gemini prompt:', prompt);
       console.log('👤 Role:', promptRole);
 

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -6,7 +6,8 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
-import { ensureUserDocExists, fetchUserProfile } from "@/services/userService";
+import { ensureUserDocExists } from "@/services/userService";
+import { loadUserProfile } from "../../../utils/userProfile";
 import { checkIfUserIsNewAndRoute } from "@/services/onboardingService";
 import { useUserStore } from "@/state/userStore";
 import { useAuthStore } from "@/state/authStore";
@@ -33,7 +34,7 @@ export default function LoginScreen() {
       if (result.localId) {
         setUid(result.localId);
         await ensureUserDocExists(result.localId, result.email);
-        const profile = await fetchUserProfile(result.localId);
+        const profile = await loadUserProfile(result.localId);
         if (profile) {
           useUserStore.getState().setUser({
             uid: profile.uid,

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -6,7 +6,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from "@/components/common/Button";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { updateUserProfile } from "../../../utils/firestoreHelpers";
+import { updateUserProfile } from "../../../utils/userProfile";
 import { useUserStore } from "@/state/userStore";
 import { useAuthStore } from "@/state/authStore";
 import { SCREENS } from "@/navigation/screens";

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -10,7 +10,7 @@ import { useUserStore } from '@/state/userStore';
 import { getTokenCount } from '@/utils/TokenManager';
 import { getDocument, setDocument } from '@/services/firestoreService';
 import { useLookupLists } from '@/hooks/useLookupLists';
-import { updateUserProfile } from '../../../utils/firestoreHelpers';
+import { updateUserProfile } from '../../../utils/userProfile';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';

--- a/utils/userProfile.ts
+++ b/utils/userProfile.ts
@@ -1,0 +1,83 @@
+import axios from 'axios';
+import { API_URL, getAuthHeaders } from '../App/config/firebaseApp';
+import { getCurrentUserId } from '../App/utils/authUtils';
+import { getDocument } from '../App/services/firestoreService';
+
+export interface ReligionData {
+  id: string;
+  name?: string;
+  aiVoice?: string;
+  prompt?: string;
+  defaultChallenges?: any[];
+  totalPoints?: number;
+}
+
+export interface UserProfile {
+  uid: string;
+  displayName?: string;
+  username?: string;
+  region?: string;
+  religion: string;
+  points?: number;
+  streak?: number;
+  currentChallenge?: any;
+  onboardingComplete?: boolean;
+  religionData?: ReligionData | null;
+  [key: string]: any;
+}
+
+let cachedProfile: UserProfile | null = null;
+
+export async function loadUserProfile(uid?: string): Promise<UserProfile | null> {
+  const userId = uid ?? (await getCurrentUserId());
+  if (!userId) {
+    console.warn('loadUserProfile called with no uid');
+    return null;
+  }
+
+  try {
+    const user = await getDocument(`users/${userId}`);
+    if (!user) return null;
+    let religionData: ReligionData | null = null;
+    if (user.religion) {
+      religionData = await getDocument(`religions/${user.religion}`);
+      if (religionData && !('prompt' in religionData)) {
+        console.log(`⚠️ Religion ${user.religion} missing 'prompt' field`);
+      }
+    }
+    cachedProfile = { uid: userId, ...user, religionData } as UserProfile;
+    return cachedProfile;
+  } catch (err) {
+    console.error('loadUserProfile failed', err);
+    return null;
+  }
+}
+
+export async function updateUserProfile(
+  fields: Record<string, any>,
+  uid?: string,
+): Promise<void> {
+  const userId = uid ?? (await getCurrentUserId());
+  if (!userId) {
+    console.warn('updateUserProfile called with no uid');
+    return;
+  }
+  try {
+    const headers = await getAuthHeaders();
+    await axios.patch(`${API_URL}/users/${userId}`, fields, { headers });
+    if (cachedProfile && cachedProfile.uid === userId) {
+      cachedProfile = { ...cachedProfile, ...fields };
+    }
+    console.log('✅ Profile updated', fields);
+  } catch (err) {
+    console.error('updateUserProfile failed', err);
+  }
+}
+
+export function getCachedUserProfile(): UserProfile | null {
+  return cachedProfile;
+}
+
+export function getUserAIPrompt(): string {
+  return cachedProfile?.religionData?.prompt || '';
+}


### PR DESCRIPTION
## Summary
- add `utils/userProfile.ts` for loading and updating profiles
- use `loadUserProfile` in login flow and AuthGate
- use unified `updateUserProfile` in onboarding and profile screens
- use religion prompt from profile in ReligionAI screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2fbf073c8330865412de9261342a