### PR TITLE
Fix profile typing & update user helpers

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -17,6 +17,7 @@ import { showGracefulError } from '@/utils/gracefulError';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { querySubcollection, addDocument, getDocument, setDocument } from '@/services/firestoreService';
 import { loadUserProfile, updateUserProfile, getUserAIPrompt } from '../../utils/userProfile';
+import type { UserProfile } from '../../types/profile';
 import { callFunction, awardPointsToUser } from '@/services/functionService';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { ensureAuth } from '@/utils/authGuard';
@@ -226,7 +227,8 @@ export default function JournalScreen() {
       const tokenPreview = token ? token.slice(0, 8) : 'none';
       console.log('ID Token:', tokenPreview);
 
-      const userData = (await loadUserProfile(uid)) || {};
+      const userData: UserProfile | null = await loadUserProfile(uid);
+      const profile = userData ?? ({} as UserProfile);
 
       console.log(`📝 Attempting to save journal entry for UID ${uid}`);
       const path = `journalEntries/${uid}/entries`;
@@ -239,9 +241,9 @@ export default function JournalScreen() {
       });
       console.log('✅ Journal entry saved');
 
-      await updateUserProfile(uid, {
-        individualPoints: (userData.individualPoints || 0) + 2,
-      });
+      await updateUserProfile({
+        individualPoints: (profile.individualPoints || 0) + 2,
+      }, uid);
 
       try {
         await callFunction('updateStreakAndXP', { type: 'journal' });

--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -8,6 +8,7 @@ import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
 import { ensureUserDocExists } from "@/services/userService";
 import { loadUserProfile } from "../../../utils/userProfile";
+import type { UserProfile } from "../../../types/profile";
 import { checkIfUserIsNewAndRoute } from "@/services/onboardingService";
 import { useUserStore } from "@/state/userStore";
 import { useAuthStore } from "@/state/authStore";
@@ -34,7 +35,7 @@ export default function LoginScreen() {
       if (result.localId) {
         setUid(result.localId);
         await ensureUserDocExists(result.localId, result.email);
-        const profile = await loadUserProfile(result.localId);
+        const profile: UserProfile | null = await loadUserProfile(result.localId);
         if (profile) {
           useUserStore.getState().setUser({
             uid: profile.uid,

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -7,13 +7,13 @@ import Button from "@/components/common/Button";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { updateUserProfile, loadUserProfile, setCachedUserProfile } from "../../../utils/userProfile";
+import type { UserProfile } from "../../../types/profile";
 import { useUserStore } from "@/state/userStore";
 import { useAuthStore } from "@/state/authStore";
 import { SCREENS } from "@/navigation/screens";
 import { useTheme } from "@/components/theme/theme";
 import { Picker } from "@react-native-picker/picker";
 import type { RootStackParamList } from "@/navigation/RootStackParamList";
-import { loadUserProfile } from "../../../utils/userProfile";
 import { useLookupLists } from "@/hooks/useLookupLists";
 
 type OnboardingScreenProps = NativeStackScreenProps<
@@ -72,7 +72,7 @@ export default function OnboardingScreen() {
         };
         console.log('🔧 updateUserProfile', { uid, ...fields });
         await updateUserProfile(fields);
-        const updated = await loadUserProfile(uid);
+        const updated: UserProfile | null = await loadUserProfile(uid);
         setCachedUserProfile(updated as any);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         useUserStore.getState().updateUser({
@@ -82,7 +82,7 @@ export default function OnboardingScreen() {
           region,
           religion,
         });
-        const check = await loadUserProfile(uid);
+        const check: UserProfile | null = await loadUserProfile(uid);
         console.log('✅ profile after onboarding', {
           username: check?.username,
           region: check?.region,

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -72,7 +72,7 @@ export default function SelectReligionScreen({ navigation }: Props) {
     if (!uid) return;
 
     try {
-      await updateUserProfile(uid, { religion: selected });
+      await updateUserProfile({ religion: selected }, uid);
       await loadUserProfile(uid);
 
       navigation.replace('Quote');

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -17,6 +17,7 @@ import { useTheme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { setDocument } from '@/services/firestoreService';
 import { loadUserProfile, updateUserProfile, getUserAIPrompt } from '../../../utils/userProfile';
+import type { UserProfile } from '../../../types/profile';
 import { callFunction, awardPointsToUser } from '@/services/functionService';
 import { ensureAuth } from '@/utils/authGuard';
 import AuthGate from '@/components/AuthGate';
@@ -137,13 +138,14 @@ export default function TriviaScreen() {
       correctStory && storyGuess.trim().toLowerCase().includes(correctStory.toLowerCase());
 
     try {
-      const userData = (await loadUserProfile(uid)) || {};
+      const userData: UserProfile | null = await loadUserProfile(uid);
+      const profile = userData ?? ({} as UserProfile);
       const earned = (religionCorrect ? 1 : 0) + (storyCorrect ? 5 : 0);
 
       if (earned > 0) {
-        await updateUserProfile(uid, {
-          individualPoints: (userData.individualPoints || 0) + earned,
-        });
+        await updateUserProfile({
+          individualPoints: (profile.individualPoints || 0) + earned,
+        }, uid);
 
         await setDocument(`completedChallenges/${uid}`, {
           lastTrivia: new Date().toISOString(),

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -13,6 +13,7 @@ import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { queryCollection, setDocument, getDocument } from '@/services/firestoreService';
 import { loadUserProfile, updateUserProfile } from '../../../utils/userProfile';
+import type { UserProfile } from '../../../types/profile';
 import { getAuthHeaders } from '@/utils/TokenManager';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';
@@ -101,10 +102,10 @@ export default function JoinOrganizationScreen() {
     const uid = await ensureAuth(user.uid);
     if (!uid) return;
     try {
-      await updateUserProfile(uid, {
+      await updateUserProfile({
         organizationId: null,
         organizationName: null,
-      });
+      }, uid);
 
       updateUser({ organizationId: undefined });
 
@@ -127,7 +128,7 @@ export default function JoinOrganizationScreen() {
     const uid = await ensureAuth(user.uid);
     if (!uid) return;
 
-    const profile = await loadUserProfile(uid);
+    const profile: UserProfile | null = await loadUserProfile(uid);
     if (profile?.organizationId) {
       Alert.alert(
         'Already Joined',
@@ -152,10 +153,10 @@ export default function JoinOrganizationScreen() {
     }
 
     try {
-      await updateUserProfile(uid, {
+      await updateUserProfile({
         organizationId: org.id,
         organizationName: org.name,
-      });
+      }, uid);
 
       updateUser({ organizationId: org.id });
 

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -10,6 +10,7 @@ import { useUserStore } from '@/state/userStore';
 import { getTokenCount } from '@/utils/TokenManager';
 import { useLookupLists } from '@/hooks/useLookupLists';
 import { loadUserProfile, updateUserProfile, setCachedUserProfile } from '../../../utils/userProfile';
+import type { UserProfile } from '../../../types/profile';
 import { getDocument } from '@/services/firestoreService';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
@@ -66,10 +67,11 @@ export default function ProfileScreen() {
     const uid = await ensureAuth(user?.uid);
     if (!uid) return;
     try {
-      const [tokenCount, profile] = await Promise.all([
+      const [tokenCount, loaded] = await Promise.all([
         getTokenCount(),
         loadUserProfile(uid),
       ]);
+      const profile: UserProfile | null = loaded;
       setTokens(tokenCount);
       if (profile) {
         setPoints(profile.individualPoints || 0);
@@ -108,7 +110,7 @@ export default function ProfileScreen() {
       const updated = await loadUserProfile(uidVal);
       setCachedUserProfile(updated as any);
       updateUser({ religion: value });
-      await updateUserProfile(uidVal, { lastChallenge: null });
+      await updateUserProfile({ lastChallenge: null }, uidVal);
       Alert.alert('Religion Updated');
     } catch (err: any) {
       console.error('Religion update failed', err);

--- a/App/services/onboardingService.ts
+++ b/App/services/onboardingService.ts
@@ -4,7 +4,7 @@ import { ensureAuth } from '@/utils/authGuard';
 
 export async function saveUsernameAndProceed(username: string): Promise<void> {
   const uid = await ensureAuth();
-  await updateUserProfile(uid, { username });
+  await updateUserProfile({ username }, uid);
   if (navigationRef.isReady()) {
     navigationRef.reset({ index: 0, routes: [{ name: 'Home' }] });
   }

--- a/App/state/challengeStore.ts
+++ b/App/state/challengeStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { loadUserProfile, updateUserProfile } from '../../utils/userProfile';
+import type { UserProfile } from '../../types/profile';
 import { ensureAuth } from '@/utils/authGuard';
 
 interface ChallengeStore {
@@ -37,7 +38,7 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
     const uid = await ensureAuth();
     if (!uid) return;
 
-    const data = await loadUserProfile(uid);
+    const data: UserProfile | null = await loadUserProfile(uid);
     if (data) {
       set({
         lastCompleted: data.lastStreakDate ? new Date(data.lastStreakDate).getTime() : null,
@@ -58,6 +59,6 @@ export const useChallengeStore = create<ChallengeStore>((set, get) => ({
         : new Date().toISOString(),
       streak,
     };
-    await updateUserProfile(uid, payload);
+    await updateUserProfile(payload, uid);
   },
 }));

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -20,7 +20,7 @@ export const setTokenCount = async (count: number) => {
   const uid = await ensureAuth();
   if (!uid) return;
 
-  await updateUserProfile(uid, { tokens: count });
+  await updateUserProfile({ tokens: count }, uid);
   console.log('🪙 Token count:', count);
 };
 
@@ -60,7 +60,7 @@ export const syncSubscriptionStatus = async () => {
   const isSubscribed = !!sub && sub.active === true;
   console.log('💎 OneVine+ Status:', isSubscribed);
   if (isSubscribed) {
-    await updateUserProfile(uid, { tokens: 9999 });
+    await updateUserProfile({ tokens: 9999 }, uid);
   }
 };
 


### PR DESCRIPTION
## Summary
- add UserProfile typings where user data loaded
- fix argument order for `updateUserProfile`
- use optional chaining and defaults on profile data access
- clean up duplicate imports and JS build artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c59a7cefc833081f1d987405307ff