### PR TITLE
Refactor client Firestore access to REST API

### DIFF
--- a/App/config/firebaseClient.ts
+++ b/App/config/firebaseClient.ts
@@ -1,5 +1,4 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
 import Constants from 'expo-constants';
 
 const firebaseConfig = {
@@ -14,5 +13,4 @@ const firebaseConfig = {
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
-export const firestore = getFirestore(app);
 export { app as firebaseApp };

--- a/App/utils/regionUtils.ts
+++ b/App/utils/regionUtils.ts
@@ -1,13 +1,7 @@
-import { Firestore, DocumentReference, doc } from 'firebase/firestore';
-
 /**
- * Helper to build a reference to a region document.
- * Region IDs in Firestore are stored lowercase so we always
- * normalize the provided ID before creating the reference.
+ * Build the Firestore document path for a region ID.
+ * Region IDs are stored lowercase in Firestore.
  */
-export function getRegionDocRef(
-  firestore: Firestore,
-  regionId: string,
-): DocumentReference {
-  return doc(firestore, 'regions', regionId.toLowerCase());
+export function getRegionDocPath(regionId: string): string {
+  return `regions/${regionId.toLowerCase()}`;
 }

--- a/firebase/religion.ts
+++ b/firebase/religion.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
-import { firestore } from '@/config/firebaseClient';
-import { doc, getDoc } from 'firebase/firestore';
+import { getDocument } from '@/services/firestoreService';
 import { getIdToken } from '../authRest';
 
 export interface ReligionItem {
@@ -31,23 +30,18 @@ export async function getReligions(forceRefresh = false): Promise<ReligionItem[]
 
   try {
     const snaps = await Promise.all(
-      RELIGION_IDS.map((id) => getDoc(doc(firestore, 'religion', id))),
+      RELIGION_IDS.map((id) => getDocument(`religion/${id}`)),
     );
-    religionsCache = snaps
-      .filter((s) => s.exists())
-      .map((s) => {
-        const data = s.data() || {};
-        return {
-          id: s.id,
-          name: data.name ?? s.id,
-          aiVoice: data.aiVoice ?? '',
-          defaultChallenges: Array.isArray(data.defaultChallenges)
-            ? data.defaultChallenges
-            : [],
-          totalPoints: Number(data.totalPoints ?? 0),
-          language: data.language ?? '',
-        } as ReligionItem;
-      });
+    religionsCache = snaps.map((data, idx) => ({
+      id: RELIGION_IDS[idx],
+      name: data?.name ?? RELIGION_IDS[idx],
+      aiVoice: data?.aiVoice ?? '',
+      defaultChallenges: Array.isArray(data?.defaultChallenges)
+        ? data.defaultChallenges
+        : [],
+      totalPoints: Number(data?.totalPoints ?? 0),
+      language: data?.language ?? '',
+    } as ReligionItem));
 
     console.log('📖 Religions fetched:', religionsCache.map((r) => r.name));
     return religionsCache;

--- a/regionRest.ts
+++ b/regionRest.ts
@@ -1,5 +1,4 @@
-import { firestore } from '@/config/firebaseClient';
-import { doc, getDoc } from 'firebase/firestore';
+import { getDocument } from '@/services/firestoreService';
 import { logFirestoreError } from './App/lib/logging';
 
 export interface RegionItem {
@@ -25,11 +24,11 @@ export async function fetchRegionList(): Promise<RegionItem[]> {
 
   try {
     const snaps = await Promise.all(
-      REGION_IDS.map((id) => getDoc(doc(firestore, 'regions', id))),
+      REGION_IDS.map((id) => getDocument(`regions/${id}`)),
     );
     regionCache = snaps
-      .filter((s) => s.exists())
-      .map((s) => ({ id: s.id, name: s.data()?.name || 'Unnamed' }));
+      .map((data, idx) => ({ id: REGION_IDS[idx], name: data?.name || 'Unnamed' }))
+      .filter((r) => r.name);
     return regionCache;
   } catch (err: any) {
     logFirestoreError('GET', 'regions', err);


### PR DESCRIPTION
## Summary
- drop Firestore SDK usage in client modules
- implement REST-based fetching for regions and religions
- update religion utilities for REST fetching
- rewrite profile completion logic with REST API
- simplify firebase client config

## Testing
- `npm install jest@30.0.5 --no-save`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68818ed18fc48330886b466479fcbfec