### PR TITLE
Implement REST-based user seeding

### DIFF
--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -44,7 +44,7 @@ export default function SignupScreen() {
       const result = await signup(email, password);
       if (!result.localId) throw new Error("User creation failed.");
 
-      await seedUserProfile(result.localId, { email });
+      await seedUserProfile(result.localId, result.idToken!, { email: result.email });
       await initializeProfile(result.localId);
       await checkIfUserIsNewAndRoute();
     } catch (err: any) {

--- a/App/utils/index.ts
+++ b/App/utils/index.ts
@@ -1,1 +1,2 @@
 // Utilities entrypoint intentionally left minimal.
+export * from './userProfile';

--- a/App/utils/seedUserProfile.ts
+++ b/App/utils/seedUserProfile.ts
@@ -1,6 +1,5 @@
-import { doc, setDoc, getDoc, Timestamp } from 'firebase/firestore';
-import { firestore } from '@/config/firebaseClient';
-import type { User } from 'firebase/auth';
+import { FIRESTORE_BASE } from '../../firebaseRest';
+import { logFirestoreError } from '@/lib/logging';
 
 export interface AuthUserLike {
   email?: string | null;
@@ -8,64 +7,105 @@ export interface AuthUserLike {
   displayName?: string | null;
 }
 
-export async function seedUserProfile(uid: string, authUser?: AuthUserLike): Promise<void> {
+export async function seedUserProfile(
+  uid: string,
+  idToken: string,
+  authUser: AuthUserLike = {},
+): Promise<boolean> {
   if (!uid) throw new Error('uid is required');
 
-  const now = Timestamp.now();
-  const profile = {
-    uid,
-    email: authUser?.email ?? '',
-    emailVerified: !!authUser?.emailVerified,
-    displayName: authUser?.displayName ?? 'New User',
-    createdAt: now,
-    lastActive: now,
-    lastFreeAsk: now,
-    lastFreeSkip: now,
-    onboardingComplete: false,
-    religion: 'SpiritGuide',
-    tokens: 5,
-    skipTokensUsed: 0,
-    individualPoints: 0,
-    isSubscribed: false,
-    nightModeEnabled: false,
-    preferredName: null,
-    pronouns: null,
-    avatarURL: null,
-    profileComplete: false,
-    profileSchemaVersion: 'v1',
+  const now = new Date().toISOString();
+  const fields = {
+    uid: { stringValue: uid },
+    email: { stringValue: authUser.email ?? '' },
+    emailVerified: { booleanValue: authUser.emailVerified ?? false },
+    displayName: { stringValue: authUser.displayName ?? 'New User' },
+    createdAt: { timestampValue: now },
+    lastActive: { timestampValue: now },
+    lastFreeAsk: { timestampValue: now },
+    lastFreeSkip: { timestampValue: now },
+    onboardingComplete: { booleanValue: false },
+    religion: { stringValue: 'SpiritGuide' },
+    tokens: { integerValue: '5' },
+    skipTokensUsed: { integerValue: '0' },
+    individualPoints: { integerValue: '0' },
+    isSubscribed: { booleanValue: false },
+    nightModeEnabled: { booleanValue: false },
+    preferredName: { nullValue: null },
+    pronouns: { nullValue: null },
+    avatarURL: { nullValue: null },
+    profileComplete: { booleanValue: false },
+    profileSchemaVersion: { stringValue: 'v1' },
     challengeStreak: {
-      count: 0,
-      lastCompletedDate: null,
+      mapValue: {
+        fields: {
+          count: { integerValue: '0' },
+          lastCompletedDate: { nullValue: null },
+        },
+      },
     },
-    dailyChallengeCount: 0,
-    dailySkipCount: 0,
-    lastChallengeLoadDate: null,
-    lastSkipDate: null,
-    organization: null,
+    dailyChallengeCount: { integerValue: '0' },
+    dailySkipCount: { integerValue: '0' },
+    lastChallengeLoadDate: { nullValue: null },
+    lastSkipDate: { nullValue: null },
+    organization: { nullValue: null },
   };
 
-  await setDoc(doc(firestore, 'users', uid), profile, { merge: true });
+  const url = `${FIRESTORE_BASE}/users/${uid}`;
+  const body = JSON.stringify({ fields });
+  const headers = {
+    Authorization: `Bearer ${idToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  try {
+    const res = await fetch(url, { method: 'PATCH', headers, body });
+    if (!res.ok) {
+      const text = await res.text();
+      console.error('❌ seedUserProfile failed', res.status, text);
+      return false;
+    }
+    console.log('✅ user profile seeded', uid);
+    return true;
+  } catch (err: any) {
+    logFirestoreError('PATCH', `users/${uid}`, err);
+    console.error('seedUserProfile error', err);
+    return false;
+  }
 }
 
-export async function verifyUserProfile(uid: string): Promise<void> {
-  const snap = await getDoc(doc(firestore, 'users', uid));
-  if (!snap.exists()) {
-    console.log('⚠️ Profile missing for', uid);
-    return;
-  }
-  const data = snap.data();
-  const critical: (keyof typeof data)[] = [
-    'uid',
-    'email',
-    'displayName',
-    'createdAt',
-    'religion',
-    'tokens',
-  ];
-  const missing = critical.filter((k) => data[k] === undefined || data[k] === null);
-  if (missing.length) {
-    console.log('⚠️ Missing fields:', missing);
-  } else {
-    console.log('✅ Profile verified for', uid);
+export async function verifyUserProfile(
+  uid: string,
+  idToken: string,
+): Promise<void> {
+  const url = `${FIRESTORE_BASE}/users/${uid}`;
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${idToken}` },
+    });
+    if (!res.ok) {
+      console.log('⚠️ Profile missing for', uid);
+      return;
+    }
+    const data = (await res.json()) as any;
+    const fields = data.fields || {};
+    const critical = [
+      'uid',
+      'email',
+      'displayName',
+      'createdAt',
+      'religion',
+      'tokens',
+    ];
+    const missing = critical.filter((k) => fields[k] === undefined);
+    if (missing.length) {
+      console.log('⚠️ Missing fields:', missing);
+    } else {
+      console.log('✅ Profile verified for', uid);
+    }
+  } catch (err: any) {
+    logFirestoreError('GET', `users/${uid}`, err);
+    console.error('verifyUserProfile error', err);
   }
 }


### PR DESCRIPTION
## Summary
- add REST implementation for user profile seeding
- wire signup screen to send ID token to the seed function
- re-export utilities for login

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687d0afe62bc83308bc2117ae22f2fbe