### PR TITLE
Implement multi-step onboarding

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -17,6 +17,7 @@ import { refreshLastActive } from '@/services/userService';
 // Auth Screens
 import LoginScreen from '@/screens/auth/LoginScreen';
 import SignupScreen from '@/screens/auth/SignupScreen';
+import ProfileCompletionScreen from '@/screens/auth/ProfileCompletionScreen';
 import WelcomeScreen from '@/screens/auth/WelcomeScreen';
 import ForgotPasswordScreen from '@/screens/auth/ForgotPasswordScreen';
 import ForgotUsernameScreen from '@/screens/auth/ForgotUsernameScreen';
@@ -168,6 +169,7 @@ export default function AuthGate() {
             <Stack.Screen name="SubmitProof" component={SubmitProofScreen} options={{ title: 'Submit Proof' }} />
             <Stack.Screen name="OrganizationManagement" component={OrganizationManagementScreen} options={{ title: 'Manage Organization' }} />
             <Stack.Screen name="JoinOrganization" component={JoinOrganizationScreen} options={{ title: 'Join Organization' }} />
+            <Stack.Screen name="ProfileCompletion" component={ProfileCompletionScreen} options={{ title: 'Complete Profile' }} />
           </>
         )}
       </Stack.Navigator>

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -18,6 +18,7 @@ export type RootStackParamList = {
   ForgotPassword: undefined;
   ForgotUsername: undefined;
   OrganizationSignup: undefined;
+  ProfileCompletion: undefined;
 
   // Main app screens
   HomeScreen: undefined;

--- a/App/navigation/screens.ts
+++ b/App/navigation/screens.ts
@@ -2,7 +2,8 @@ export const SCREENS = {
   AUTH: {
     LOGIN: 'Login',
     SIGNUP: 'Signup',
-    ORGANIZATION_SIGNUP: 'OrganizationSignup'
+    ORGANIZATION_SIGNUP: 'OrganizationSignup',
+    PROFILE_COMPLETION: 'ProfileCompletion'
     // FORGOT_PASSWORD: 'ForgotPassword' // Optional: add if needed
   },
 

--- a/App/screens/auth/ProfileCompletionScreen.tsx
+++ b/App/screens/auth/ProfileCompletionScreen.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect } from 'react';
+import CustomText from '@/components/CustomText';
+import { View, StyleSheet, ScrollView, Alert, ActivityIndicator } from 'react-native';
+import ScreenContainer from '@/components/theme/ScreenContainer';
+import TextField from '@/components/TextField';
+import Button from '@/components/common/Button';
+import { Picker } from '@react-native-picker/picker';
+import { useLookupLists } from '@/hooks/useLookupLists';
+import { updateUserProfile } from '@/utils/userProfile';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '@/navigation/RootStackParamList';
+import { useTheme } from '@/components/theme/theme';
+import { SCREENS } from '@/navigation/screens';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function ProfileCompletionScreen() {
+  const { uid } = useAuth();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { regions, religions, loading } = useLookupLists();
+  const theme = useTheme();
+
+  const [region, setRegion] = useState('');
+  const [religion, setReligion] = useState('');
+  const [preferredName, setPreferredName] = useState('');
+  const [pronouns, setPronouns] = useState('');
+  const [avatarURL, setAvatarURL] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!region && regions.length) setRegion(regions[0].name);
+    if (!religion && religions.length) setReligion(religions[0].id);
+  }, [regions, religions]);
+
+  const handleComplete = async () => {
+    if (!uid) return;
+    if (!region || !religion) {
+      Alert.alert('Missing Info', 'Please select a region and religion.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: Record<string, any> = {
+        region,
+        religion,
+        onboardingComplete: true,
+        profileComplete: true,
+      };
+      if (preferredName.trim()) payload.preferredName = preferredName.trim();
+      if (pronouns.trim()) payload.pronouns = pronouns.trim();
+      if (avatarURL.trim()) payload.avatarURL = avatarURL.trim();
+      await updateUserProfile(payload, uid);
+      navigation.reset({ index: 0, routes: [{ name: SCREENS.MAIN.HOME }] });
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Could not save profile');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        title: {
+          fontSize: 24,
+          fontWeight: '700',
+          color: theme.colors.text,
+          marginBottom: 20,
+        },
+        pickerWrapper: {
+          borderWidth: 1,
+          borderColor: theme.colors.border,
+          borderRadius: 8,
+          marginBottom: 20,
+          overflow: 'hidden',
+          backgroundColor: theme.colors.surface,
+        },
+        picker: { height: 50, color: theme.colors.text },
+        link: {
+          marginTop: 20,
+          color: theme.colors.primary,
+          textAlign: 'center',
+        },
+      }),
+    [theme]
+  );
+
+  if (loading) {
+    return (
+      <ScreenContainer>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </ScreenContainer>
+    );
+  }
+
+  return (
+    <ScreenContainer>
+      <ScrollView contentContainerStyle={{ paddingBottom: theme.spacing.lg }}>
+        <CustomText style={styles.title}>Complete Your Profile</CustomText>
+        <TextField
+          label="Preferred Name"
+          value={preferredName}
+          onChangeText={setPreferredName}
+          placeholder="Optional"
+        />
+        <TextField
+          label="Pronouns"
+          value={pronouns}
+          onChangeText={setPronouns}
+          placeholder="Optional"
+        />
+        <TextField
+          label="Avatar URL"
+          value={avatarURL}
+          onChangeText={setAvatarURL}
+          placeholder="Optional"
+        />
+
+        <CustomText style={{ marginBottom: 8 }}>Select your region:</CustomText>
+        <View style={styles.pickerWrapper}>
+          <Picker
+            selectedValue={region}
+            onValueChange={(v) => setRegion(v)}
+            style={styles.picker}
+          >
+            {regions.map((r) => (
+              <Picker.Item key={r.id} label={r.name} value={r.name} />
+            ))}
+          </Picker>
+        </View>
+
+        <CustomText style={{ marginBottom: 8 }}>Choose your spiritual lens:</CustomText>
+        <View style={styles.pickerWrapper}>
+          <Picker
+            selectedValue={religion}
+            onValueChange={(v) => setReligion(v)}
+            style={styles.picker}
+          >
+            {religions.map((r) => (
+              <Picker.Item key={r.id} label={r.id} value={r.id} />
+            ))}
+          </Picker>
+        </View>
+
+        <Button title="Complete Profile" onPress={handleComplete} loading={saving} />
+      </ScrollView>
+    </ScreenContainer>
+  );
+}

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -1,23 +1,17 @@
 import React, { useState } from "react";
 import CustomText from "@/components/CustomText";
