### PR TITLE
Revise settings screen

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -43,6 +43,7 @@ import QuoteScreen from '@/screens/QuoteScreen';
 
 import BuyTokensScreen from '@/screens/BuyTokensScreen';
 import GiveBackScreen from '@/screens/GiveBackScreen';
+import AppInfoScreen from '@/screens/AppInfoScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -161,6 +162,7 @@ export default function AuthGate() {
         <Stack.Screen name="Profile" component={ProfileScreen} />
         <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Change Password' }} />
         <Stack.Screen name="Settings" component={SettingsScreen} />
+        <Stack.Screen name="AppInfo" component={AppInfoScreen} options={{ title: 'App Info' }} />
         <Stack.Screen name="Trivia" component={TriviaScreen} options={{ title: 'Trivia Challenge' }} />
         <Stack.Screen name="Leaderboards" component={LeaderboardScreen} options={{ title: 'Leaderboards' }} />
         <Stack.Screen name="SubmitProof" component={SubmitProofScreen} options={{ title: 'Submit Proof' }} />

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -45,6 +45,7 @@ export type RootStackParamList = {
   Profile: undefined;
   ChangePassword: undefined;
   Settings: undefined;
+  AppInfo: undefined;
 
   // Shared flow screens
   Quote: undefined;

--- a/App/screens/AppInfoScreen.tsx
+++ b/App/screens/AppInfoScreen.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import CustomText from '@/components/CustomText';
+import { View, StyleSheet } from 'react-native';
+import ScreenContainer from '@/components/theme/ScreenContainer';
+import { useTheme } from '@/components/theme/theme';
+import Button from '@/components/common/Button';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '@/navigation/RootStackParamList';
+import Constants from 'expo-constants';
+import AuthGate from '@/components/AuthGate';
+
+export default function AppInfoScreen() {
+  const theme = useTheme();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        content: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+        title: { fontSize: 24, marginBottom: theme.spacing.lg, color: theme.colors.text },
+      }),
+    [theme],
+  );
+  return (
+    <AuthGate>
+    <ScreenContainer>
+      <View style={styles.content}>
+        <CustomText style={styles.title}>OneVine</CustomText>
+        <CustomText>Version {Constants.expoConfig?.version}</CustomText>
+        <Button title="Back" onPress={() => navigation.goBack()} />
+      </View>
+    </ScreenContainer>
+    </AuthGate>
+  );
+}

--- a/App/screens/profile/SettingsScreen.tsx
+++ b/App/screens/profile/SettingsScreen.tsx
@@ -15,15 +15,12 @@ import type { MainTabsParamList } from '@/navigation/MainTabsParamList';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
 import { useSettingsStore } from "@/state/settingsStore";
 import { useUserProfileStore } from "@/state/userProfile";
-import { shallow } from 'zustand/shallow';
-import { useUser } from '@/hooks/useUser';
 import { useTheme } from "@/components/theme/theme";
 import { scheduleReflectionReminder, cancelReflectionReminder } from '@/utils/reminderNotification';
 import AuthGate from '@/components/AuthGate';
 
 export default function SettingsScreen() {
   const theme = useTheme();
-  const { user } = useUser();
   const nightMode = useSettingsStore((s) => s.nightMode);
   const reminderEnabled = useSettingsStore((s) => s.reminderEnabled);
   const reminderTime = useSettingsStore((s) => s.reminderTime);
@@ -132,31 +129,16 @@ export default function SettingsScreen() {
             />
           </View>
         )}
-        {user ? (
-          <>
-            <Button title="Profile" onPress={() => navigation.navigate('Profile')} />
-            <Button title="Buy Tokens" onPress={() => navigation.navigate('BuyTokens')} />
-            <Button title="Upgrade" onPress={() => navigation.navigate('Upgrade')} />
-            <Button title="Join Organization" onPress={() => navigation.navigate('JoinOrganization')} />
-            <Button title="Give Back" onPress={() => navigation.navigate('GiveBack')} />
-            <Button title="Change Password" onPress={handleChangePassword} loading={changing} />
-            <Button title="Sign Out" onPress={handleLogout} />
-          </>
-        ) : (
-          <>
-            <Button title="Log In" onPress={resetToLogin} />
-            <Button title="Sign Up" onPress={() => navigation.navigate('Signup')} />
-            <Button
-              title="App Info"
-              onPress={() =>
-                Alert.alert(
-                  'OneVine',
-                  `Version ${Constants.expoConfig?.version}`,
-                )
-              }
-            />
-          </>
-        )}
+        <>
+          <Button title="Profile" onPress={() => navigation.navigate('Profile')} />
+          <Button title="Upgrade" onPress={() => navigation.navigate('Upgrade')} />
+          <Button title="Buy Tokens" onPress={() => navigation.navigate('BuyTokens')} />
+          <Button title="Give Back" onPress={() => navigation.navigate('GiveBack')} />
+          <Button title="Join Organization" onPress={() => navigation.navigate('JoinOrganization')} />
+          <Button title="App Info" onPress={() => navigation.navigate('AppInfo')} />
+          <Button title="Change Password" onPress={handleChangePassword} loading={changing} />
+          <Button title="Sign Out" onPress={handleLogout} />
+        </>
         <CustomText style={styles.version}>v{Constants.expoConfig?.version}</CustomText>
       </View>
     </ScreenContainer>


### PR DESCRIPTION
## Summary
- add a simple `AppInfoScreen`
- expose new `AppInfo` route in `RootStackParamList` and `AuthGate`
- clean up `SettingsScreen` and add nav buttons for Profile, Upgrade, Buy Tokens, Give Back, Join Organization, and App Info

## Testing
- `npx --yes jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885b934f930833099f86f40346fc585