### PR TITLE
Update Firebase functions to Node 20

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,7 +10,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "firebase-admin": "^13.4.0",
-        "firebase-functions": "^6.3.2",
+        "firebase-functions": "^6.4.0",
         "stripe": "^18.3.0"
       },
       "devDependencies": {
@@ -19,7 +19,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "18"
+        "node": "20"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -1297,9 +1297,9 @@
       "license": "MIT"
     },
     "node_modules/firebase-functions": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.2.tgz",
-      "integrity": "sha512-FC3A1/nhqt1ZzxRnj5HZLScQaozAcFSD/vSR8khqSoFNOfxuXgwJS6ZABTB7+v+iMD5z6Mmxw6OfqITUBuI7OQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.4.0.tgz",
+      "integrity": "sha512-Q/LGhJrmJEhT0dbV60J4hCkVSeOM6/r7xJS/ccmkXzTWMjo+UPAYX9zlQmGlEjotstZ0U9GtQSJSgbB2Z+TJDg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,15 +5,15 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "npm run clean && tsc",
-    "deploy": "npm run clean && npm run build && firebase deploy --only functions --runtime=nodejs18",
+    "deploy": "npm run clean && npm run build && firebase deploy --only functions --runtime=nodejs20",
     "start": "npm run clean && npm run build && firebase emulators:start --only functions"
   },
   "engines": {
-    "node": "18"
+    "node": "20"
   },
   "dependencies": {
     "firebase-admin": "^13.4.0",
-    "firebase-functions": "^6.3.2",
+    "firebase-functions": "^6.4.0",
     "dotenv": "^16.5.0",
     "@google/generative-ai": "^0.24.1",
     "stripe": "^18.3.0",


### PR DESCRIPTION
## Summary
- use Node.js 20 runtime for Cloud Functions
- upgrade `firebase-functions` to v6.4.0

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687dde7cdf4c83309799847b86193fe4