### PR TITLE
Fix Firestore lookups using getDoc

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -80,9 +80,5 @@ service cloud.firestore {
       allow get, list: if isSignedIn(); // ⚠️ Same here for batchGet compatibility
     }
 
-    // 🚨 TEMPORARY DEBUGGING: fallback get matcher
-    match /{document=**} {
-      allow get: if isSignedIn();
-    }
   }
 }


### PR DESCRIPTION
## Summary
- refactor region fetcher to call `getDoc` for each region
- refactor religion fetcher and profile lookup to use Firestore SDK
- switch firebase helper to use `getDoc`
- tighten Firestore rules and remove wildcard fallback

## Testing
- `npx --yes jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881880dc8488330874d1f172e73acd3