### PR TITLE
Fix Firestore REST writes

### DIFF
--- a/App/services/firestoreService.ts
+++ b/App/services/firestoreService.ts
@@ -126,8 +126,12 @@ export async function setDocument(path: string, data: any): Promise<void> {
   warnIfInvalidPath(path, true);
   try {
     const body = { fields: toFirestoreFields(data) };
+    const maskParams = Object.keys(data)
+      .map((f) => `updateMask.fieldPaths=${encodeURIComponent(f)}`)
+      .join('&');
+    const url = maskParams ? `${BASE}/${path}?${maskParams}` : `${BASE}/${path}`;
     console.log('➡️ Firestore SET', path, data);
-    await apiClient.patch(`${BASE}/${path}`, body, { headers: await authHeaders() });
+    await apiClient.patch(url, body, { headers: await authHeaders() });
   } catch (err: any) {
     logFirestoreError('SET', path, err);
     if (err.response?.status === 403) {
@@ -271,13 +275,13 @@ export async function querySubcollection(
   orderByField?: string,
   direction: 'ASCENDING' | 'DESCENDING' = 'ASCENDING',
 ): Promise<any[]> {
-  const fullPath = `${parentPath}/${collectionName}`;
-  console.warn('📄 Structured subquery path:', fullPath);
+  const collectionPath = `${parentPath}/${collectionName}`;
+  console.warn('📄 Structured subquery path:', collectionPath);
   if (!orderByField) {
-    return queryCollection(fullPath);
+    return queryCollection(collectionPath);
   }
   const query = {
-    parent: `projects/${PROJECT_ID}/databases/(default)/documents/${fullPath}`,
+    parent: `projects/${PROJECT_ID}/databases/(default)/documents/${parentPath}`,
     from: [{ collectionId: collectionName }],
     orderBy: [{ field: { fieldPath: orderByField }, direction }],
   };

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -215,7 +215,12 @@ export async function createUserDocument(
   idToken: string,
 ) {
   const path = `users/${uid}`;
-  const url = `${FIRESTORE_BASE}/${path}`;
+  const maskParams = Object.keys(data)
+    .map((f) => `updateMask.fieldPaths=${encodeURIComponent(f)}`)
+    .join('&');
+  const url = `${FIRESTORE_BASE}/${path}?currentDocument.exists=false${
+    maskParams ? `&${maskParams}` : ''
+  }`;
   const headers = {
     Authorization: `Bearer ${idToken}`,
     "Content-Type": "application/json",
@@ -223,8 +228,8 @@ export async function createUserDocument(
   const body = { fields: toFirestoreFields(data) };
 
   try {
-    console.log("➡️ PUT", url);
-    const res = await axios.put(url, body, { headers });
+    console.log("➡️ PATCH", url);
+    const res = await axios.patch(url, body, { headers });
     console.log("✅ Firestore user created:", res.data);
   } catch (err: any) {
     logFirestoreError("PUT", path, err);

--- a/firestore.rules
+++ b/firestore.rules
@@ -8,8 +8,7 @@ service cloud.firestore {
 
     // 🔐 User profile document
     match /users/{userId} {
-      allow read, update: if isSignedIn() && request.auth.uid == userId;
-      allow create: if false; // Created via Cloud Function
+      allow read, create, update: if isSignedIn() && request.auth.uid == userId;
     }
 
     // ✅ Active challenge document


### PR DESCRIPTION
## Summary
- create user documents with PATCH and `currentDocument.exists=false`
- patch only specified fields when updating documents
- fix `querySubcollection` parent path
- allow clients to create user profiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881b2150a748330b308ba04b4c5d6d7