### PR TITLE
Fix region doc lookup casing

### DIFF
--- a/App/screens/auth/ProfileCompletionScreen.tsx
+++ b/App/screens/auth/ProfileCompletionScreen.tsx
@@ -8,6 +8,7 @@ import { Picker } from '@react-native-picker/picker';
 import { useLookupLists } from '@/hooks/useLookupLists';
 import { firestore } from '@/config/firebaseClient';
 import { doc, runTransaction } from 'firebase/firestore';
+import { getRegionDocRef } from '@/utils/regionUtils';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
@@ -52,7 +53,7 @@ export default function ProfileCompletionScreen() {
       if (avatarURL.trim()) payload.avatarURL = avatarURL.trim();
 
       await runTransaction(firestore, async (transaction) => {
-        const regionRef = doc(firestore, 'regions', region);
+        const regionRef = getRegionDocRef(firestore, region);
         const religionRef = doc(firestore, 'religion', religion);
         const userRef = doc(firestore, 'users', uid);
 

--- a/App/utils/regionUtils.ts
+++ b/App/utils/regionUtils.ts
@@ -1,0 +1,13 @@
+import { Firestore, DocumentReference, doc } from 'firebase/firestore';
+
+/**
+ * Helper to build a reference to a region document.
+ * Region IDs in Firestore are stored lowercase so we always
+ * normalize the provided ID before creating the reference.
+ */
+export function getRegionDocRef(
+  firestore: Firestore,
+  regionId: string,
+): DocumentReference {
+  return doc(firestore, 'regions', regionId.toLowerCase());
+}


### PR DESCRIPTION
## Summary
- helper to create region doc refs with lowercase IDs
- use helper when updating region counts during profile completion

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68816dc63854833090565a8fcbeca53f