### PR TITLE
Fix conditional navigation to MainTabs

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -13,21 +13,17 @@ import { useUserProfileStore } from '@/state/userProfile';
 import { initAuthState } from '@/services/authService';
 import { loadUserProfile } from '@/utils/userProfile';
 import { refreshLastActive } from '@/services/userService';
-import { SCREENS } from './screens';
+import AuthNavigator from './AuthNavigator';
+import MainTabNavigator from './MainTabNavigator';
 
 // Auth Screens
-import LoginScreen from '@/screens/auth/LoginScreen';
-import SignupScreen from '@/screens/auth/SignupScreen';
 import ProfileCompletionScreen from '@/screens/auth/ProfileCompletionScreen';
 import WelcomeScreen from '@/screens/auth/WelcomeScreen';
 import ForgotPasswordScreen from '@/screens/auth/ForgotPasswordScreen';
 import ForgotUsernameScreen from '@/screens/auth/ForgotUsernameScreen';
 import SelectReligionScreen from '@/screens/auth/SelectReligionScreen';
-import OrganizationSignupScreen from '@/screens/auth/OrganizationSignupScreen';
 
 // Dashboard Screens
-import HomeScreen from '@/screens/dashboard/HomeScreen';
-import ChallengeScreen from '@/screens/dashboard/ChallengeScreen';
 import UpgradeScreen from '@/screens/dashboard/UpgradeScreen';
 import LeaderboardScreen from '@/screens/dashboard/LeaderboardScreen';
 import TriviaScreen from '@/screens/dashboard/TriviaScreen';
@@ -42,9 +38,7 @@ import ChangePasswordScreen from '@/screens/profile/ChangePasswordScreen';
 
 // Root-Level Screens
 import QuoteScreen from '@/screens/QuoteScreen';
-import ReligionAIScreen from '@/screens/ReligionAIScreen';
-import JournalScreen from '@/screens/JournalScreen';
-import ConfessionalScreen from '@/screens/ConfessionalScreen';
+
 import BuyTokensScreen from '@/screens/BuyTokensScreen';
 import GiveBackScreen from '@/screens/GiveBackScreen';
 
@@ -54,7 +48,7 @@ export default function AuthGate() {
   const theme = useTheme();
   const { uid, idToken, authReady } = useAuth();
   const { user } = useUser();
-  const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList>('Login');
+  const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList>('Auth');
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
@@ -67,8 +61,8 @@ export default function AuthGate() {
       console.log('🔍 AuthGate verify', { uid, hasToken: !!idToken });
 
       if (!uid || !idToken) {
-        console.log('➡️ route -> Login');
-        setInitialRoute('Login');
+        console.log('➡️ route -> Auth');
+        setInitialRoute('Auth');
         setChecking(false);
         return;
       }
@@ -96,15 +90,15 @@ export default function AuthGate() {
           }
         } catch (err) {
           console.warn('Failed to fetch profile', err);
-          setInitialRoute('Login');
+          setInitialRoute('Auth');
           setChecking(false);
           return;
         }
       }
 
       if (!profile) {
-        console.log('➡️ route -> Login');
-        setInitialRoute('Login');
+        console.log('➡️ route -> Auth');
+        setInitialRoute('Auth');
         setChecking(false);
         return;
       }
@@ -114,10 +108,10 @@ export default function AuthGate() {
         (profile.onboardingComplete === false || profile.onboardingComplete === undefined)
       ) {
         console.log('➡️ route -> ProfileCompletion');
-        setInitialRoute(SCREENS.AUTH.PROFILE_COMPLETION as keyof RootStackParamList);
+        setInitialRoute('ProfileCompletion');
       } else {
-        console.log('➡️ route -> HomeScreen');
-        setInitialRoute(SCREENS.MAIN.HOME as keyof RootStackParamList);
+        console.log('➡️ route -> MainTabs');
+        setInitialRoute('MainTabs');
       }
       setChecking(false);
     }
@@ -149,39 +143,25 @@ export default function AuthGate() {
           headerTitleStyle: { fontWeight: 'bold', fontSize: 20, fontFamily: theme.fonts.title },
         }}
       >
