### PR TITLE
Fix Firestore merges for religion docs

### DIFF
--- a/functions/firestoreArchitecture.ts
+++ b/functions/firestoreArchitecture.ts
@@ -67,9 +67,18 @@ export const onCompletedChallengeCreate = functions.firestore
       const org = userData.organization as string | undefined;
       const region = userData.region as string | undefined;
       const religion = userData.religion as string | undefined;
-      if (org) tasks.push(db.doc(`organizations/${org}`).set({ orgPoints: inc }, { merge: true }));
-      if (region) tasks.push(db.doc(`regions/${region}`).set({ regionPoints: inc }, { merge: true }));
-      if (religion) tasks.push(db.doc(`religion/${religion}`).set({ religionPoints: inc }, { merge: true }));
+      if (org) {
+        functions.logger.info('🛠 Updating organization doc with merge', { org });
+        tasks.push(db.doc(`organizations/${org}`).set({ orgPoints: inc }, { merge: true }));
+      }
+      if (region) {
+        functions.logger.info('🛠 Updating region doc with merge', { region });
+        tasks.push(db.doc(`regions/${region}`).set({ regionPoints: inc }, { merge: true }));
+      }
+      if (religion) {
+        functions.logger.info('🛠 Updating religion doc with merge', { religion });
+        tasks.push(db.doc(`religion/${religion}`).set({ religionPoints: inc }, { merge: true }));
+      }
 
       tasks.push(
         db
@@ -78,6 +87,7 @@ export const onCompletedChallengeCreate = functions.firestore
       );
 
       await Promise.all(tasks);
+      functions.logger.info('✅ Points updated for completion', { uid, points });
     } catch (err) {
       functions.logger.error('onCompletedChallengeCreate', err);
     }

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -240,11 +240,13 @@ export const incrementReligionPoints = functions
         }
 
         const ref = db.collection("religion").doc(religion);
+        logger.info("🛠 Updating religion doc with merge", { religion });
         await db.runTransaction(async (t: FirebaseFirestore.Transaction) => {
           const snap = await t.get(ref);
           const current = snap.exists ? (snap.data()?.totalPoints ?? 0) : 0;
           t.set(ref, { totalPoints: current + points }, { merge: true });
         });
+        logger.info("✅ Religion updated", { religion });
 
         res.status(200).send({ message: "Points updated" });
       } catch (err: any) {
@@ -280,15 +282,19 @@ export const awardPointsToUser = functions
         await db.runTransaction(async (t) => {
           if (religionId) {
             const ref = db.doc(`religion/${religionId}`);
+            logger.info("🛠 Updating religion doc with merge", { religionId });
             const snap = await t.get(ref);
             const current = snap.exists ? (snap.data()?.totalPoints ?? 0) : 0;
             t.set(ref, { name: religionId, totalPoints: current + points }, { merge: true });
+            logger.info("✅ Religion updated", { religionId });
           }
           if (organizationId) {
             const ref = db.doc(`organizations/${organizationId}`);
+            logger.info("🛠 Updating organization doc with merge", { organizationId });
             const snap = await t.get(ref);
             const current = snap.exists ? (snap.data()?.totalPoints ?? 0) : 0;
             t.set(ref, { name: organizationId, totalPoints: current + points }, { merge: true });
+            logger.info("✅ Organization updated", { organizationId });
           }
         });
 
@@ -488,7 +494,9 @@ export const completeChallengeDay = functions
       if (relRef) {
         const rs = await t.get(relRef);
         const current = rs.exists ? (rs.data()?.totalPoints ?? 0) : 0;
+        logger.info("🛠 Updating religion doc with merge", { ref: relRef.path });
         t.set(relRef, { totalPoints: current + points }, { merge: true });
+        logger.info("✅ Religion updated", { ref: relRef.path });
       }
     });
 
@@ -1452,7 +1460,9 @@ async function ensureDocument(
   const ref = db.doc(path);
   const snap = await ref.get();
   if (!snap.exists) {
-    await ref.set(data);
+    logger.info("🛠 Creating doc with merge", { path });
+    await ref.set(data, { merge: true });
+    logger.info("✅ Doc ensured", { path });
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve fields when seeding shared docs
- log and use merge-safe writes when updating religion and region stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e1054b888330994af2dd7a103ed7