### PR TITLE
Fix onboarding flow and improve auth logging

### DIFF
--- a/App/lib/auth.ts
+++ b/App/lib/auth.ts
@@ -90,14 +90,19 @@ export async function signup(email: string, password: string) {
 }
 
 export async function login(email: string, password: string) {
-  const res = await signInWithEmailAndPassword(email, password);
-  currentToken = res.idToken;
-  currentRefresh = res.refreshToken;
-  currentUid = res.localId;
-  await setItem(TOKEN_KEY, res.idToken);
-  await setItem(REFRESH_KEY, res.refreshToken);
-  await setItem(UID_KEY, res.localId);
-  return { uid: res.localId, email: res.email };
+  try {
+    const res = await signInWithEmailAndPassword(email, password);
+    currentToken = res.idToken;
+    currentRefresh = res.refreshToken;
+    currentUid = res.localId;
+    await setItem(TOKEN_KEY, res.idToken);
+    await setItem(REFRESH_KEY, res.refreshToken);
+    await setItem(UID_KEY, res.localId);
+    return { uid: res.localId, email: res.email };
+  } catch (error: any) {
+    console.warn('🚫 Login Failed:', error.response?.data?.error?.message);
+    throw error;
+  }
 }
 
 export async function logout() {

--- a/App/screens/auth/SignupScreen.tsx
+++ b/App/screens/auth/SignupScreen.tsx
@@ -68,6 +68,7 @@ export default function SignupScreen() {
       switch (code) {
         case "EMAIL_EXISTS":
           friendly = "Email already in use.";
+          navigation.navigate('Login');
           break;
         case "INVALID_EMAIL":
           friendly = "Invalid email address.";

--- a/App/services/onboardingService.ts
+++ b/App/services/onboardingService.ts
@@ -1,18 +1,28 @@
 import { navigationRef } from '@/navigation/navigationRef';
 import { loadUserProfile, updateUserProfile } from '@/utils/userProfile';
 import { ensureAuth } from '@/utils/authGuard';
+import { Alert } from 'react-native';
 
 export async function saveUsernameAndProceed(username: string): Promise<void> {
   const uid = await ensureAuth();
   await updateUserProfile({ username }, uid);
   if (navigationRef.isReady()) {
-    navigationRef.reset({ index: 0, routes: [{ name: 'HomeScreen' }] });
+    navigationRef.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
   }
 }
 
 export async function checkIfUserIsNewAndRoute(): Promise<void> {
   const uid = await ensureAuth();
+  if (!uid) return;
+  const profile = await loadUserProfile(uid);
+  const needsProfile =
+    !profile?.onboardingComplete || !profile?.profileComplete;
   if (navigationRef.isReady()) {
-    navigationRef.reset({ index: 0, routes: [{ name: 'HomeScreen' }] });
+    if (needsProfile) {
+      Alert.alert('Profile Incomplete', 'Please complete your profile before using the app.');
+      navigationRef.reset({ index: 0, routes: [{ name: 'ProfileCompletion' }] });
+    } else {
+      navigationRef.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+    }
   }
 }

--- a/firebaseRest.ts
+++ b/firebaseRest.ts
@@ -46,11 +46,11 @@ export async function signUpWithEmailAndPassword(
     return res.data as AuthResponse;
   } catch (err: any) {
     if (err.response) {
-      console.error("❌ signup error response", err.response.data);
+      console.error('❌ signup error response', err.response.data);
     } else {
-      console.error("❌ signup error", err.message);
+      console.error('❌ signup error', err.message);
     }
-    console.warn("🚫 Signup Failed:", err.response?.data?.error?.message);
+    console.warn('🚫 Signup Failed:', err.response?.data?.error?.message);
     throw err;
   }
 }
@@ -60,12 +60,22 @@ export async function signInWithEmailAndPassword(
   password: string,
 ): Promise<AuthResponse> {
   const url = `${ID_BASE}/accounts:signInWithPassword?key=${API_KEY}`;
-  const res = await axios.post(url, {
-    email,
-    password,
-    returnSecureToken: true,
-  });
-  return res.data as AuthResponse;
+  const payload = { email, password, returnSecureToken: true };
+  console.log('➡️ login request', { url, payload });
+  try {
+    const res = await axios.post(url, payload, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    console.log('✅ login response', res.data);
+    return res.data as AuthResponse;
+  } catch (err: any) {
+    if (err.response) {
+      console.error('❌ login error response', err.response.data);
+    } else {
+      console.error('❌ login error', err.message);
+    }
+    throw err;
+  }
 }
 
 export async function getUserData(uid: string, idToken: string) {

--- a/regionRest.ts
+++ b/regionRest.ts
@@ -16,6 +16,14 @@ const REGION_IDS = [
   'southwest',
 ];
 
+const FALLBACK_REGIONS: RegionItem[] = [
+  { id: 'midwest', name: 'Midwest' },
+  { id: 'northeast', name: 'Northeast' },
+  { id: 'northwest', name: 'Northwest' },
+  { id: 'southeast', name: 'Southeast' },
+  { id: 'southwest', name: 'Southwest' },
+];
+
 export async function fetchRegionList(): Promise<RegionItem[]> {
   if (regionCache) {
     console.log('📦 Regions served from cache');
@@ -29,9 +37,15 @@ export async function fetchRegionList(): Promise<RegionItem[]> {
     regionCache = snaps
       .map((data, idx) => ({ id: REGION_IDS[idx], name: data?.name || 'Unnamed' }))
       .filter((r) => r.name);
+    if (!regionCache.length) {
+      console.warn('⚠️ Empty region list from Firestore, using fallback');
+      regionCache = FALLBACK_REGIONS;
+    }
     return regionCache;
   } catch (err: any) {
     logFirestoreError('GET', 'regions', err);
-    throw new Error('Unable to fetch regions');
+    console.warn('Failed to fetch regions, using fallback', err.response?.data || err.message);
+    regionCache = FALLBACK_REGIONS;
+    return regionCache;
   }
 }


### PR DESCRIPTION
## Summary
- add fallback regions and better loading checks
- improve Firebase login error logging
- handle login failures in auth util
- validate profile completion fields before marking as complete
- navigate correctly after signup/onboarding
- send users to login if email already exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68828125312c83308c96fa4f152c8763