### PR TITLE
Fix Firestore updates and user document creation

### DIFF
--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -158,6 +158,13 @@ export function generateDefaultUserData({
   religionSlug: string;
   lastActive: string;
   profileSchemaVersion: number;
+  organizationId: string | null;
+  religionPrefix: string;
+  challengeStreak: { count: number; lastCompletedDate: string | null };
+  dailyChallengeCount: number;
+  dailySkipCount: number;
+  lastChallengeLoadDate: string | null;
+  lastSkipDate: string | null;
 } {
   const slugify = (str: string) =>
     str
@@ -191,7 +198,14 @@ export function generateDefaultUserData({
     lastFreeSkip: now,
     isSubscribed: false,
     onboardingComplete: false,
-  nightModeEnabled: false,
+    nightModeEnabled: false,
+    organizationId: null,
+    religionPrefix: '',
+    challengeStreak: { count: 0, lastCompletedDate: null },
+    dailyChallengeCount: 0,
+    dailySkipCount: 0,
+    lastChallengeLoadDate: null,
+    lastSkipDate: null,
   };
 }
 
@@ -211,8 +225,9 @@ export async function createUserDocument(
     await axios.patch(url, body, { headers });
   } catch (err: any) {
     if (err?.response?.status === 404) {
-      console.log("➡️ PUT", url);
-      await axios.put(url, body, { headers });
+      const createUrl = `${url}?currentDocument.exists=false`;
+      console.log("➡️ PUT", createUrl);
+      await axios.put(createUrl, body, { headers });
     } else {
       logFirestoreError("GET", path, err);
       throw err;

--- a/firestore.rules
+++ b/firestore.rules
@@ -73,15 +73,19 @@ service cloud.firestore {
     // 🌍 Static lookup: Regions (lowercase IDs)
     match /regions/{regionId} {
       allow get, list: if isSignedIn();
-      // Allow incrementing userCount
-      allow update: if isSignedIn() && request.resource.data.keys().hasOnly(['userCount']) && request.resource.data.userCount is number;
+      // Allow incrementing userCount only
+      allow update: if isSignedIn() &&
+        request.resource.data.diff(resource.data).changedKeys().hasOnly(['userCount']) &&
+        request.resource.data.userCount is number;
     }
 
     // 📖 Static lookup: Religion (capitalized IDs)
     match /religion/{religionId} {
       allow get, list: if isSignedIn();
-      // Allow incrementing userCount
-      allow update: if isSignedIn() && request.resource.data.keys().hasOnly(['userCount']) && request.resource.data.userCount is number;
+      // Allow incrementing userCount only
+      allow update: if isSignedIn() &&
+        request.resource.data.diff(resource.data).changedKeys().hasOnly(['userCount']) &&
+        request.resource.data.userCount is number;
     }
 
   }


### PR DESCRIPTION
## Summary
- restrict region and religion updates to only `userCount`
- add missing defaults for new users
- correctly create user doc via REST when missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68819fd96d9083309e149df409e88a67