### PR TITLE
Remove firebase-functions v2 imports

### DIFF
--- a/functions/firestoreArchitecture.ts
+++ b/functions/firestoreArchitecture.ts
@@ -1,4 +1,4 @@
-import * as functions from 'firebase-functions/v1';
+import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { db } from './firebase';
 import { createGeminiModel, fetchReligionContext } from './geminiUtils';

--- a/functions/helpers.ts
+++ b/functions/helpers.ts
@@ -2,7 +2,10 @@ import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import cors from 'cors';
-import { Request, Response } from 'express';
+
+// Use Cloud Functions HTTP types instead of express directly
+type Request = functions.https.Request;
+type Response = functions.Response;
 import { auth, db } from './firebase';
 
 const corsHandler = cors({ origin: true });

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -223,7 +223,7 @@ async function updateStreakAndXPInternal(uid: string, type: string) {
 
 export const incrementReligionPoints = functions
   .https.onRequest(
-    withCors(async (req: functions.Request, res: functions.Response) => {
+    withCors(async (req: functions.https.Request, res: functions.Response) => {
       try {
         const { uid } = await verifyIdToken(req);
         const { religion, points } = req.body;
@@ -258,7 +258,7 @@ export const incrementReligionPoints = functions
 
 export const awardPointsToUser = functions
   .https.onRequest(
-    withCors(async (req: functions.Request, res: functions.Response) => {
+    withCors(async (req: functions.https.Request, res: functions.Response) => {
       try {
         const { uid } = await verifyIdToken(req);
         const { points } = req.body;
@@ -306,7 +306,7 @@ export const awardPointsToUser = functions
   );
 
 export const completeChallenge = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const authHeader = req.headers.authorization;
   const token = authHeader?.split('Bearer ')[1];
   if (!token) {
@@ -329,7 +329,7 @@ export const completeChallenge = functions
 });
 
 export const createMultiDayChallenge = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const authHeader = req.headers.authorization;
   const token = authHeader?.split('Bearer ')[1];
   if (!token) {
@@ -404,7 +404,7 @@ export const createMultiDayChallenge = functions
 });
 
 export const completeChallengeDay = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const authHeader = req.headers.authorization;
   const token = authHeader?.split('Bearer ')[1];
   if (!token) {
@@ -505,7 +505,7 @@ export const completeChallengeDay = functions
 });
 
 export const askGeminiSimple = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -564,7 +564,7 @@ export const askGeminiSimple = functions
 });
 
 export const confessionalAI = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -656,7 +656,7 @@ export const askGeminiV2 = functions.https.onCall(
 });
 
 export const generateChallenge = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -733,7 +733,7 @@ export const generateChallenge = functions
 });
 
 export const generateDailyChallenge = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     console.error("❌ Gus Bug Alert: Missing ID token in header. 🐞");
@@ -835,7 +835,7 @@ export const generateDailyChallenge = functions
 });
 
 export const skipDailyChallenge = functions
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (req: functions.https.Request, res: functions.Response) => {
   const idToken = req.headers.authorization?.split("Bearer ")[1];
   if (!idToken) {
     res.status(401).json({ error: "Unauthorized" });
@@ -958,7 +958,7 @@ export const skipDailyChallenge = functions
 // TODO: startSubscriptionCheckout is unused in the current frontend. Consider
 // removing or wiring it up in a future release.
 export const startSubscriptionCheckout = functions
-  .https.onRequest(withCors(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(withCors(async (req: functions.https.Request, res: functions.Response) => {
   logger.info("📦 startSubscriptionCheckout payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -1012,7 +1012,7 @@ export const startSubscriptionCheckout = functions
 // TODO: startOneTimeTokenCheckout is unused in the current frontend. Consider
 // removing or wiring it up in a future release.
 export const startOneTimeTokenCheckout = functions
-  .https.onRequest(withCors(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(withCors(async (req: functions.https.Request, res: functions.Response) => {
   logger.info("📦 startOneTimeTokenCheckout payload", req.body);
   logger.info(
     "🔐 Stripe Secret:",
@@ -1068,7 +1068,7 @@ export const startOneTimeTokenCheckout = functions
 }));
 
 export const startTokenCheckout = functions
-  .https.onRequest(withCors(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(withCors(async (req: functions.https.Request, res: functions.Response) => {
   logger.info("🪙 startTokenCheckout payload", req.body);
   const { uid, priceId } = req.body || {};
   if (!uid || !priceId) {
@@ -1115,7 +1115,7 @@ export const startTokenCheckout = functions
 }));
 
 export const startDonationCheckout = functions
-  .https.onRequest(withCors(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(withCors(async (req: functions.https.Request, res: functions.Response) => {
   logger.info("💖 startDonationCheckout payload", req.body);
   const { userId, amount } = req.body || {};
   if (!userId || typeof amount !== "number" || amount <= 0) {
@@ -1172,7 +1172,7 @@ export const startDonationCheckout = functions
 }));
 
 export const startCheckoutSession = functions
-  .https.onRequest(withCors(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(withCors(async (req: functions.https.Request, res: functions.Response) => {
   logger.info("📦 startCheckoutSession payload", req.body);
   logger.debug("startCheckoutSession headers", req.headers);
   logger.info(
@@ -1229,7 +1229,7 @@ export const startCheckoutSession = functions
 }));
 
 export const createStripeCheckout = functions
-  .https.onRequest(withCors(async (req: functions.Request, res: functions.Response) => {
+  .https.onRequest(withCors(async (req: functions.https.Request, res: functions.Response) => {
   logger.info("🛒 createStripeCheckout payload", req.body);
   const { uid, email, priceId, type, quantity, returnUrl } = req.body || {};
 
@@ -1363,7 +1363,7 @@ export const handleStripeWebhookV2 = functions
 
 export const updateStreakAndXP = functions
   .https.onRequest(
-    withCors(async (req: functions.Request, res: functions.Response) => {
+    withCors(async (req: functions.https.Request, res: functions.Response) => {
       let authData: { uid: string; token: string };
       try {
         authData = await verifyAuth(req);
@@ -1386,7 +1386,7 @@ export const updateStreakAndXP = functions
 
 export const getUserProfile = functions
   .https.onRequest(
-    withCors(async (req: functions.Request, res: functions.Response) => {
+    withCors(async (req: functions.https.Request, res: functions.Response) => {
       let authData: { uid: string; token: string };
       try {
         authData = await verifyAuth(req);
@@ -1434,7 +1434,7 @@ async function ensureDocument(
 }
 
 export const seedFirestore = functions
-  .https.onRequest(async (_req: functions.Request, res: functions.Response) => {
+  .https.onRequest(async (_req: functions.https.Request, res: functions.Response) => {
   try {
     await Promise.all([
       ensureDocument('users/seed-user', { initialized: true }),

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -1,5 +1,5 @@
-import { Request } from 'express';
+import * as functions from 'firebase-functions';
 
-export interface RawBodyRequest extends Request {
+export interface RawBodyRequest extends functions.https.Request {
   rawBody: Buffer;
 }


### PR DESCRIPTION
## Summary
- update helper types to use Cloud Functions v1 typings
- fix RawBodyRequest type
- swap firestoreArchitecture import to firebase-functions v1
- update handlers in index.ts to reference functions.https.Request/Response

## Testing
- `npm --prefix functions run build`
- `npx jest` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882fa43ac5883308669c2c32a9156d5