### PR TITLE
Fix TypeScript issues

### DIFF
--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -43,32 +43,17 @@ export async function ensureUserDocExists(
   email?: string,
   displayName?: string,
 ): Promise<boolean> {
-  const existing = await fetchUserProfile(uid);
-  if (existing) {
-    console.log('📄 User doc already exists for', uid);
-    return false;
-
-
-
-  } catch (err: any) {
-    if (err?.response?.status === 404) {
-      const idToken = await getIdToken(true);
-      if (!idToken) throw new Error("Unable to get auth token");
-      await createUserDoc({
-        uid,
-        email: email || "",
-        displayName: displayName || "New User",
-        region: "",
-        religion: DEFAULT_RELIGION,
-        idToken,
-      });
-      console.log("📄 Created user doc for", uid);
-      return true;
+  try {
+    const existing = await fetchUserProfile(uid);
+    if (existing) {
+      console.log('📄 User doc already exists for', uid);
+      return false;
     }
-    console.warn("⚠️ ensureUserDocExists failed", err);
-    throw err;
-
-
+  } catch (err: any) {
+    if (err?.response?.status !== 404) {
+      console.warn('⚠️ ensureUserDocExists failed', err);
+      throw err;
+    }
   }
 
   const idToken = await getIdToken(true);

--- a/App/types/user.ts
+++ b/App/types/user.ts
@@ -31,6 +31,13 @@ export interface ChallengeHistoryEntry {
 // 🧠 This is what's loaded from Firestore or held in app state
 export interface UserProfile extends DefaultUserData {
   dailyChallengeHistory?: ChallengeHistoryEntry;
+  lastChallenge?: any;
+  lastChallengeText?: string;
+  dailySkipCount?: number;
+  lastSkipDate?: string;
+  challengeStreak?: { count: number; lastCompletedDate: string | null };
+  dailyChallengeCount?: number;
+  lastChallengeLoadDate?: string | null;
 }
 
 // 🛠️ When patching/updating a user — all fields optional

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -115,10 +115,6 @@ export interface DefaultUserData {
 
 
 export function generateDefaultUserData({
-
-export async function createUserDoc({
-
-
   uid,
   email = '',
   emailVerified = false,
@@ -171,14 +167,23 @@ export async function createUserDoc({
 
 export async function createUserDoc({
   uid,
-  email = '',
+  email,
   emailVerified = false,
-  displayName = 'New User',
-  username = '',
-  region = '',
-  religion = '',
+  displayName,
+  username,
+  region,
+  religion,
   idToken,
-}: DefaultUserData) {
+}: {
+  uid: string;
+  email: string;
+  emailVerified?: boolean;
+  displayName: string;
+  username: string;
+  region: string;
+  religion: string;
+  idToken: string;
+}) {
   const path = `users/${uid}`;
   const url = `${FIRESTORE_BASE}/${path}`;
   const payload = generateDefaultUserData({

--- a/types/profile.d.ts
+++ b/types/profile.d.ts
@@ -24,6 +24,11 @@ export interface UserProfile {
   streak?: Streak;
   currentChallenge?: any;
   onboardingComplete?: boolean;
+  lastChallenge?: any;
+  lastChallengeText?: string;
+  dailySkipCount?: number;
+  lastSkipDate?: string;
+  createdAt?: number;
   /** Tokens spent on skipping challenges */
   skipTokensUsed?: number;
   /** Dark mode preference */

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -24,6 +24,11 @@ export interface UserProfile {
   streak?: Streak;
   currentChallenge?: any;
   onboardingComplete?: boolean;
+  lastChallenge?: any;
+  lastChallengeText?: string;
+  dailySkipCount?: number;
+  lastSkipDate?: string;
+  createdAt?: number;
   /** Tokens spent on skipping challenges */
   skipTokensUsed?: number;
   /** Dark mode preference */


### PR DESCRIPTION
## Summary
- wrap ensureUserDocExists logic with a try/catch block
- correct `createUserDoc` definition in `firebaseRest.ts`
- extend `UserProfile` interfaces with optional fields used across the app

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_686dda8d58088330a9e1aadd2d2c88e8