### PR TITLE
Add onboarding routing and count updates

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -13,6 +13,7 @@ import { useUserProfileStore } from '@/state/userProfile';
 import { initAuthState } from '@/services/authService';
 import { loadUserProfile } from '@/utils/userProfile';
 import { refreshLastActive } from '@/services/userService';
+import { SCREENS } from './screens';
 
 // Auth Screens
 import LoginScreen from '@/screens/auth/LoginScreen';
@@ -108,8 +109,16 @@ export default function AuthGate() {
         return;
       }
 
-      console.log('➡️ route -> HomeScreen');
-      setInitialRoute('HomeScreen');
+      if (
+        profile &&
+        (profile.onboardingComplete === false || profile.onboardingComplete === undefined)
+      ) {
+        console.log('➡️ route -> ProfileCompletion');
+        setInitialRoute(SCREENS.AUTH.PROFILE_COMPLETION as keyof RootStackParamList);
+      } else {
+        console.log('➡️ route -> HomeScreen');
+        setInitialRoute(SCREENS.MAIN.HOME as keyof RootStackParamList);
+      }
       setChecking(false);
     }
     verify();

--- a/firestore.rules
+++ b/firestore.rules
@@ -77,10 +77,12 @@ service cloud.firestore {
     // Allow authenticated users to read regions and religions
     match /regions/{regionId} {
       allow read: if isSignedIn();
+      allow update: if isSignedIn();
     }
 
     match /religions/{religionId} {
       allow read: if isSignedIn();
+      allow update: if isSignedIn();
     }
   }
 }


### PR DESCRIPTION
## Summary
- route authenticated users to onboarding or home
- increment region/religion counts when finishing profile
- allow updates to region and religion docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688124be5b688330b43eaa7edddc0084