### PR TITLE
Fix onboarding with REST-based profile creation

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -7,8 +7,7 @@ import Button from "@/components/common/Button";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { loadUserProfile, setCachedUserProfile, updateUserProfile } from "@/utils/userProfile";
-import { fetchUserProfile } from "../../services/userService";
-import { createUserDoc } from "../../../firebaseRest";
+
 import { getIdToken } from "@/utils/authUtils";
 import { DEFAULT_RELIGION } from "@/config/constants";
 import type { UserProfile } from "../../../types";
@@ -67,22 +66,7 @@ export default function OnboardingScreen() {
     console.log('💾 Submitting onboarding', { username, region, religion, organization });
     try {
       if (uid) {
-        const token = await getIdToken(true);
-        // Always call createUserDoc to ensure Firestore is seeded with all required fields
-        const userDocFields = {
-          uid,
-          email: user?.email || '',
-          displayName: username.trim(),
-          username: username.trim(),
-          region: region || '',
-          religion: religion || DEFAULT_RELIGION,
-          idToken: token || '',
-          preferredName: user?.preferredName || '',
-          pronouns: user?.pronouns || '',
-          avatarURL: user?.avatarURL || '',
-          organization: organization || null,
-        };
-        await createUserDoc(userDocFields);
+        await getIdToken(true); // ensure token valid
         // Always reload the full profile after creation/update
         await updateUserProfile(
           {

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -5,7 +5,6 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { signup } from "@/services/authService";
-import { initializeProfile } from "@/services/userService";
 import { seedUserProfile } from "@/utils/seedUserProfile";
 import { checkIfUserIsNewAndRoute } from "@/services/onboardingService";
 import { useNavigation } from "@react-navigation/native";
@@ -45,7 +44,6 @@ export default function SignupScreen() {
       if (!result.localId) throw new Error("User creation failed.");
 
       await seedUserProfile(result.localId, result.idToken!, { email: result.email });
-      await initializeProfile(result.localId);
       await checkIfUserIsNewAndRoute();
     } catch (err: any) {
       console.warn("🚫 Signup Failed:", err?.response?.data?.error?.message);

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -1,7 +1,6 @@
 import { loadUserProfile, updateUserProfile } from "@/utils/userProfile";
 import { useUserStore } from "@/state/userStore";
 import { useUserProfileStore } from "@/state/userProfile";
-import { callFunction } from "@/services/functionService";
 import { ensureAuth } from "@/utils/authGuard";
 import { getIdToken } from "@/utils/authUtils";
 import type { FirestoreUser, UserProfile } from "../../types";
@@ -226,15 +225,3 @@ export async function completeOnboarding(uid: string) {
   await updateUserProfile({ onboardingComplete: true }, storedUid);
 }
 
-export async function initializeProfile(uid: string) {
-  try {
-    const profile = await callFunction('createUserProfile', { uid });
-    if (profile) {
-      useUserProfileStore.getState().setUserProfile(profile as any);
-    }
-    return profile as UserProfile;
-  } catch (err) {
-    console.warn('initializeProfile failed', err);
-    return null;
-  }
-}

--- a/App/utils/seedUserProfile.ts
+++ b/App/utils/seedUserProfile.ts
@@ -19,6 +19,18 @@ export async function seedUserProfile(
   idToken: string,
   authUser: AuthUser = {},
 ): Promise<void> {
+  // Skip creation if document already exists
+  const checkRes = await fetch(`${FIRESTORE_URL}/${uid}`, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  if (checkRes.ok) {
+    console.log('📄 User doc already exists, skipping seed');
+    return;
+  }
+  if (checkRes.status !== 404) {
+    console.error('🔥 Failed to check user doc', checkRes.status);
+    throw new Error(`Failed to verify user doc: ${checkRes.status}`);
+  }
   const now = new Date().toISOString();
 
   const body: FirestoreSeedBody = {


### PR DESCRIPTION
## Summary
- avoid duplicate profile creation
- remove cloud function usage during onboarding
- fetch user profiles directly via Firestore REST
- ensure missing profiles are created via REST

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d57a892e08330981eaea0cd028cd5