### PR TITLE
Update Firestore rules for read-only lookup collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -77,12 +77,10 @@ service cloud.firestore {
     // Allow authenticated users to read regions and religions
     match /regions/{regionId} {
       allow read: if isSignedIn();
-      allow update: if isSignedIn();
     }
 
     match /religions/{religionId} {
       allow read: if isSignedIn();
-      allow update: if isSignedIn();
     }
   }
 }


### PR DESCRIPTION
## Summary
- restrict write access to `/regions/{regionId}` and `/religions/{religionId}`
- maintain existing rules for users, challenges, organizations and other user collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688131d0fe008330b80682507046d03e