### PR TITLE
Fix settings navigation

### DIFF
--- a/App/components/common/Header.tsx
+++ b/App/components/common/Header.tsx
@@ -64,7 +64,7 @@ export default function Header() {
       console.error('🚫 Navigation object is undefined');
       return;
     }
-    navigation.navigate('Settings');
+    navigation.navigate('MainTabs', { screen: 'Settings' });
   };
 
   return (


### PR DESCRIPTION
## Summary
- wire header settings button to use nested MainTabs route instead of direct settings route

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6885399fd65c8330a0610191b05faaf9