### PR TITLE
Ensure UID/email saved on signup and make onboarding scrollable

### DIFF
--- a/App/screens/auth/OnboardingScreen.tsx
+++ b/App/screens/auth/OnboardingScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import CustomText from "@/components/CustomText";
-import { View, StyleSheet, Alert, ActivityIndicator } from "react-native";
+import { View, StyleSheet, Alert, ActivityIndicator, ScrollView } from "react-native";
 import TextField from "@/components/TextField";
 import * as SecureStore from "expo-secure-store";
 import ScreenContainer from "@/components/theme/ScreenContainer";
@@ -239,8 +239,9 @@ export default function OnboardingScreen() {
 
   return (
     <ScreenContainer>
-      <CustomText style={styles.title}>Welcome to OneVine 🌿</CustomText>
-      <CustomText style={styles.subtitle}>Tell us about yourself:</CustomText>
+      <ScrollView contentContainerStyle={{ paddingBottom: theme.spacing.lg }}>
+        <CustomText style={styles.title}>Welcome to OneVine 🌿</CustomText>
+        <CustomText style={styles.subtitle}>Tell us about yourself:</CustomText>
 
       <TextField
         label="Username *"
@@ -327,12 +328,13 @@ export default function OnboardingScreen() {
           loading={backfilling}
         />
       )}
-      <CustomText
-        style={styles.link}
-        onPress={() => navigation.navigate("Login")}
-      >
-        Already have an account? Log in
-      </CustomText>
+        <CustomText
+          style={styles.link}
+          onPress={() => navigation.navigate("Login")}
+        >
+          Already have an account? Log in
+        </CustomText>
+      </ScrollView>
     </ScreenContainer>
   );
 }

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1477,8 +1477,8 @@ export const onUserCreate = functions
       const docRef = admin.firestore().doc(`users/${uid}`);
       const timestamp = admin.firestore.FieldValue.serverTimestamp();
       const profile = {
-        uid,
-        email: user.email || "",
+        uid: user.uid,
+        email: user.email ?? "",
         emailVerified: !!user.emailVerified,
         displayName: user.displayName || "",
         username: "",
@@ -1507,6 +1507,8 @@ export const onUserCreate = functions
         organization: null,
         religionPrefix: "",
       };
+
+      logger.info("onUserCreate profile", profile);
 
       await docRef.set(profile, { merge: false });
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure email and uid fields are set in `onUserCreate`
- log the profile object before writing
- wrap onboarding screen content in a `ScrollView`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dd7f9522c8330b27d599fa4717059