### PR TITLE
Fix Firestore user updates with updateMask

### DIFF
--- a/App/utils/firestoreHelpers.ts
+++ b/App/utils/firestoreHelpers.ts
@@ -52,10 +52,17 @@ export async function updateUserProfile(
     console.warn("\u274C No UID available for user update.");
     return;
   }
+  if (!Object.keys(fields).length) {
+    console.warn('⚠️ updateUserProfile called with no fields');
+    return;
+  }
 
   try {
     const headers = await getAuthHeaders();
-    const url = `${FIRESTORE_BASE}/users/${uid}`;
+    const mask = Object.keys(fields)
+      .map((f) => `updateMask.fieldPaths=${encodeURIComponent(f)}`)
+      .join('&');
+    const url = `${FIRESTORE_BASE}/users/${uid}?${mask}`;
     console.log('➡️ PATCH', url, { payload: fields, headers });
     await apiClient.patch(url, { fields: toFirestoreFields(fields) }, { headers });
     console.log('✅ Profile updated:', fields);


### PR DESCRIPTION
## Summary
- update `updateUserProfile` helper to send PATCH with `updateMask`
- patch `incrementUserPoints` via updateMask
- improve `updateUserProfile` in `firestoreHelpers` to only update provided fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a767d26c83309b97637b0f57d1d5