### PR TITLE
Fix auth cycles and onboarding state

### DIFF
--- a/App/hooks/useNotifications.ts
+++ b/App/hooks/useNotifications.ts
@@ -1,12 +1,10 @@
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 
-const isDevClient =
-  !Constants.appOwnership ||
-  (Constants.appOwnership as unknown as string) === 'expo-dev-client';
+const canUseNotifications = Constants.appOwnership !== 'expo';
 
 export async function scheduleDailyNotification(title: string, body: string) {
-  if (!isDevClient) {
+  if (!canUseNotifications) {
     console.warn('⚠️ Push notifications disabled in Expo Go.');
     return;
   }

--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -7,7 +7,7 @@ import Button from "@/components/common/Button";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { loadUserProfile, setCachedUserProfile, updateUserProfile } from "@/utils/userProfile";
-import { fetchUserProfile, completeOnboarding } from "../../services/userService";
+import { fetchUserProfile } from "../../services/userService";
 import { createUserDoc } from "../../../firebaseRest";
 import { getIdToken } from "@/utils/authUtils";
 import type { UserProfile } from "../../../types";
@@ -78,20 +78,24 @@ export default function OnboardingScreen() {
             religion,
             idToken: token || '',
           });
-        } else {
-          await updateUserProfile(
-            {
-              displayName: username.trim(),
-              username: username.trim(),
-              region,
-              religion,
-            },
-            uid,
-          );
         }
+        await updateUserProfile(
+          {
+            displayName: username.trim(),
+            username: username.trim(),
+            region,
+            religion,
+            onboardingComplete: true,
+            challengeStreak: { count: 0, lastCompletedDate: null },
+            dailyChallengeCount: 0,
+            dailySkipCount: 0,
+            lastChallengeLoadDate: null,
+            lastSkipDate: null,
+          },
+          uid,
+        );
         const updated: UserProfile | null = await loadUserProfile(uid);
         setCachedUserProfile(updated as any);
