### PR TITLE
Allow nested reads for static lookup collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -74,12 +74,13 @@ service cloud.firestore {
     }
 
     // 🌍 Static lookup collections
-    // Allow authenticated users to read regions and religions
-    match /regions/{regionId} {
+    // Allow authenticated users to read regions and religions, including any
+    // nested subcollections or documents.
+    match /regions/{path=**} {
       allow read: if isSignedIn();
     }
 
-    match /religion/{religionId} {
+    match /religion/{path=**} {
       allow read: if isSignedIn();
     }
   }


### PR DESCRIPTION
## Summary
- update Firestore rules to allow nested `read` access for `regions` and `religion`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814276114883309603134964fc2c71