### PR TITLE
Update Gemini endpoint for askGeminiV2

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -615,7 +615,7 @@ export const askGeminiV2 = functions
     }
 
     const endpoint =
-      `https://generativelanguage.googleapis.com/v1/models/gemini-pro@latest:generateContent?key=${apiKey}`;
+      `https://generativelanguage.googleapis.com/v1/models/gemini-2.5-pro:generateContent?key=${apiKey}`;
     const payload = {
       contents: [
         {


### PR DESCRIPTION
## Summary
- update askGeminiV2 to use the gemini-2.5-pro model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883327752ac8330bcb50264e5790694