-import { View, StyleSheet, Alert, ScrollView, ActivityIndicator } from "react-native";
+import { StyleSheet, Alert, ScrollView } from "react-native";
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { signup } from "@/services/authService";
-import { API_URL } from "@/config/firebaseApp";
-import { getAuthHeaders } from "@/utils/authUtils";
-import { loadUserProfile, CURRENT_PROFILE_SCHEMA } from "@/utils/userProfile";
-import { useUserProfileStore } from "@/state/userProfile";
-import { DEFAULT_RELIGION } from "@/config/constants";
+import { updateUserProfile } from "@/utils/userProfile";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTheme } from "@/components/theme/theme";
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { resetToLogin } from "@/navigation/navigationRef";
 import { SCREENS } from "@/navigation/screens";
-import { Picker } from "@react-native-picker/picker";
-import { useLookupLists } from "@/hooks/useLookupLists";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -25,18 +19,10 @@ export default function SignupScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [username, setUsername] = useState("");
-  const [preferredName, setPreferredName] = useState("");
-  const [pronouns, setPronouns] = useState("");
-  const [avatarURL, setAvatarURL] = useState("");
-  const [region, setRegion] = useState("");
-  const [religion, setReligion] = useState("");
-  const [organization, setOrganization] = useState("");
-  const [religionError, setReligionError] = useState("");
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
   const navigation = useNavigation<NavigationProp>();
   const theme = useTheme();
