### PR TITLE
Implement full Firestore REST flow

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -16,7 +16,7 @@ import { useTheme } from "@/components/theme/theme";
 import { showGracefulError } from '@/utils/gracefulError';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { querySubcollection, addDocument, getDocument, setDocument } from '@/services/firestoreService';
-import { loadUserProfile, updateUserProfile, getUserAIPrompt } from '../../utils/userProfile';
+import { loadUserProfile, incrementUserPoints, getUserAIPrompt } from '../../utils/userProfile';
 import type { UserProfile } from '../../types/profile';
 import { callFunction, awardPointsToUser } from '@/services/functionService';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
@@ -241,9 +241,7 @@ export default function JournalScreen() {
       });
       console.log('✅ Journal entry saved');
 
-      await updateUserProfile({
-        individualPoints: (profile.individualPoints || 0) + 2,
-      }, uid);
+      await incrementUserPoints(2, uid);
 
       try {
         await callFunction('updateStreakAndXP', { type: 'journal' });

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -8,7 +8,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { loadUserProfile, setCachedUserProfile, updateUserProfile } from "../../../utils/userProfile";
 import { fetchUserProfile } from "../../services/userService";
-import { createDefaultUserDoc } from "../../../firebaseRest";
+import { createUserDoc } from "../../../firebaseRest";
 import { getIdToken } from "@/utils/authUtils";
 import type { UserProfile } from "../../../types/profile";
 import { useUserStore } from "@/state/userStore";
@@ -69,7 +69,7 @@ export default function OnboardingScreen() {
         const token = await getIdToken(true);
         const existing = await fetchUserProfile(uid);
         if (!existing) {
-          await createDefaultUserDoc({
+          await createUserDoc({
             uid,
             email: user?.email || '',
             displayName: username.trim(),

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -13,7 +13,7 @@ import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
 import { ASK_GEMINI_SIMPLE, GENERATE_CHALLENGE_URL } from "@/utils/constants";
 import { getOrCreateActiveChallenge } from '@/services/firestoreService';
-import { loadUserProfile, updateUserProfile, getUserAIPrompt } from '../../../utils/userProfile';
+import { loadUserProfile, updateUserProfile, getUserAIPrompt, incrementUserPoints } from '../../../utils/userProfile';
 import { canLoadNewChallenge } from '@/services/challengeLimitService';
 import { completeChallengeWithStreakCheck } from '@/services/challengeStreakService';
 import {
@@ -332,9 +332,7 @@ export default function ChallengeScreen() {
     const currentTokens = await getTokenCount();
     await setTokenCount(currentTokens + 1);
 
-    await updateUserProfile({
-      individualPoints: (profile.individualPoints || 0) + 2,
-    }, uid);
+    await incrementUserPoints(2, uid);
 
     try {
       await awardPointsToUser(2);

--- a/App/screens/dashboard/TriviaScreen.tsx
+++ b/App/screens/dashboard/TriviaScreen.tsx
@@ -16,7 +16,7 @@ import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { setDocument } from '@/services/firestoreService';
-import { loadUserProfile, updateUserProfile, getUserAIPrompt } from '../../../utils/userProfile';
+import { loadUserProfile, incrementUserPoints, getUserAIPrompt } from '../../../utils/userProfile';
 import type { UserProfile } from '../../../types/profile';
 import { callFunction, awardPointsToUser } from '@/services/functionService';
 import { ensureAuth } from '@/utils/authGuard';
@@ -143,9 +143,7 @@ export default function TriviaScreen() {
       const earned = (religionCorrect ? 1 : 0) + (storyCorrect ? 5 : 0);
 
       if (earned > 0) {
-        await updateUserProfile({
-          individualPoints: (profile.individualPoints || 0) + earned,
-        }, uid);
+        await incrementUserPoints(earned, uid);
 
         await setDocument(`completedChallenges/${uid}`, {
           lastTrivia: new Date().toISOString(),

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -4,7 +4,7 @@ import { ensureAuth } from "@/utils/authGuard";
 import { getIdToken } from "@/utils/authUtils";
 import type { FirestoreUser, UserProfile } from "../../types/profile";
 import { DEFAULT_RELIGION } from "@/config/constants";
-import { createDefaultUserDoc } from "../../firebaseRest";
+import { createUserDoc } from "../../firebaseRest";
 
 /**
  * Initialize optional user fields if they're missing.
@@ -51,7 +51,7 @@ export async function ensureUserDocExists(
     if (err?.response?.status === 404) {
       const idToken = await getIdToken(true);
       if (!idToken) throw new Error("Unable to get auth token");
-      await createDefaultUserDoc({
+      await createUserDoc({
         uid,
         email: email || "",
         displayName: displayName || "New User",

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -35,7 +35,7 @@ export async function signUpWithEmailAndPassword(email: string, password: string
     // After successful signup, create default Firestore user doc
     const { localId, idToken, email: userEmail } = res.data as AuthResponse;
     try {
-      await createDefaultUserDoc({
+      await createUserDoc({
         uid: localId,
         email: userEmail,
         displayName: 'New User',
@@ -112,7 +112,7 @@ export interface DefaultUserData {
   idToken: string;
 }
 
-export async function createDefaultUserDoc({
+export async function createUserDoc({
   uid,
   email = '',
   emailVerified = false,
@@ -147,8 +147,8 @@ export async function createDefaultUserDoc({
     individualPoints: 0,
     tokens: 5,
     skipTokensUsed: 0,
-    lastFreeAsk: null,
-    lastFreeSkip: null,
+    lastFreeAsk: now,
+    lastFreeSkip: now,
     isSubscribed: false,
     onboardingComplete: false,
     nightModeEnabled: false,
@@ -162,7 +162,7 @@ export async function createDefaultUserDoc({
     console.log('✅ user doc created', uid);
   } catch (err: any) {
     logFirestoreError('SET', path, err);
-    console.error('createDefaultUserDoc error', err?.response?.data || err);
+    console.error('createUserDoc error', err?.response?.data || err);
     throw err;
   }
 }

--- a/religionRest.ts
+++ b/religionRest.ts
@@ -45,6 +45,7 @@ export async function getReligionProfile(
   }
   const idToken = await getIdToken();
   const url = `${FIRESTORE_BASE}/religion/${id}`;
+  console.log('➡️ Sending Firestore request to:', url);
   try {
     const res = await axios.get(url, { headers: { Authorization: `Bearer ${idToken}` } });
     const fields = res.data.fields || {};
@@ -57,11 +58,18 @@ export async function getReligionProfile(
       aiVoice: fields.aiVoice?.stringValue,
     };
     religionCache[id] = profile;
+    console.log('✅ Firestore response:', res.status);
     return profile;
   } catch (err: any) {
     logFirestoreError('GET', `religion/${id}`, err);
     return null;
   }
+}
+
+export async function fetchReligionPrompt(id: string): Promise<{ prompt: string; aiVoice?: string } | null> {
+  const profile = await getReligionProfile(id);
+  if (!profile) return null;
+  return { prompt: profile.prompt || '', aiVoice: profile.aiVoice };
 }
 
 async function fetchReligionList(): Promise<ReligionItem[]> {

--- a/utils/userProfile.ts
+++ b/utils/userProfile.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError } from 'axios';
 import { FIRESTORE_BASE } from '../firebaseRest';
 import { getAuthHeaders, getCurrentUserId } from '../App/utils/authUtils';
 import { getDocument } from '../App/services/firestoreService';
+import { logFirestoreError } from '../App/lib/logging';
 import type { CachedProfile, ReligionDocument, UserProfile } from '../types/profile';
 import { getReligionProfile } from '../religionRest';
 
@@ -68,27 +69,60 @@ export async function updateUserProfile(
     console.warn('updateUserProfile called with no uid');
     return;
   }
+  const sanitized: Record<string, any> = { ...fields };
+  if (typeof sanitized.username === 'string') {
+    sanitized.username = sanitized.username.trim();
+  }
+  if (typeof sanitized.displayName === 'string') {
+    sanitized.displayName = sanitized.displayName.trim();
+  }
   try {
     const headers = await getAuthHeaders();
     const url = `${FIRESTORE_BASE}/users/${userId}`;
-    console.log('➡️ PATCH', url, { payload: fields, headers });
-    await axios.patch(url, { fields: toFirestoreFields(fields) }, { headers });
+    console.log('➡️ PATCH', url, { payload: sanitized, headers });
+    await axios.patch(url, { fields: toFirestoreFields(sanitized) }, { headers });
     if (cachedProfile && cachedProfile.uid === userId) {
-      if ('religion' in fields) {
-        const religionData = await getReligionProfile(fields.religion);
+      if ('religion' in sanitized) {
+        const religionData = await getReligionProfile(sanitized.religion);
         cachedProfile = {
           ...cachedProfile,
-          ...fields,
+          ...sanitized,
           religionData: religionData || null,
         } as CachedProfile;
       } else {
-        cachedProfile = { ...cachedProfile, ...fields } as CachedProfile;
+        cachedProfile = { ...cachedProfile, ...sanitized } as CachedProfile;
       }
     }
-    console.log('✅ Profile updated', fields);
+    console.log('✅ Profile updated', sanitized);
   } catch (err: any) {
     const errorData = (err as AxiosError).response?.data;
     console.error('updateUserProfile failed', errorData || err);
+  }
+}
+
+export async function incrementUserPoints(points: number, uid?: string): Promise<void> {
+  const userId = uid ?? (await getCurrentUserId());
+  if (!userId) {
+    console.warn('incrementUserPoints called with no uid');
+    return;
+  }
+  try {
+    const headers = await getAuthHeaders();
+    const url = `${FIRESTORE_BASE}/users/${userId}`;
+    console.log('➡️ Sending Firestore request to:', url);
+    const res = await axios.get(url, { headers });
+    const current = Number(res.data?.fields?.individualPoints?.integerValue ?? 0);
+    const newTotal = current + points;
+    const body = { fields: toFirestoreFields({ individualPoints: newTotal }) };
+    console.log('➡️ Sending Firestore request to:', url, body);
+    await axios.patch(url, body, { headers });
+    if (cachedProfile && cachedProfile.uid === userId) {
+      cachedProfile = { ...cachedProfile, individualPoints: newTotal } as CachedProfile;
+    }
+    console.log('✅ Firestore response:', newTotal);
+  } catch (error: any) {
+    logFirestoreError('PATCH', `users/${userId}`, error);
+    console.error('🔥 Firestore error:', error.message || error.response);
   }
 }
 


### PR DESCRIPTION
## Summary
- add createUserDoc helper and defaults
- sanitize updates in updateUserProfile and add incrementUserPoints
- hook onboarding and signup to createUserDoc
- fetch religion prompt with logging
- track challenge points using incrementUserPoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9c3c1fec8330929370dd46850a65