### PR TITLE
Fix Firestore user creation flow

### DIFF
--- a/App/utils/seedUserProfile.ts
+++ b/App/utils/seedUserProfile.ts
@@ -1,5 +1,6 @@
 const PROJECT_ID = 'wwjd-app';
-const FIRESTORE_URL = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/users`;
+const FIRESTORE_URL =
+  `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/users`;
 
 // Type for the authUser argument
 interface AuthUser {
@@ -16,7 +17,7 @@ interface FirestoreSeedBody {
 export async function seedUserProfile(
   uid: string,
   idToken: string,
-  authUser: AuthUser = {}
+  authUser: AuthUser = {},
 ): Promise<void> {
   const now = new Date().toISOString();
 
@@ -58,8 +59,8 @@ export async function seedUserProfile(
     }
   };
 
-  const res = await fetch(`${FIRESTORE_URL}/${uid}`, {
-    method: 'PUT',
+  const res = await fetch(`${FIRESTORE_URL}?documentId=${uid}`, {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${idToken}`,
       'Content-Type': 'application/json'
@@ -68,11 +69,15 @@ export async function seedUserProfile(
   });
 
   if (!res.ok) {
-    const err = await res.text();
-    console.error('🔥 Firestore seed failed:', res.status, err);
+    let errorMsg: any = null;
+    try {
+      errorMsg = await res.json();
+    } catch {
+      errorMsg = await res.text();
+    }
+    console.error('🔥 Firestore seed failed:', res.status, errorMsg);
     throw new Error(`Firestore seed failed with status ${res.status}`);
   }
 
-  const json = await res.json();
-  console.log('✅ Firestore seed success:', json.name);
+  console.log('✅ Document created:', res.status);
 }

--- a/religionRest.ts
+++ b/religionRest.ts
@@ -47,7 +47,9 @@ export async function getReligionProfile(
   const url = `${FIRESTORE_BASE}/religion/${id}`;
   console.log('➡️ Sending Firestore request to:', url);
   try {
-    const res = await apiClient.get(url, { headers: { Authorization: `Bearer ${idToken}` } });
+    const res = await apiClient.get(url, {
+      headers: { Authorization: `Bearer ${idToken}` },
+    });
     const fields = (res.data as any).fields || {};
     const profile: ReligionProfile = {
       id,
@@ -62,6 +64,15 @@ export async function getReligionProfile(
     return profile;
   } catch (err: any) {
     logFirestoreError('GET', `religion/${id}`, err);
+    if (err.response?.status === 404) {
+      console.warn(`⚠️ Religion document missing: ${id}`);
+      const fallback: ReligionProfile = {
+        id,
+        name: id,
+        prompt: 'Respond with empathy, logic, and gentle spirituality.',
+      };
+      return fallback;
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- create the user profile document with POST and a documentId
- improve error logging for profile creation
- handle missing religion docs with a fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4ca1d558833092683af23fd46bb9