### PR TITLE
Add default subscription doc on user creation

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1577,6 +1577,14 @@ export const onUserCreate = functions
       logger.info("onUserCreate profile", profile);
 
       await docRef.set(profile, { merge: false });
+      const subscriptionRef = admin.firestore().doc(`subscriptions/${uid}`);
+      await subscriptionRef.set({
+        isSubscribed: false,
+        plan: null,
+        startDate: null,
+        expiryDate: null,
+        createdAt: timestamp,
+      });
     } catch (err) {
       logger.error(`onUserCreate failed for ${uid}`, err);
     }


### PR DESCRIPTION
## Summary
- append creating a `subscriptions/{uid}` doc in `onUserCreate`
- ensure new users always have a default subscription entry

## Testing
- `npm test`
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_6885a9b7f3bc8330b51b270a4fa682fe