-        await completeOnboarding(uid);
         await SecureStore.setItemAsync(`hasSeenOnboarding-${uid}`, 'true');
         const current = useUserProfileStore.getState().profile;
         useUserProfileStore.getState().setUserProfile({
@@ -107,7 +111,7 @@ export default function OnboardingScreen() {
         }
         navigation.reset({
           index: 0,
-          routes: [{ name: 'Home' as keyof RootStackParamList }],
+          routes: [{ name: SCREENS.MAIN.HOME }],
         });
       }
     } catch (err: any) {

--- a/App/services/apiService.ts
+++ b/App/services/apiService.ts
@@ -3,7 +3,7 @@ import { STRIPE_CHECKOUT_URL, TOKEN_CHECKOUT_URL, SUBSCRIPTION_CHECKOUT_URL } fr
 import { STRIPE_SUCCESS_URL, STRIPE_CANCEL_URL } from '@/config/stripeConfig';
 import { getAuthHeaders } from '@/utils/authUtils';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';
-import { logTokenIssue } from '@/services/authLogger';
+import { logTokenIssue } from '@/shared/tokenLogger';
 import { showPermissionDenied } from '@/utils/gracefulError';
 
 type StripeCheckoutResponse = {

--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -3,12 +3,12 @@ import { useUserStore } from '@/state/userStore';
 import {
   signup as fbSignup,
   login as fbLogin,
-  logout as fbLogout,
   resetPassword as fbResetPassword,
   changePassword as fbChangePassword,
   getIdToken as fbGetIdToken,
   observeAuthState,
 } from '@/lib/auth';
+import { performLogout } from '@/shared/logout';
 import { startTokenRefresh, stopTokenRefresh } from '@/lib/tokenRefresh';
 import { resetToLogin } from '@/navigation/navigationRef';
 import { ensureUserDocExists, loadUser, refreshLastActive } from './userService';
@@ -57,10 +57,7 @@ export async function login(email: string, password: string) {
 }
 
 export async function logout(): Promise<void> {
-  await fbLogout();
-  useUserStore.getState().clearUser();
-  useAuthStore.getState().setUid(null);
-  useAuthStore.getState().setIdToken(null);
+  await performLogout();
 }
 
 export function resetPassword(email: string) {

--- a/App/services/functionService.ts
+++ b/App/services/functionService.ts
@@ -1,5 +1,5 @@
 import { getAuthHeaders } from '@/utils/authUtils';
-import { logTokenIssue } from '@/services/authLogger';
+import { logTokenIssue } from '@/shared/tokenLogger';
 import apiClient from '@/utils/apiClient';
 import Constants from 'expo-constants';
 

--- a/App/shared/logout.ts
+++ b/App/shared/logout.ts
@@ -1,0 +1,10 @@
+import { logout as fbLogout } from '@/lib/auth';
+import { useUserStore } from '@/state/userStore';
+import { useAuthStore } from '@/state/authStore';
+
+export async function performLogout(): Promise<void> {
+  await fbLogout();
+  useUserStore.getState().clearUser();
+  useAuthStore.getState().setUid(null);
+  useAuthStore.getState().setIdToken(null);
+}

--- a/App/shared/signOut.ts
+++ b/App/shared/signOut.ts
@@ -1,16 +1,10 @@
 import { Alert } from 'react-native';
-import { useAuthStore } from '@/state/authStore';
 import { resetToLogin } from '@/navigation/navigationRef';
-import { logout } from './authService';
-
-export function logTokenIssue(context: string) {
-  const { uid } = useAuthStore.getState();
-  console.warn(`🔐 Token issue during ${context}`, { uid });
-}
+import { performLogout } from '@/shared/logout';
 
 export async function signOutAndRetry(): Promise<void> {
   console.warn('🚪 Auth failure detected');
   Alert.alert('Session expired', 'Please sign in again.');
-  await logout();
+  await performLogout();
   resetToLogin();
 }

--- a/App/shared/tokenLogger.ts
+++ b/App/shared/tokenLogger.ts
@@ -1,0 +1,6 @@
+import { useAuthStore } from '@/state/authStore';
+
+export function logTokenIssue(context: string) {
+  const { uid } = useAuthStore.getState();
+  console.warn(`🔐 Token issue during ${context}`, { uid });
+}

--- a/App/utils/apiClient.ts
+++ b/App/utils/apiClient.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { getIdToken } from '@/utils/authUtils';
-import { signOutAndRetry } from '@/services/authLogger';
+import { signOutAndRetry } from '@/shared/signOut';
 
 let refreshPromise: Promise<string | null> | null = null;
 

--- a/App/utils/firebaseRequest.ts
+++ b/App/utils/firebaseRequest.ts
@@ -1,5 +1,5 @@
 import apiClient from '@/utils/apiClient';
-import { logTokenIssue } from '@/services/authLogger';
+import { logTokenIssue } from '@/shared/tokenLogger';
 import { getIdToken } from '@/utils/authUtils';
 import { useAuthStore } from '@/state/authStore';
 import { sendRequestWithGusBugLogging } from '@/utils/gusBugLogger';

--- a/App/utils/gusBugLogger.ts
+++ b/App/utils/gusBugLogger.ts
@@ -1,4 +1,5 @@
-import { signOutAndRetry, logTokenIssue } from '@/services/authLogger';
+import { signOutAndRetry } from '@/shared/signOut';
+import { logTokenIssue } from '@/shared/tokenLogger';
 import { getIdToken } from '@/utils/authUtils';
 import { showPermissionDenied } from '@/utils/gracefulError';
 import { useAuthStore } from '@/state/authStore';

--- a/App/utils/reminderNotification.ts
+++ b/App/utils/reminderNotification.ts
@@ -2,14 +2,12 @@ import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 
-const isDevClient =
-  !Constants.appOwnership ||
-  (Constants.appOwnership as unknown as string) === 'expo-dev-client';
+const canUseNotifications = Constants.appOwnership !== 'expo';
 
 const STORAGE_KEY = 'reflectionReminderId';
 
 export async function scheduleReflectionReminder(time: string) {
-  if (!isDevClient) {
+  if (!canUseNotifications) {
     console.warn('⚠️ Push notifications disabled in Expo Go.');
     return;
   }
@@ -26,7 +24,7 @@ export async function scheduleReflectionReminder(time: string) {
 }
 
 export async function cancelReflectionReminder() {
-  if (!isDevClient) {
+  if (!canUseNotifications) {
     console.warn('⚠️ Push notifications disabled in Expo Go.');
     return;
   }


### PR DESCRIPTION
## Summary
- break circular deps by moving logging helpers to App/shared
- patch onboarding to update full profile in one request
- guard push notifications from running in Expo Go

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879a223749c83308a39a3035c11cc41