### PR TITLE
Fix profile completion transaction

### DIFF
--- a/App/screens/auth/ProfileCompletionScreen.tsx
+++ b/App/screens/auth/ProfileCompletionScreen.tsx
@@ -53,7 +53,7 @@ export default function ProfileCompletionScreen() {
 
       await runTransaction(firestore, async (transaction) => {
         const regionRef = doc(firestore, 'regions', region);
-        const religionRef = doc(firestore, 'religions', religion);
+        const religionRef = doc(firestore, 'religion', religion);
         const userRef = doc(firestore, 'users', uid);
 
         const regionDoc = await transaction.get(regionRef);

--- a/firestore.rules
+++ b/firestore.rules
@@ -76,14 +76,20 @@ service cloud.firestore {
     // 🌍 Static lookup collections
     // Allow authenticated users to read regions and religions, including any
     // nested subcollections or documents.
-    match /regions/{path=**} {
+    match /regions/{regionId} {
       allow read: if isSignedIn();
+      allow update: if isSignedIn();
+      // Subcollections remain read-only
+      match /{subPath=**} {
+        allow read: if isSignedIn();
+      }
     }
 
     // 📖 Religion lookup collection uses capitalized document IDs
     // Match the top-level document and any nested paths
     match /religion/{religionId} {
       allow read: if isSignedIn();
+      allow update: if isSignedIn();
       match /{subPath=**} {
         allow read: if isSignedIn();
       }


### PR DESCRIPTION
## Summary
- update Firestore rules to allow updating regions and religion docs
- correct collection path in ProfileCompletionScreen so writes go to `religion`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68815abc245883309c80d4f4daf5dfdd