### PR TITLE
Remove subscription check from settings

### DIFF
--- a/App/screens/profile/SettingsScreen.tsx
+++ b/App/screens/profile/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import CustomText from '@/components/CustomText';
 import { View, StyleSheet, Switch, Alert, LayoutAnimation } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -16,7 +16,6 @@ import { useUser } from '@/hooks/useUser';
 import { useTheme } from "@/components/theme/theme";
 import { scheduleReflectionReminder, cancelReflectionReminder } from '@/utils/reminderNotification';
 import AuthGate from '@/components/AuthGate';
-import { getDocument } from '@/services/firestoreService';
 
 export default function SettingsScreen() {
   const theme = useTheme();
@@ -32,7 +31,6 @@ export default function SettingsScreen() {
     toggleNightStore();
   };
   const [changing, setChanging] = useState(false);
-  const [isSubscribed, setIsSubscribed] = useState(false);
   const clearUser = useUserProfileStore((s) => s.setUserProfile.bind(null, null as any));
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
@@ -52,30 +50,6 @@ export default function SettingsScreen() {
     [theme],
   );
 
-  useEffect(() => {
-    if (!user?.uid) return;
-
-    let cancelled = false;
-
-    const fetchSub = async () => {
-      try {
-        const doc = await getDocument(`subscriptions/${user.uid}`);
-        const active = !!doc && doc.active === true;
-        if (!cancelled && active !== isSubscribed) {
-          setIsSubscribed(active);
-          console.log('✅ isSubscribed updated:', active);
-        }
-      } catch (err) {
-        console.warn('Subscription fetch failed', err);
-      }
-    };
-
-    fetchSub();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [user?.uid]);
 
   const handleChangePassword = async () => {
     Alert.prompt(
@@ -153,9 +127,9 @@ export default function SettingsScreen() {
           <>
             <Button title="Profile" onPress={() => navigation.navigate('Profile')} />
             <Button title="Buy Tokens" onPress={() => navigation.navigate('BuyTokens')} />
-            <Button title="Upgrade" onPress={() => navigation.navigate('Upgrade')} />
+            <Button title="Upgrade to OneVine+" onPress={() => navigation.navigate('Upgrade')} />
             <Button title="Join Organization" onPress={() => navigation.navigate('JoinOrganization')} />
-            <Button title="Give Back" onPress={() => navigation.navigate('GiveBack')} />
+            <Button title="Donate" onPress={() => navigation.navigate('GiveBack')} />
             <Button title="Change Password" onPress={handleChangePassword} loading={changing} />
             <Button title="Sign Out" onPress={handleLogout} />
           </>


### PR DESCRIPTION
## Summary
- clean up `SettingsScreen` by deleting Firestore subscription calls
- rename buttons to match current upgrade and donation options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688588262a788330b751563e5877a18f