### PR TITLE
Integrate REST profiles and religion prompt cache

### DIFF
--- a/App/hooks/useUserProfile.ts
+++ b/App/hooks/useUserProfile.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState, useCallback } from 'react';
+import { loadUserProfile, updateUserProfile, getCachedUserProfile } from '../../utils/userProfile';
+import { useAuthStore } from '@/state/authStore';
+import type { UserProfile } from '../../types/profile';
+
+export function useUserProfile() {
+  const uid = useAuthStore((s) => s.uid);
+  const [profile, setProfile] = useState<UserProfile | null>(getCachedUserProfile());
+  const [loading, setLoading] = useState(!profile);
+
+  const reload = useCallback(async () => {
+    if (!uid) return;
+    setLoading(true);
+    const data = await loadUserProfile(uid);
+    setProfile(data);
+    setLoading(false);
+  }, [uid]);
+
+  const update = useCallback(
+    async (fields: Record<string, any>) => {
+      if (!uid) return;
+      await updateUserProfile(fields, uid);
+      await reload();
+    },
+    [uid, reload],
+  );
+
+  useEffect(() => {
+    if (!profile && uid) reload();
+  }, [profile, uid, reload]);
+
+  return { profile, loading, reload, update };
+}

--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -13,7 +13,7 @@ import {
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import Button from '@/components/common/Button';
 import { useTheme } from "@/components/theme/theme";
-import { getDocument } from '@/services/firestoreService';
+import { loadUserProfile } from '../../utils/userProfile';
 import { ensureAuth } from '@/utils/authGuard';
 import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { showGracefulError } from '@/utils/gracefulError';
@@ -97,7 +97,7 @@ export default function ConfessionalScreen() {
       if (!token) throw new Error('Missing token');
       console.log('Using token', token.slice(0, 10));
 
-      const userData = await getDocument(`users/${uid}`);
+      const userData = await loadUserProfile(uid);
       const religion = userData?.religion;
       if (!uid || !religion) {
         console.warn('⚠️ Confessional blocked — missing uid or religion', { uid, religion });

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -18,8 +18,7 @@ import { useTheme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
 import { ASK_GEMINI_V2 } from "@/utils/constants";
-import { getDocument, setDocument } from '@/services/firestoreService';
-import { updateUserProfile, getUserAIPrompt } from '../../utils/userProfile';
+import { loadUserProfile, updateUserProfile, getUserAIPrompt } from '../../utils/userProfile';
 import { useUser } from '@/hooks/useUser';
 import { ensureAuth } from '@/utils/authGuard';
 import { getToken, getCurrentUserId } from '@/utils/TokenManager';
@@ -122,7 +121,7 @@ export default function ReligionAIScreen() {
       }
       const uid = await ensureAuth(firebaseUid);
       try {
-        const userData = await getDocument(`users/${uid}`) || {};
+        const userData = (await loadUserProfile(uid)) || {};
         const subscribed = await checkIfUserIsSubscribed(uid);
         setIsSubscribed(subscribed);
         const hist = await fetchHistory(uid, subscribed);
@@ -174,7 +173,7 @@ export default function ReligionAIScreen() {
       const firebaseUid = await getCurrentUserId();
       const uid = await ensureAuth(firebaseUid ?? undefined);
 
-      const userData = await getDocument(`users/${uid}`) || {};
+      const userData = (await loadUserProfile(uid)) || {};
       const lastAsk = userData.lastFreeAsk?.toDate?.();
       const now = new Date();
       const oneDay = 24 * 60 * 60 * 1000;

--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, Alert } from 'react-native';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import TextField from '@/components/TextField';
 import Button from '@/components/common/Button';
-import { getDocument, queryCollection } from '@/services/firestoreService';
+import { queryCollection } from '@/services/firestoreService';
+import { loadUserProfile } from '../../../utils/userProfile';
 import { ensureAuth } from '@/utils/authGuard';
 import { useTheme } from '@/components/theme/theme';
 import { Picker } from '@react-native-picker/picker';
@@ -78,7 +79,7 @@ export default function ForgotUsernameScreen() {
 
     setLoading(true);
     try {
-      const doc = await getDocument(`users/${uid}`);
+      const doc = await loadUserProfile(uid);
       if (doc && doc.displayName === name && doc.region === region) {
         setEmail(doc.email);
       } else {

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -13,7 +13,7 @@ import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
 import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
-import { getDocument } from "@/services/firestoreService";
+import { loadUserProfile } from "../../../utils/userProfile";
 import { useLookupLists } from "@/hooks/useLookupLists";
 
 type OnboardingScreenProps = NativeStackScreenProps<
@@ -82,7 +82,7 @@ export default function OnboardingScreen() {
           region,
           religion,
         });
-        const check = await getDocument(`users/${uid}`);
+        const check = await loadUserProfile(uid);
         console.log('✅ profile after onboarding', {
           username: check?.username,
           region: check?.region,

--- a/App/screens/profile/OrganizationManagementScreen.tsx
+++ b/App/screens/profile/OrganizationManagementScreen.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator} from 'react-native';
 import Button from '@/components/common/Button';
 import { getDocument, setDocument } from '@/services/firestoreService';
+import { loadUserProfile } from '../../../utils/userProfile';
 import { useUser } from '@/hooks/useUser';
 import { getAuthHeaders } from '@/utils/TokenManager';
 import ScreenContainer from '@/components/theme/ScreenContainer';
@@ -100,7 +101,7 @@ export default function OrganizationManagementScreen() {
     if (!uid) return;
     setLoading(true);
     try {
-      const userSnap = await getDocument(`users/${uid}`);
+      const userSnap = await loadUserProfile(uid);
       const orgId = userSnap?.organizationId;
       if (!orgId) throw new Error('No organization found');
 

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -8,9 +8,9 @@ import { Picker } from '@react-native-picker/picker';
 import { useUser } from '@/hooks/useUser';
 import { useUserStore } from '@/state/userStore';
 import { getTokenCount } from '@/utils/TokenManager';
-import { getDocument } from '@/services/firestoreService';
 import { useLookupLists } from '@/hooks/useLookupLists';
-import { updateUserProfile, loadUserProfile, setCachedUserProfile } from '../../../utils/userProfile';
+import { loadUserProfile, updateUserProfile, setCachedUserProfile } from '../../../utils/userProfile';
+import { getDocument } from '@/services/firestoreService';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';
@@ -68,7 +68,7 @@ export default function ProfileScreen() {
     try {
       const [tokenCount, profile] = await Promise.all([
         getTokenCount(),
-        getDocument(`users/${uid}`),
+        loadUserProfile(uid),
       ]);
       setTokens(tokenCount);
       if (profile) {

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -132,11 +132,13 @@ export async function createUserProfile({
     uid,
     email,
     username,
-    displayName,
+    displayName: displayName || 'New User',
     religion,
     region,
     individualPoints: 0,
     isSubscribed: false,
+    skipTokensUsed: 0,
+    nightModeEnabled: false,
     onboardingComplete: false,
     createdAt: now,
     streak: { current: 0, longest: 0, lastUpdated: new Date().toISOString() },
@@ -145,7 +147,7 @@ export async function createUserProfile({
     dailySkipCount: 0,
     lastChallengeLoadDate: null,
     lastSkipDate: null,
-  };
+  } as any;
 
   if (organizationId) {
     (userData as any).organizationId = organizationId;

--- a/firestore.rules
+++ b/firestore.rules
@@ -120,15 +120,10 @@ service cloud.firestore {
       allow read: if request.auth != null;
     }
 
-    // ✅ Allow authed read on religion docs, restrict updates to admins
-    match /religion/{religionId} {
-      allow read: if request.auth != null;
-      allow update: if request.auth != null && request.auth.token.admin == true;
-    }
-
-    // 🛐 Public religion content
+    // ✅ Religion collection - read open, writes restricted to admins
     match /religion/{religionId} {
       allow read: if true;
+      allow write: if request.auth != null && request.auth.token.admin == true;
     }
 
     // 🏆 Leaderboards

--- a/server/server.ts
+++ b/server/server.ts
@@ -76,6 +76,23 @@ app.post('/leaderboard/:uid/points', verifyFirebaseIdToken, async (req: AuthedRe
   }
 });
 
+app.get('/users/:uid', verifyFirebaseIdToken, async (req: AuthedRequest, res) => {
+  const { uid } = req.params;
+  if (req.uid !== uid) {
+    return res.status(403).json({ error: 'Unauthorized' });
+  }
+  try {
+    const snap = await db.collection('users').doc(uid).get();
+    if (!snap.exists) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    res.json(snap.data());
+  } catch (err) {
+    console.error('get user failed', err);
+    res.status(500).json({ error: 'Failed to fetch user' });
+  }
+});
+
 app.patch('/users', verifyFirebaseIdToken, async (req: AuthedRequest, res) => {
   const { uid, fields } = req.body || {};
   console.log('🔧 PATCH /users request:', req.body);


### PR DESCRIPTION
## Summary
- fetch profiles via `/users/:uid` REST endpoint
- cache religion prompts with `getReligionProfile`
- reload profile with new `useUserProfile` hook
- default profile values include skip token and night mode settings
- tighten Firestore rules for `religion` collection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4b036afc8330b07fae7766720488