### PR TITLE
Fix initAuthState error handling

### DIFF
--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -18,17 +18,22 @@ export function initAuthState(): void {
   const setUid = useAuthStore.getState().setUid;
   const setIdToken = useAuthStore.getState().setIdToken;
   observeAuthState(async (user) => {
-    if (user) {
-      setUid(user.uid);
-      setIdToken(await fbGetIdToken(true));
-      await ensureUserDocExists(user.uid, user.email ?? undefined);
-      await loadUser(user.uid);
-    } else {
-      setUid(null);
-      setIdToken(null);
-      useUserStore.getState().clearUser();
+    try {
+      if (user) {
+        setUid(user.uid);
+        setIdToken(await fbGetIdToken(true));
+        await ensureUserDocExists(user.uid, user.email ?? undefined);
+        await loadUser(user.uid);
+      } else {
+        setUid(null);
+        setIdToken(null);
+        useUserStore.getState().clearUser();
+      }
+    } catch (err) {
+      console.warn('initAuthState failed', err);
+    } finally {
+      setAuthReady(true);
     }
-    setAuthReady(true);
   });
 }
 


### PR DESCRIPTION
## Summary
- add try/catch/finally around `initAuthState`

## Testing
- `npx -y jest --runTestsByPath server/__tests__/leaderboard.test.ts --runInBand` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de9329fcc83309579e045852c7108