### PR TITLE
Fix AuthGate initial route to Home

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -9,6 +9,7 @@ import LoadingScreen from '@/components/common/LoadingScreen';
 import { useAuth } from '@/hooks/useAuth';
 import { useUser } from '@/hooks/useUser';
 import { useUserStore } from '@/state/userStore';
+import { useUserProfileStore } from '@/state/userProfile';
 import { initAuthState } from '@/services/authService';
 import { loadUserProfile } from '@/utils/userProfile';
 import { refreshLastActive } from '@/services/userService';
@@ -75,6 +76,7 @@ export default function AuthGate() {
         try {
           const fetched = await loadUserProfile(uid);
           if (fetched) {
+            useUserProfileStore.getState().setUserProfile(fetched as any);
             useUserStore.getState().setUser({
               uid: fetched.uid,
               email: fetched.email,


### PR DESCRIPTION
## Summary
- ensure user profile store is updated when verifying auth
- avoid missing `Home` screen on first render by keeping profile in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687efc623fa88330a6a247e6dc0b7875