### PR TITLE
Fix MainTabs navigation types

### DIFF
--- a/App/navigation/MainTabsParamList.ts
+++ b/App/navigation/MainTabsParamList.ts
@@ -1,0 +1,13 @@
+// MainTabsParamList defines the available routes for the bottom tab navigator.
+// Each tab screen maps to a key in this object, all with no params.
+export type MainTabsParamList = {
+  HomeScreen: undefined;
+  ReligionAI: undefined;
+  Journal: undefined;
+  Challenge: undefined;
+  Confessional: undefined;
+  Trivia: undefined;
+  Leaderboards: undefined;
+  Profile: undefined;
+  Settings: undefined;
+};

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -10,10 +10,14 @@ declare global {
   }
 }
 
+import type { NavigatorScreenParams } from '@react-navigation/native';
+import type { MainTabsParamList } from './MainTabsParamList';
+
 export type RootStackParamList = {
   // Root navigators
   Auth: undefined;
-  MainTabs: undefined;
+  // MainTabs accepts nested navigation params for the bottom tab navigator
+  MainTabs: NavigatorScreenParams<MainTabsParamList> | undefined;
 
   // Auth stack screens
   Welcome: undefined;

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -9,10 +9,11 @@ import { PRICE_IDS } from '@/config/stripeConfig';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import AuthGate from '@/components/AuthGate';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 
-type Props = NativeStackScreenProps<RootStackParamList, 'BuyTokens'>;
+// We only care about navigation back to the MainTabs stack here, so type it accordingly
+type Props = { navigation: NativeStackNavigationProp<RootStackParamList, 'MainTabs'> };
 
 export default function BuyTokensScreen({ navigation }: Props) {
   const theme = useTheme();

--- a/App/screens/GiveBackScreen.tsx
+++ b/App/screens/GiveBackScreen.tsx
@@ -5,10 +5,11 @@ import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import AuthGate from '@/components/AuthGate';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 
-type Props = NativeStackScreenProps<RootStackParamList, 'GiveBack'>;
+// The Give Back screen only needs navigation to MainTabs when closing
+type Props = { navigation: NativeStackNavigationProp<RootStackParamList, 'MainTabs'> };
 
 export default function GiveBackScreen({ navigation }: Props) {
   const theme = useTheme();

--- a/App/screens/dashboard/UpgradeScreen.tsx
+++ b/App/screens/dashboard/UpgradeScreen.tsx
@@ -4,14 +4,15 @@ import { View, StyleSheet, Alert, Linking } from 'react-native';
 import Button from '@/components/common/Button';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { useUser } from '@/hooks/useUser';
 import { startSubscriptionCheckout } from '@/services/apiService';
 import { ONEVINE_PLUS_PRICE_ID } from '@/config/stripeConfig';
 import { getAuthHeaders, getCurrentUserId } from '@/utils/TokenManager';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Upgrade'>;
+// NavigationProp typed for MainTabs allows navigating to tab screens
+type Props = { navigation: NativeStackNavigationProp<RootStackParamList, 'MainTabs'> };
 
 export default function UpgradeScreen({ navigation }: Props) {
   const theme = useTheme();


### PR DESCRIPTION
## Summary
- add MainTabsParamList to describe tab navigator routes
- allow RootStack.MainTabs to accept nested tab params
- update BuyTokens, Upgrade, and GiveBack screens to type navigation for MainTabs

## Testing
- `npx jest` *(fails: Jest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6883809e223483309524e8a1e7dfaf9f