-  const { regions, religions, loading: listsLoading } = useLookupLists();
 
   const handleSignup = async () => {
     if (!email || !/^\S+@\S+\.\S+$/.test(email)) {
@@ -57,29 +43,6 @@ export default function SignupScreen() {
       Alert.alert("Missing Info", "Username is required.");
       return;
     }
-    if (!preferredName.trim()) {
-      console.log('Validation failed: preferred name required');
-      Alert.alert("Missing Info", "Preferred name is required.");
-      return;
-    }
-    if (!pronouns.trim()) {
-      console.log('Validation failed: pronouns required');
-      Alert.alert("Missing Info", "Pronouns are required.");
-      return;
-    }
-    if (!avatarURL.trim()) {
-      console.log('Validation failed: avatar URL required');
-      Alert.alert("Missing Info", "Avatar URL is required.");
-      return;
-    }
-    if (!religion) {
-      console.log('Validation failed: religion not selected');
-      setReligionError("Please select a spiritual lens.");
-      return;
-    } else {
-      setReligionError("");
-    }
-
     const requestPayload = { email, password };
     console.log("➡️ signup payload", requestPayload);
     setErrorMsg("");
@@ -88,64 +51,9 @@ export default function SignupScreen() {
       const result = await signup(email, password);
       if (!result.localId) throw new Error("User creation failed.");
 
-      const uid = result.localId;
-      const headers = await getAuthHeaders();
-      const now = new Date().toISOString();
-      const profile = {
-        uid,
-        email: email.trim(),
-        emailVerified: false,
-        displayName: username.trim(),
-        username: username.trim(),
-        region: region || "",
-        createdAt: now,
-        lastActive: now,
-        lastFreeAsk: now,
-        lastFreeSkip: now,
-        onboardingComplete: true,
-        religion: religion || DEFAULT_RELIGION,
-        tokens: 0,
-        skipTokensUsed: 0,
-        individualPoints: 0,
-        isSubscribed: false,
-        nightModeEnabled: false,
-        preferredName: preferredName.trim(),
-        pronouns: pronouns.trim(),
-        avatarURL: avatarURL.trim(),
-        profileComplete: true,
-        profileSchemaVersion: CURRENT_PROFILE_SCHEMA,
-        challengeStreak: { count: 0, lastCompletedDate: null },
-        dailyChallengeCount: 0,
-        dailySkipCount: 0,
-        lastChallengeLoadDate: null,
-        lastSkipDate: null,
-        organization: organization || null,
-        organizationId: null,
-        religionPrefix: "",
-      };
+      await updateUserProfile({ username: username.trim(), displayName: username.trim() }, result.localId);
 
-      const res = await fetch(`${API_URL}/completeSignupAndProfile`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ data: { uid, profile } }),
-      });
-      if (!res.ok) {
-        try {
-          const { error } = await res.json();
-          const e: any = new Error(error?.message || `HTTP ${res.status}`);
-          e.code = error?.status || error?.message;
-          throw e;
-        } catch (err) {
-          if (err instanceof Error) throw err;
-          throw new Error(`HTTP ${res.status}`);
-        }
-      }
-
-      const createdProfile = await loadUserProfile(uid);
-      if (createdProfile) {
-        useUserProfileStore.getState().setUserProfile(createdProfile as any);
-      }
-      navigation.reset({ index: 0, routes: [{ name: SCREENS.MAIN.HOME }] });
+      navigation.navigate(SCREENS.AUTH.PROFILE_COMPLETION as any);
     } catch (err: any) {
       console.warn(
         "🚫 Signup Failed:",
@@ -199,24 +107,6 @@ export default function SignupScreen() {
           color: theme.colors.text,
           marginBottom: 20,
         },
-        subtitle: {
-          fontSize: 16,
-          color: theme.colors.fadedText,
-          marginBottom: 20,
-          textAlign: "center",
-        },
-        pickerWrapper: {
-          borderWidth: 1,
-          borderColor: theme.colors.border,
-          borderRadius: 8,
-          marginBottom: 20,
-          overflow: "hidden",
-        },
-        picker: {
-          height: 50,
-          color: theme.colors.text,
-          backgroundColor: theme.colors.inputBackground || theme.colors.surface,
-        },
         link: {
           marginTop: 20,
           color: theme.colors.primary,
@@ -225,14 +115,6 @@ export default function SignupScreen() {
       }),
     [theme],
   );
-
-  if (listsLoading) {
-    return (
-      <ScreenContainer>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-      </ScreenContainer>
-    );
-  }
 
   return (
     <ScreenContainer>
@@ -259,67 +141,6 @@ export default function SignupScreen() {
           value={username}
           onChangeText={setUsername}
           placeholder="johndoe"
-        />
-
-        <TextField
-          label="Preferred Name *"
-          value={preferredName}
-          onChangeText={setPreferredName}
-          placeholder="John"
-        />
-
-        <TextField
-          label="Pronouns *"
-          value={pronouns}
-          onChangeText={setPronouns}
-          placeholder="he/him"
-        />
-
-        <TextField
-          label="Avatar URL *"
-          value={avatarURL}
-          onChangeText={setAvatarURL}
-          placeholder="https://example.com/avatar.jpg"
-        />
-
-        <CustomText style={styles.subtitle}>Select your region:</CustomText>
-        <View style={styles.pickerWrapper}>
-          <Picker
-            selectedValue={region}
-            onValueChange={(val) => setRegion(val)}
-            style={styles.picker}
-          >
-            <Picker.Item label="Select your region" value="" />
-            {regions.map((r) => (
-              <Picker.Item key={r.id} label={r.name} value={r.name} />
-            ))}
-          </Picker>
-        </View>
-
-        <CustomText style={styles.subtitle}>Choose your spiritual lens:</CustomText>
-        <View style={styles.pickerWrapper}>
-          <Picker
-            selectedValue={religion}
-            onValueChange={(val) => setReligion(val)}
-            style={styles.picker}
-          >
-            <Picker.Item label="Select your spiritual lens" value="" />
-            {religions.map((r) => (
-              <Picker.Item key={r.id} label={r.id} value={r.id} />
-            ))}
-          </Picker>
-        </View>
-        {religionError ? (
-          <CustomText style={{ color: 'red', marginBottom: 8 }}>
-            {religionError}
-          </CustomText>
-        ) : null}
-
-        <TextField
-          label="Organization"
-          value={organization}
-          onChangeText={setOrganization}
-          placeholder="Optional"
         />
 
         {errorMsg ? (

--- a/firestore.rules
+++ b/firestore.rules
@@ -74,15 +74,13 @@ service cloud.firestore {
     }
 
     // 🌍 Static lookup collections
-    match /religion/{docId} {
-      // Religion list is used on the signup screen before auth
-      // so allow public read access
-      allow read: if true;
+    // Allow authenticated users to read regions and religions
+    match /regions/{regionId} {
+      allow read: if isSignedIn();
     }
 
-    match /regions/{docId} {
-      // Region list is required prior to authentication
-      allow read: if true;
+    match /religions/{religionId} {
+      allow read: if isSignedIn();
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow authenticated users to read lookup collections
- add ProfileCompletionScreen for onboarding
- streamline SignupScreen to only create auth user
- navigate to profile completion after signup
- register new screen in navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68811f67c0888330bd365b093c38c37c