### PR TITLE
Ensure Firestore profile created after auth

### DIFF
--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -1,60 +1,59 @@
-import React, { useState } from 'react';
-import CustomText from '@/components/CustomText';
-import { View, StyleSheet, Alert } from 'react-native';
+import React, { useState } from "react";
+import CustomText from "@/components/CustomText";
+import { View, StyleSheet, Alert } from "react-native";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { signup } from "@/services/authService";
-import { createUserProfile, loadUser } from "@/services/userService";
+import { ensureUserDocExists, loadUser } from "@/services/userService";
 import { checkIfUserIsNewAndRoute } from "@/services/onboardingService";
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTheme } from "@/components/theme/theme";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
-import { resetToLogin } from '@/navigation/navigationRef';
+import { resetToLogin } from "@/navigation/navigationRef";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function SignupScreen() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const [errorMsg, setErrorMsg] = useState('');
+  const [errorMsg, setErrorMsg] = useState("");
   const navigation = useNavigation<NavigationProp>();
   const theme = useTheme();
 
   const handleSignup = async () => {
     if (!email || !/^\S+@\S+\.\S+$/.test(email)) {
-      Alert.alert('Invalid Email', 'Please enter a valid email address.');
+      Alert.alert("Invalid Email", "Please enter a valid email address.");
       return;
     }
     if (!password || password.length < 6) {
-      Alert.alert('Invalid Password', 'Password must be at least 6 characters long.');
+      Alert.alert(
+        "Invalid Password",
+        "Password must be at least 6 characters long.",
+      );
       return;
     }
     const requestPayload = { email, password };
-    console.log('➡️ signup payload', requestPayload);
-    setErrorMsg('');
+    console.log("➡️ signup payload", requestPayload);
+    setErrorMsg("");
     setLoading(true);
     try {
       const result = await signup(email, password);
-      if (!result.localId) throw new Error('User creation failed.');
+      if (!result.localId) throw new Error("User creation failed.");
 
-      await createUserProfile({
-        uid: result.localId,
-        email: result.email,
-        username: '',
-        displayName: '',
-      });
+      await ensureUserDocExists(result.localId, result.email);
       await loadUser(result.localId);
       await checkIfUserIsNewAndRoute();
     } catch (err: any) {
-      console.warn('🚫 Signup Failed:', err?.response?.data?.error?.message);
+      console.warn("🚫 Signup Failed:", err?.response?.data?.error?.message);
       const fbMessage = err?.response?.data?.error?.message;
       const message = fbMessage || err.message;
-      const friendly = fbMessage === 'EMAIL_EXISTS' ? 'Email already in use.' : message;
+      const friendly =
+        fbMessage === "EMAIL_EXISTS" ? "Email already in use." : message;
       setErrorMsg(friendly);
-      Alert.alert('Signup Failed', friendly);
+      Alert.alert("Signup Failed", friendly);
     } finally {
       setLoading(false);
     }
@@ -65,14 +64,14 @@ export default function SignupScreen() {
       StyleSheet.create({
         title: {
           fontSize: 24,
-          fontWeight: '700',
+          fontWeight: "700",
           color: theme.colors.text,
           marginBottom: 20,
         },
         link: {
           marginTop: 20,
           color: theme.colors.primary,
-          textAlign: 'center',
+          textAlign: "center",
         },
       }),
     [theme],
@@ -98,21 +97,20 @@ export default function SignupScreen() {
       />
 
       {errorMsg ? (
-        <CustomText style={{ color: theme.colors.danger }}>{errorMsg}</CustomText>
+        <CustomText style={{ color: theme.colors.danger }}>
+          {errorMsg}
+        </CustomText>
       ) : null}
 
       <Button title="Sign Up" onPress={handleSignup} loading={loading} />
 
-      <CustomText
-        style={styles.link}
-        onPress={resetToLogin}
-      >
+      <CustomText style={styles.link} onPress={resetToLogin}>
         Already have an account? Log in
       </CustomText>
 
       <CustomText
         style={styles.link}
-        onPress={() => navigation.navigate('OrganizationSignup')}
+        onPress={() => navigation.navigate("OrganizationSignup")}
       >
         Want to register your organization? Click here
       </CustomText>
@@ -121,4 +119,3 @@ export default function SignupScreen() {
 }
 
 // styles created inside component so they update with theme
-


### PR DESCRIPTION
## Summary
- create Firestore user doc when missing using `createDefaultUserDoc`
- call `ensureUserDocExists` after signing up

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ceeecac3483309c287192827dee62