### PR TITLE
Fix completed challenge trigger and export

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1790,4 +1790,4 @@ export const completeSignupAndProfile = functions
     }
   });
 
-export * from './firestoreArchitecture';
+export { onCompletedChallengeCreate } from './firestoreArchitecture';


### PR DESCRIPTION
## Summary
- update `onCompletedChallengeCreate` to use flat `completedChallenges/{challengeId}` path
- award points to user and related entities
- update `leaderboards/global` with `updatedAt` timestamp
- export the function explicitly from `index.ts`

## Testing
- `npm --prefix functions run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688299a36af08330a7a2f3b10023785d