### PR TITLE
Fix Firestore user profile creation

### DIFF
--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -103,19 +103,23 @@ function toFirestoreFields(obj: any): any {
 
 export interface DefaultUserData {
   uid: string;
-  email: string;
-  displayName: string;
-  region: string;
-  religion: string;
+  email?: string;
+  emailVerified?: boolean;
+  displayName?: string;
+  username?: string;
+  region?: string;
+  religion?: string;
   idToken: string;
 }
 
 export async function createDefaultUserDoc({
   uid,
-  email,
-  displayName,
-  region,
-  religion,
+  email = '',
+  emailVerified = false,
+  displayName = 'New User',
+  username = '',
+  region = '',
+  religion = '',
   idToken,
 }: DefaultUserData) {
   const path = `users/${uid}`;
@@ -132,8 +136,9 @@ export async function createDefaultUserDoc({
   const payload = {
     uid,
     email,
-    emailVerified: false,
+    emailVerified,
     displayName,
+    username,
     createdAt: now,
     religion,
     religionSlug: slugify(religion),
@@ -145,7 +150,7 @@ export async function createDefaultUserDoc({
     lastFreeAsk: null,
     lastFreeSkip: null,
     isSubscribed: false,
-    onboardingComplete: true,
+    onboardingComplete: false,
     nightModeEnabled: false,
   };
 


### PR DESCRIPTION
## Summary
- expand `createDefaultUserDoc` to populate every profile field
- ensure onboarding checks for existing profile and warns if incomplete
- validate loaded user profiles for missing required fields

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing libraries and tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_686d6dbb5b848330a90375594cf4328e