### PR TITLE
Fix Firestore rule syntax

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -77,12 +77,12 @@ service cloud.firestore {
     match /religion/{docId} {
       // Religion list is used on the signup screen before auth
       // so allow public read access
-      allow read: true;
+      allow read: if true;
     }
 
     match /regions/{docId} {
       // Region list is required prior to authentication
-      allow read: true;
+      allow read: if true;
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix Firestore security rules by adding missing `if` clauses

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68801d40eda48330a031e98cff0c4e04