### PR TITLE
Finalize onUserCreate user profile

### DIFF
--- a/App/services/authService.ts
+++ b/App/services/authService.ts
@@ -11,7 +11,7 @@ import {
 import { performLogout } from '@/shared/logout';
 import { startTokenRefresh, stopTokenRefresh } from '@/lib/tokenRefresh';
 import { resetToLogin } from '@/navigation/navigationRef';
-import { ensureUserDocExists, loadUser, refreshLastActive } from './userService';
+import { loadUser, refreshLastActive } from './userService';
 
 export function initAuthState(): void {
   const setAuthReady = useAuthStore.getState().setAuthReady;
@@ -23,7 +23,6 @@ export function initAuthState(): void {
         setUid(user.uid);
         setIdToken(await fbGetIdToken(true));
         startTokenRefresh();
-        await ensureUserDocExists(user.uid, user.email ?? undefined);
         await loadUser(user.uid);
         await refreshLastActive(user.uid);
       } else {

--- a/App/services/userService.ts
+++ b/App/services/userService.ts
@@ -2,10 +2,8 @@ import { loadUserProfile, updateUserProfile } from "@/utils/userProfile";
 import { useUserStore } from "@/state/userStore";
 import { useUserProfileStore } from "@/state/userProfile";
 import { ensureAuth } from "@/utils/authGuard";
-import { getIdToken } from "@/utils/authUtils";
 import type { FirestoreUser, UserProfile } from "../../types";
 import { DEFAULT_RELIGION } from "@/config/constants";
-import { createUserDoc } from "../../firebaseRest";
 
 function generateUsernameFromDisplayName(displayName: string): string {
   return displayName
@@ -47,42 +45,6 @@ export async function initializeUserDataIfNeeded(uid: string): Promise<void> {
 /**
  * Ensure the user document exists before accessing it
  */
-export async function ensureUserDocExists(
-  uid: string,
-  email?: string,
-  displayName?: string,
-): Promise<boolean> {
-  try {
-    const existing = await fetchUserProfile(uid);
-    if (existing) {
-      console.log('📄 User doc already exists for', uid);
-      return false;
-    }
-  } catch (err: any) {
-    if (err?.response?.status !== 404) {
-      console.warn('⚠️ ensureUserDocExists failed', err);
-      throw err;
-    }
-  }
-
-  const idToken = await getIdToken(true);
-  if (!idToken) throw new Error('Unable to get auth token');
-  await createUserDoc({
-    uid,
-    email: email || '',
-    displayName: displayName || 'New User',
-    username: generateUsernameFromDisplayName(displayName || 'New User'),
-    region: '',
-    religion: DEFAULT_RELIGION,
-    idToken,
-    preferredName: '',
-    pronouns: '',
-    avatarURL: '',
-    organization: null,
-  });
-  console.log('📄 Created user doc for', uid);
-  return true;
-}
 
 export async function refreshLastActive(uid: string): Promise<void> {
   const storedUid = await ensureAuth(uid);
@@ -115,7 +77,6 @@ export async function loadUser(uid: string): Promise<void> {
   const storedUid = await ensureAuth(uid);
   if (!storedUid) return;
 
-  await ensureUserDocExists(storedUid);
   await initializeUserDataIfNeeded(storedUid);
 
   const snapshot = await loadUserProfile(storedUid);
@@ -143,76 +104,6 @@ export async function loadUser(uid: string): Promise<void> {
   } else {
     throw new Error("User not found in Firestore.");
   }
-}
-
-/**
- * Create user profile in Firestore on first signup
- */
-export async function createUserProfile({
-  uid,
-  email,
-  displayName,
-  username,
-  religion = DEFAULT_RELIGION,
-  region = "",
-  organizationId,
-}: {
-  uid: string;
-  email: string;
-  username?: string;
-  displayName?: string;
-  religion?: string;
-  region?: string;
-  organizationId?: string;
-}) {
-  const storedUid = await ensureAuth(uid);
-  if (!storedUid) return;
-
-  const slugify = (str: string) =>
-    str
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "");
-
-  const now = Date.now();
-
-  const userData: FirestoreUser = {
-    email,
-    username,
-    displayName: displayName || "New User",
-    religion,
-    religionSlug: slugify(religion),
-    region,
-    organization: organizationId || null,
-    individualPoints: 0,
-    tokens: 0,
-    skipTokensUsed: 0,
-    lastFreeAsk: null,
-    lastFreeSkip: null,
-    isSubscribed: false,
-    nightModeEnabled: false,
-    religionPrefix: "",
-    onboardingComplete: false,
-    profileComplete: false,
-    profileSchemaVersion: 1,
-    lastActive: new Date().toISOString(),
-    preferredName: "",
-    pronouns: "",
-    avatarURL: "",
-    createdAt: now,
-    streak: { current: 0, longest: 0, lastUpdated: new Date().toISOString() },
-    challengeStreak: { count: 0, lastCompletedDate: null },
-    dailyChallengeCount: 0,
-    dailySkipCount: 0,
-    lastChallengeLoadDate: null,
-    lastSkipDate: null,
-  } as any;
-
-  if (organizationId) {
-    (userData as any).organizationId = organizationId;
-  }
-
-  await updateUserProfile(userData, storedUid);
 }
 
 /**

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1473,27 +1473,20 @@ export const onUserCreate = functions
   .user()
   .onCreate(async (user: admin.auth.UserRecord) => {
     const uid = user.uid;
-    console.log(`onUserCreate triggered for ${uid}`);
     try {
       const docRef = admin.firestore().doc(`users/${uid}`);
-      const existing = await docRef.get();
-      if (existing.exists) {
-        console.log(`User document already exists for ${uid}`);
-        return;
-      }
-
       const timestamp = admin.firestore.FieldValue.serverTimestamp();
       const profile = {
         uid,
         email: user.email || "",
         emailVerified: !!user.emailVerified,
-        displayName: null,
+        displayName: "",
         createdAt: timestamp,
         lastActive: timestamp,
         lastFreeAsk: null,
         lastFreeSkip: null,
         onboardingComplete: false,
-        religion: null,
+        religion: "SpiritGuide",
         tokens: 5,
         skipTokensUsed: 0,
         individualPoints: 0,
@@ -1503,14 +1496,17 @@ export const onUserCreate = functions
         pronouns: null,
         avatarURL: null,
         profileComplete: false,
-        profileSchemaVersion: "v1",
+        profileSchemaVersion: 1,
         challengeStreak: { count: 0, lastCompletedDate: null },
+        dailyChallengeCount: 0,
+        dailySkipCount: 0,
+        lastChallengeLoadDate: null,
+        lastSkipDate: null,
+        organization: null,
       };
 
       await docRef.set(profile, { merge: false });
-
-      console.log(`onUserCreate completed for ${uid}`);
     } catch (err) {
-      console.error(`onUserCreate failed for ${uid}`, err);
+      logger.error(`onUserCreate failed for ${uid}`, err);
     }
   });


### PR DESCRIPTION
## Summary
- create full user document from onUserCreate with default values
- rely on Cloud Function instead of client helpers for profile creation
- remove redundant createUserDoc logic
- simplify profile initialization helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dadce1e588330bfa480bd954fd2fb