### PR TITLE
Fix region update and sign-out navigation

### DIFF
--- a/App/navigation/navigationRef.ts
+++ b/App/navigation/navigationRef.ts
@@ -5,6 +5,9 @@ export const navigationRef = createNavigationContainerRef<RootStackParamList>();
 
 export function resetToLogin() {
   if (navigationRef.isReady()) {
-    navigationRef.reset({ index: 0, routes: [{ name: "Login" }] });
+    navigationRef.reset({
+      index: 0,
+      routes: [{ name: 'Auth', params: { screen: 'Login' } }],
+    });
   }
 }

--- a/App/screens/auth/ProfileCompletionScreen.tsx
+++ b/App/screens/auth/ProfileCompletionScreen.tsx
@@ -6,7 +6,7 @@ import TextField from '@/components/TextField';
 import Button from '@/components/common/Button';
 import { Picker } from '@react-native-picker/picker';
 import { useLookupLists } from '@/hooks/useLookupLists';
-import { getDocument, setDocument } from '@/services/firestoreService';
+import { getDocument, updateDocument } from '@/services/firestoreService';
 import { updateUserProfile, loadUserProfile } from '@/utils/userProfile';
 import { useUserProfileStore } from '@/state/userProfile';
 import { useNavigation } from '@react-navigation/native';
@@ -53,8 +53,8 @@ export default function ProfileCompletionScreen() {
       Alert.alert('Missing Info', 'Please select a region and religion.');
       return;
     }
-    if (!hasDisplay || !hasUsername || !preferredName.trim() || !pronouns.trim()) {
-      Alert.alert('Missing Info', 'All fields are required.');
+    if (!hasDisplay || !hasUsername || !preferredName.trim()) {
+      Alert.alert('Missing Info', 'Preferred name is required.');
       return;
     }
     setSaving(true);
@@ -63,10 +63,10 @@ export default function ProfileCompletionScreen() {
         region,
         religion,
         preferredName: preferredName.trim(),
-        pronouns: pronouns.trim(),
         onboardingComplete: true,
         profileComplete: true,
       };
+      if (pronouns.trim()) payload.pronouns = pronouns.trim();
       if (avatarURL.trim()) payload.avatarURL = avatarURL.trim();
 
       const regionPath = `regions/${region.toLowerCase()}`;
@@ -81,8 +81,8 @@ export default function ProfileCompletionScreen() {
       const religionCount = religionDoc?.userCount ?? 0;
 
       await Promise.all([
-        setDocument(regionPath, { userCount: regionCount + 1 }),
-        setDocument(religionPath, { userCount: religionCount + 1 }),
+        updateDocument(regionPath, { userCount: regionCount + 1 }),
+        updateDocument(religionPath, { userCount: religionCount + 1 }),
         updateUserProfile(payload, uid),
       ]);
       await profileStore.refreshUserProfile();
@@ -141,9 +141,10 @@ export default function ProfileCompletionScreen() {
           onChangeText={setPreferredName}
         />
         <TextField
-          label="Pronouns *"
+          label="Pronouns"
           value={pronouns}
           onChangeText={setPronouns}
+          placeholder="Optional"
         />
         <TextField
           label="Avatar URL"

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -46,9 +46,11 @@ const STRIPE_100_TOKEN_PRICE_ID = process.env.STRIPE_100_TOKEN_PRICE_ID || "";
 const CURRENT_PROFILE_SCHEMA = 1;
 
 function validateSignupProfile(profile: any): Required<Pick<any,
-  'email' | 'displayName' | 'username' | 'religion' | 'preferredName' | 'pronouns' | 'avatarURL'>> & {
+  'email' | 'displayName' | 'username' | 'religion' | 'preferredName'>> & {
   region?: string;
   organization?: string | null;
+  pronouns?: string;
+  avatarURL?: string;
 } {
   if (!profile || typeof profile !== 'object') {
     throw new functions.https.HttpsError('invalid-argument', 'profile must be an object');
@@ -60,8 +62,6 @@ function validateSignupProfile(profile: any): Required<Pick<any,
     'username',
     'religion',
     'preferredName',
-    'pronouns',
-    'avatarURL',
   ];
 
   const sanitized: any = {};
@@ -83,11 +83,17 @@ function validateSignupProfile(profile: any): Required<Pick<any,
     throw new functions.https.HttpsError('invalid-argument', 'Invalid username');
   }
 
-  try {
-    // throws if url is invalid
-    new URL(sanitized.avatarURL);
-  } catch {
-    throw new functions.https.HttpsError('invalid-argument', 'Invalid avatarURL');
+  if (typeof profile.avatarURL === 'string' && profile.avatarURL.trim()) {
+    try {
+      new URL(profile.avatarURL);
+    } catch {
+      throw new functions.https.HttpsError('invalid-argument', 'Invalid avatarURL');
+    }
+    sanitized.avatarURL = profile.avatarURL.trim();
+  }
+
+  if ('pronouns' in profile && typeof profile.pronouns === 'string') {
+    sanitized.pronouns = profile.pronouns.trim();
   }
 
   if ('region' in profile) {


### PR DESCRIPTION
## Summary
- improve region/religion userCount updates so documents aren't overwritten
- make pronouns and avatar optional when completing profile
- add currentDocument.exists option to Firestore helpers
- route sign out through the Auth stack's Login screen

## Testing
- `npx jest` *(fails: need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6882a38c20548330a510fd61cc2f6be7