### PR TITLE
Handle missing subscription doc

### DIFF
--- a/App/utils/userProfile.ts
+++ b/App/utils/userProfile.ts
@@ -92,7 +92,11 @@ export async function loadUserProfile(uid?: string): Promise<UserProfile | null>
       const subDoc = fromFirestore(subRes.data);
       isSubscribed = subDoc?.active === true;
     } catch (subErr: any) {
-      if (subErr?.response?.status !== 404) {
+      if (subErr?.response?.status === 404) {
+        console.warn(
+          `\u26A0\uFE0F Subscription document missing for uid: ${userId}, defaulting to isSubscribed: false`,
+        );
+      } else {
         logFirestoreError('GET', `subscriptions/${userId}`, subErr);
       }
     }


### PR DESCRIPTION
## Summary
- avoid crashing when subscription doc doesn't exist

## Testing
- `npx jest`
- `npx tsc -p tsconfig.json --noEmit` *(fails: 'children' are specified twice in UpgradeScreen)*

------
https://chatgpt.com/codex/tasks/task_e_68859dec72608330832e326b10bd1a40