### PR TITLE
Use Firebase config for Gemini key

### DIFF
--- a/functions/geminiUtils.ts
+++ b/functions/geminiUtils.ts
@@ -3,8 +3,7 @@ import * as functions from 'firebase-functions/v1';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { db } from './firebase';
 
-const GEMINI_API_KEY =
-  process.env.GEMINI_API_KEY || functions.config().gemini?.key || '';
+const GEMINI_API_KEY = functions.config().gemini?.key || '';
 
 export function createGeminiModel(apiKey: string = GEMINI_API_KEY) {
   if (!apiKey) {


### PR DESCRIPTION
## Summary
- read Gemini API key directly from `functions.config()`
- clean up configuration warnings
- update `askGeminiV2` to POST to the Gemini Pro Vision REST API using Axios and headers

## Testing
- `npm --prefix functions install`
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_68832b0515688330af548ab61f0b0442