### PR TITLE
Fix ChallengeScreen profile types

### DIFF
--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -27,7 +27,7 @@ import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { useAuth } from '@/hooks/useAuth';
 import { sendGeminiPrompt } from '@/services/geminiService';
 import AuthGate from '@/components/AuthGate';
-import { UserProfile } from '../../types/user'; // adjust path if needed
+import { UserProfile } from '../../../types';
 export default function ChallengeScreen() {
   const theme = useTheme();
   const styles = React.useMemo(
@@ -133,7 +133,7 @@ export default function ChallengeScreen() {
 
       const userData: UserProfile | null = await loadUserProfile(uid);
       const profile = userData ?? ({} as UserProfile);
-      const lastChallenge = profile.lastChallenge?.toDate?.();
+      const lastChallenge = profile.lastChallenge ? new Date(profile.lastChallenge) : null;
       const now = new Date();
       const oneDay = 24 * 60 * 60 * 1000;
 

--- a/App/types/user.ts
+++ b/App/types/user.ts
@@ -31,10 +31,11 @@ export interface ChallengeHistoryEntry {
 // 🧠 This is what's loaded from Firestore or held in app state
 export interface UserProfile extends DefaultUserData {
   dailyChallengeHistory?: ChallengeHistoryEntry;
-  lastChallenge?: any;
+  lastChallenge?: Date;
   lastChallengeText?: string;
   dailySkipCount?: number;
   lastSkipDate?: string;
+  streakMilestones?: Record<string, boolean>;
   challengeStreak?: { count: number; lastCompletedDate: string | null };
   dailyChallengeCount?: number;
   lastChallengeLoadDate?: string | null;

--- a/types/profile.d.ts
+++ b/types/profile.d.ts
@@ -21,13 +21,21 @@ export interface UserProfile {
   region?: string;
   religion: string;
   points?: number;
+  tokens?: number;
   streak?: Streak;
+  isSubscribed?: boolean;
   currentChallenge?: any;
   onboardingComplete?: boolean;
-  lastChallenge?: any;
+  lastChallenge?: Date;
   lastChallengeText?: string;
   dailySkipCount?: number;
-  lastSkipDate?: string;
+  lastSkipDate?: string | null;
+  dailyChallengeHistory?: {
+    date: string;
+    completed: number;
+    skipped: number;
+  };
+  streakMilestones?: Record<string, boolean>;
   createdAt?: number;
   /** Tokens spent on skipping challenges */
   skipTokensUsed?: number;

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -21,13 +21,21 @@ export interface UserProfile {
   region?: string;
   religion: string;
   points?: number;
+  tokens?: number;
   streak?: Streak;
+  isSubscribed?: boolean;
   currentChallenge?: any;
   onboardingComplete?: boolean;
-  lastChallenge?: any;
+  lastChallenge?: Date;
   lastChallengeText?: string;
   dailySkipCount?: number;
-  lastSkipDate?: string;
+  lastSkipDate?: string | null;
+  dailyChallengeHistory?: {
+    date: string;
+    completed: number;
+    skipped: number;
+  };
+  streakMilestones?: Record<string, boolean>;
   createdAt?: number;
   /** Tokens spent on skipping challenges */
   skipTokensUsed?: number;


### PR DESCRIPTION
## Summary
- update ChallengeScreen to import root profile types
- handle nullable `lastChallenge` as Date
- expand `UserProfile` interface in app and server types

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: numerous existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ddecbf6a08330a17c597dbba1ea72