### PR TITLE
Fix Settings store selector issue

### DIFF
--- a/App/screens/profile/SettingsScreen.tsx
+++ b/App/screens/profile/SettingsScreen.tsx
@@ -24,24 +24,12 @@ import AuthGate from '@/components/AuthGate';
 export default function SettingsScreen() {
   const theme = useTheme();
   const { user } = useUser();
-  const {
-    nightMode,
-    reminderEnabled,
-    reminderTime,
-    setReminderEnabled,
-    setReminderTime,
-    toggleNightMode,
-  } = useSettingsStore(
-    (s) => ({
-      nightMode: s.nightMode,
-      reminderEnabled: s.reminderEnabled,
-      reminderTime: s.reminderTime,
-      setReminderEnabled: s.setReminderEnabled,
-      setReminderTime: s.setReminderTime,
-      toggleNightMode: s.toggleNightMode,
-    }),
-    shallow,
-  );
+  const nightMode = useSettingsStore((s) => s.nightMode);
+  const reminderEnabled = useSettingsStore((s) => s.reminderEnabled);
+  const reminderTime = useSettingsStore((s) => s.reminderTime);
+  const setReminderEnabled = useSettingsStore((s) => s.setReminderEnabled);
+  const setReminderTime = useSettingsStore((s) => s.setReminderTime);
+  const toggleNightMode = useSettingsStore((s) => s.toggleNightMode);
   const toggleNight = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     toggleNightMode();

--- a/App/state/settingsStore.ts
+++ b/App/state/settingsStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 
-interface SettingsState {
+export interface SettingsState {
   nightMode: boolean
   toggleNightMode: () => void
   setNightMode: (value: boolean) => void
@@ -10,7 +10,7 @@ interface SettingsState {
   setReminderTime: (time: string) => void
 }
 
-export const useSettingsStore = create<SettingsState>((set: any) => ({
+export const useSettingsStore = create<SettingsState>((set) => ({
   nightMode: false,
   toggleNightMode: () => set((s: SettingsState) => ({ nightMode: !s.nightMode })),
   setNightMode: (value: boolean) => set({ nightMode: value }),


### PR DESCRIPTION
## Summary
- export `SettingsState` and properly type the zustand create function
- use individual selectors in `SettingsScreen` so React 19 caches the snapshot

## Testing
- `npx tsc --noEmit App/state/settingsStore.ts App/screens/profile/SettingsScreen.tsx`
- `npx jest --runInBand` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6885b494f15883309f38b20585b57b24