-        {!user ? (
-          <>
-            <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
-            <Stack.Screen name="Login" component={LoginScreen} options={{ title: 'Login' }} />
-            <Stack.Screen name="Signup" component={SignupScreen} options={{ title: 'Sign Up' }} />
-            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Reset Password' }} />
-            <Stack.Screen name="ForgotUsername" component={ForgotUsernameScreen} options={{ title: 'Find Email' }} />
-            <Stack.Screen name="OrganizationSignup" component={OrganizationSignupScreen} options={{ title: 'Create Organization' }} />
-            <Stack.Screen name="ProfileCompletion" component={ProfileCompletionScreen} options={{ title: 'Complete Profile' }} />
-          </>
-        ) : (
-          <>
-            <Stack.Screen name="Quote" component={QuoteScreen} options={{ headerShown: false }} />
-            <Stack.Screen name="SelectReligion" component={SelectReligionScreen} options={{ title: 'Select Religion' }} />
-            <Stack.Screen name="HomeScreen" component={HomeScreen} />
-            <Stack.Screen name="ReligionAI" component={ReligionAIScreen} options={{ title: 'Religion AI' }} />
-            <Stack.Screen name="Journal" component={JournalScreen} options={{ title: 'Quiet Journal' }} />
-            <Stack.Screen name="Challenge" component={ChallengeScreen} options={{ title: 'Daily Challenge' }} />
-            <Stack.Screen name="Confessional" component={ConfessionalScreen} options={{ title: 'Confessional' }} />
-            <Stack.Screen name="BuyTokens" component={BuyTokensScreen} options={{ title: 'Buy Tokens' }} />
-            <Stack.Screen name="Upgrade" component={UpgradeScreen} options={{ title: 'Upgrade to OneVine+' }} />
-            <Stack.Screen name="GiveBack" component={GiveBackScreen} options={{ title: 'Give Back' }} />
-            <Stack.Screen name="Profile" component={ProfileScreen} />
-            <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Change Password' }} />
-            <Stack.Screen name="Settings" component={SettingsScreen} />
-            <Stack.Screen name="Trivia" component={TriviaScreen} options={{ title: 'Trivia Challenge' }} />
-            <Stack.Screen name="Leaderboards" component={LeaderboardScreen} options={{ title: 'Leaderboards' }} />
-            <Stack.Screen name="SubmitProof" component={SubmitProofScreen} options={{ title: 'Submit Proof' }} />
-            <Stack.Screen name="OrganizationManagement" component={OrganizationManagementScreen} options={{ title: 'Manage Organization' }} />
-            <Stack.Screen name="JoinOrganization" component={JoinOrganizationScreen} options={{ title: 'Join Organization' }} />
-            <Stack.Screen name="ProfileCompletion" component={ProfileCompletionScreen} options={{ title: 'Complete Profile' }} />
-          </>
-        )}
+        <Stack.Screen name="Auth" component={AuthNavigator} options={{ headerShown: false }} />
+        <Stack.Screen name="MainTabs" component={MainTabNavigator} options={{ headerShown: false }} />
+        <Stack.Screen name="ProfileCompletion" component={ProfileCompletionScreen} options={{ title: 'Complete Profile' }} />
+        <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
+        <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Reset Password' }} />
+        <Stack.Screen name="ForgotUsername" component={ForgotUsernameScreen} options={{ title: 'Find Email' }} />
+        <Stack.Screen name="SelectReligion" component={SelectReligionScreen} options={{ title: 'Select Religion' }} />
+        <Stack.Screen name="Quote" component={QuoteScreen} options={{ headerShown: false }} />
+        <Stack.Screen name="BuyTokens" component={BuyTokensScreen} options={{ title: 'Buy Tokens' }} />
+        <Stack.Screen name="Upgrade" component={UpgradeScreen} options={{ title: 'Upgrade to OneVine+' }} />
+        <Stack.Screen name="GiveBack" component={GiveBackScreen} options={{ title: 'Give Back' }} />
+        <Stack.Screen name="Profile" component={ProfileScreen} />
+        <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Change Password' }} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
+        <Stack.Screen name="Trivia" component={TriviaScreen} options={{ title: 'Trivia Challenge' }} />
+        <Stack.Screen name="Leaderboards" component={LeaderboardScreen} options={{ title: 'Leaderboards' }} />
+        <Stack.Screen name="SubmitProof" component={SubmitProofScreen} options={{ title: 'Submit Proof' }} />
+        <Stack.Screen name="OrganizationManagement" component={OrganizationManagementScreen} options={{ title: 'Manage Organization' }} />
+        <Stack.Screen name="JoinOrganization" component={JoinOrganizationScreen} options={{ title: 'Join Organization' }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/App/navigation/AuthNavigator.tsx
+++ b/App/navigation/AuthNavigator.tsx
@@ -8,7 +8,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function AuthNavigator() {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator initialRouteName="Login" screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen name="Signup" component={SignupScreen} />
       <Stack.Screen

--- a/App/navigation/MainTabNavigator.tsx
+++ b/App/navigation/MainTabNavigator.tsx
@@ -20,6 +20,7 @@ export default function MainTabNavigator() {
   const theme = useTheme();
   return (
     <Tab.Navigator
+      initialRouteName="HomeScreen"
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarActiveTintColor: theme.colors.primary,

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -11,6 +11,10 @@ declare global {
 }
 
 export type RootStackParamList = {
+  // Root navigators
+  Auth: undefined;
+  MainTabs: undefined;
+
   // Auth stack screens
   Welcome: undefined;
   Login: undefined;

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -121,7 +121,7 @@ export default function BuyTokensScreen({ navigation }: Props) {
         </View>
 
         <View style={styles.buttonWrap}>
-          <Button title="Back to Home" onPress={() => navigation.navigate('HomeScreen')} />
+          <Button title="Back to Home" onPress={() => navigation.navigate('MainTabs', { screen: 'HomeScreen' })} />
         </View>
       </View>
     </ScreenContainer>

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -81,7 +81,7 @@ export default function GiveBackScreen({ navigation }: Props) {
         </CustomText>
 
         <View style={styles.backWrap}>
-          <Button title="Back to Home" onPress={() => navigation.navigate('HomeScreen')} />
+          <Button title="Back to Home" onPress={() => navigation.navigate('MainTabs', { screen: 'HomeScreen' })} />
         </View>
       </View>
     </ScreenContainer>

--- a/App/screens/QuoteScreen.tsx
+++ b/App/screens/QuoteScreen.tsx
@@ -91,7 +91,7 @@ export default function QuoteScreen({ navigation }: Props) {
         <CustomText style={styles.quote}>“{quote.text}”</CustomText>
         <CustomText style={styles.reference}>— {quote.reference}</CustomText>
         <View style={styles.buttonWrap}>
-          <Button title="Continue" onPress={() => navigation.replace('HomeScreen')} />
+          <Button title="Continue" onPress={() => navigation.replace('MainTabs')} />
         </View>
       </View>
     </ScreenContainer>

--- a/App/screens/auth/ProfileCompletionScreen.tsx
+++ b/App/screens/auth/ProfileCompletionScreen.tsx
@@ -68,7 +68,7 @@ export default function ProfileCompletionScreen() {
         setDocument(userPath, payload),
       ]);
 
-      navigation.reset({ index: 0, routes: [{ name: SCREENS.MAIN.HOME }] });
+      navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
     } catch (err: any) {
       Alert.alert('Error', err.message || 'Could not save profile or update counts');
       console.error('Transaction failed:', err);

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -107,7 +107,7 @@ export default function UpgradeScreen({ navigation }: Props) {
         </View>
 
         <View style={styles.buttonWrap}>
-          <Button title="Back to Home" onPress={() => navigation.navigate('HomeScreen')} />
+          <Button title="Back to Home" onPress={() => navigation.navigate('MainTabs', { screen: 'HomeScreen' })} />
         </View>
       </View>
     </ScreenContainer>


### PR DESCRIPTION
## Summary
- route from AuthGate into AuthNavigator or MainTabNavigator
- set initialRouteName for each navigator
- update RootStackParamList with new navigator names
- fix screens that jumped directly to `HomeScreen`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881ac99f4488330afe2d2eba8f51282