### PR TITLE
Fix Gemini 2.5 integration

### DIFF
--- a/functions/geminiUtils.ts
+++ b/functions/geminiUtils.ts
@@ -11,7 +11,7 @@ export function createGeminiModel(apiKey: string = GEMINI_API_KEY) {
   }
   try {
     const genAI = new GoogleGenerativeAI(apiKey);
-    return genAI.getGenerativeModel({ model: 'gemini-1.5-pro' });
+    return genAI.getGenerativeModel({ model: 'models/gemini-2.5-pro' });
   } catch (err) {
     logger.error('Failed to initialize GoogleGenerativeAI', err);
     throw err;

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -647,16 +647,17 @@ export const askGeminiV2 = functions
       functions.logger.info(`askGeminiV2 full prompt: ${finalPrompt}`);
 
       const genAI = new GoogleGenerativeAI(apiKey);
-      const model = genAI.getGenerativeModel({ model: "gemini-pro" });
+      const model = genAI.getGenerativeModel({ model: 'models/gemini-2.5-pro' });
       const chat = await model.startChat({
         history: history.map((msg: any) => ({
           role: msg.role,
           parts: msg.parts || [{ text: msg.text }],
         })),
       });
+      console.log('📖 Chat history', JSON.stringify(history));
       const result = await chat.sendMessage(finalPrompt);
-      console.log("📨 Gemini full response", JSON.stringify(result, null, 2));
-      const reply = result?.response?.text?.() || "";
+      console.log('📨 Gemini full response', JSON.stringify(result, null, 2));
+      const reply = result?.response?.text?.() || '';
 
       if (!reply) {
         console.error("Gemini returned empty reply");


### PR DESCRIPTION
## Summary
- use `models/gemini-2.5-pro` for Gemini requests
- log chat history and Gemini output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688394740a0c833081067432a202a983