### PR TITLE
Refactor user profile utilities and AI prompts

### DIFF
--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -241,9 +241,10 @@ export default function ReligionAIScreen() {
       const debugToken = await getToken(true);
       console.log('ID Token:', debugToken);
 
+      const prefix = getUserAIPrompt();
       const answer = await sendGeminiPrompt({
         url: ASK_GEMINI_V2,
-        prompt,
+        prompt: `${prefix} ${prompt}`.trim(),
         history: formattedHistory,
         token: debugToken || undefined,
         religion,

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "@/components/theme/theme";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useUser } from "@/hooks/useUser";
 import { setDocument } from '@/services/firestoreService';
-import { updateUserProfile } from '../../../utils/firestoreHelpers';
+import { loadUserProfile, updateUserProfile } from '../../../utils/userProfile';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { ensureAuth } from '@/utils/authGuard';
@@ -73,6 +73,7 @@ export default function SelectReligionScreen({ navigation }: Props) {
 
     try {
       await updateUserProfile(uid, { religion: selected });
+      await loadUserProfile(uid);
 
       navigation.replace('Quote');
     } catch (err) {

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -12,7 +12,7 @@ import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { queryCollection, setDocument, getDocument } from '@/services/firestoreService';
-import { updateUserProfile } from '../../../utils/firestoreHelpers';
+import { loadUserProfile, updateUserProfile } from '../../../utils/userProfile';
 import { getAuthHeaders } from '@/utils/TokenManager';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';
@@ -127,7 +127,7 @@ export default function JoinOrganizationScreen() {
     const uid = await ensureAuth(user.uid);
     if (!uid) return;
 
-    const profile = await getDocument(`users/${uid}`);
+    const profile = await loadUserProfile(uid);
     if (profile?.organizationId) {
       Alert.alert(
         'Already Joined',

--- a/firestore.rules
+++ b/firestore.rules
@@ -120,10 +120,10 @@ service cloud.firestore {
       allow read: if request.auth != null;
     }
 
-    // ✅ Allow authed read + patch on religion docs
+    // ✅ Allow authed read on religion docs, restrict updates to admins
     match /religion/{religionId} {
       allow read: if request.auth != null;
-      allow update: if request.auth != null;
+      allow update: if request.auth != null && request.auth.token.admin == true;
     }
 
     // 🛐 Public religion content

--- a/functions/seedReligionFields.ts
+++ b/functions/seedReligionFields.ts
@@ -1,0 +1,30 @@
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+export async function seedReligionFields() {
+  const snap = await db.collection('religions').get();
+  const batch = db.batch();
+  snap.docs.forEach((doc) => {
+    const data = doc.data();
+    const name = data.name || doc.id;
+    batch.set(doc.ref, {
+      prompt: data.prompt || `Speak as a compassionate guide, representing the spirit of ${name}.`,
+      aiVoice: data.aiVoice || 'Voice Title',
+      language: data.language || 'en',
+      totalPoints: data.totalPoints ?? 0,
+    }, { merge: true });
+  });
+  await batch.commit();
+  console.log(`Updated ${snap.docs.length} religion docs`);
+}
+
+if (require.main === module) {
+  seedReligionFields()
+    .then(() => process.exit(0))
+    .catch((err) => { console.error('Failed to seed religions', err); process.exit(1); });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "include": [
     "App/**/*",
-    "App.tsx"
+    "App.tsx",
+    "types/**/*.d.ts"
   ]
 }

--- a/types/profile.d.ts
+++ b/types/profile.d.ts
@@ -1,0 +1,26 @@
+export interface ReligionDocument {
+  id: string;
+  name?: string;
+  aiVoice?: string;
+  prompt?: string;
+  defaultChallenges?: any[];
+  language?: string;
+  totalPoints?: number;
+}
+
+export interface UserProfile {
+  uid: string;
+  displayName?: string;
+  username?: string;
+  region?: string;
+  religion: string;
+  points?: number;
+  streak?: number;
+  currentChallenge?: any;
+  onboardingComplete?: boolean;
+  [key: string]: any;
+}
+
+export interface CachedProfile extends UserProfile {
+  religionData?: ReligionDocument | null;
+}


### PR DESCRIPTION
## Summary
- add shared profile types
- enhance caching logic in `userProfile` utils
- require admin privileges for religion updates
- seed missing religion fields
- refresh religion cache after selecting
- load profile data across screens
- prepend user-specific prompts before AI requests
- include `types/**/*.d.ts` in TS config

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c359707a88330b0c8a1f5e6a61c95