### PR TITLE
Handle Stripe success redirect

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -30,6 +30,7 @@ import UpgradeScreen from '@/screens/dashboard/UpgradeScreen';
 import LeaderboardScreen from '@/screens/dashboard/LeaderboardScreen';
 import TriviaScreen from '@/screens/dashboard/TriviaScreen';
 import SubmitProofScreen from '@/screens/dashboard/SubmitProofScreen';
+import StripeSuccessScreen from '@/screens/dashboard/StripeSuccessScreen';
 
 // Profile Screens
 import ProfileScreen from '@/screens/profile/ProfileScreen';
@@ -158,6 +159,7 @@ export default function AuthGate() {
         <Stack.Screen name="Quote" component={QuoteScreen} options={{ headerShown: false }} />
         <Stack.Screen name="BuyTokens" component={BuyTokensScreen} options={{ title: 'Buy Tokens' }} />
         <Stack.Screen name="Upgrade" component={UpgradeScreen} options={{ title: 'Upgrade to OneVine+' }} />
+        <Stack.Screen name="StripeSuccess" component={StripeSuccessScreen} options={{ title: 'Subscription Success' }} />
         <Stack.Screen name="GiveBack" component={GiveBackScreen} options={{ title: 'Give Back' }} />
         <Stack.Screen name="Profile" component={ProfileScreen} />
         <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Change Password' }} />

--- a/App/navigation/RootStackParamList.ts
+++ b/App/navigation/RootStackParamList.ts
@@ -47,6 +47,9 @@ export type RootStackParamList = {
   Settings: undefined;
   AppInfo: undefined;
 
+  // Stripe flow
+  StripeSuccess: { success?: string } | undefined;
+
   // Shared flow screens
   Quote: undefined;
   SelectReligion: undefined;

--- a/App/navigation/screens.ts
+++ b/App/navigation/screens.ts
@@ -22,6 +22,7 @@ export const SCREENS = {
     SUBMIT_PROOF: 'SubmitProof',
     JOIN_ORGANIZATION: 'JoinOrganization',
     MANAGE_ORGANIZATION: 'OrganizationManagement',
-    SELECT_RELIGION: 'SelectReligion'
+    SELECT_RELIGION: 'SelectReligion',
+    STRIPE_SUCCESS: 'StripeSuccess'
   }
 } as const;

--- a/App/screens/dashboard/StripeSuccessScreen.tsx
+++ b/App/screens/dashboard/StripeSuccessScreen.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import CustomText from '@/components/CustomText';
+import ScreenContainer from '@/components/theme/ScreenContainer';
+import Button from '@/components/common/Button';
+import { useTheme } from '@/components/theme/theme';
+import { useUserProfileStore } from '@/state/userProfile';
+import { RootStackParamList } from '@/navigation/RootStackParamList';
+
+/**
+ * Screen shown after returning from Stripe's success_url.
+ * Verifies subscription status and redirects into the app.
+ */
+
+export default function StripeSuccessScreen() {
+  type SuccessRoute = RouteProp<RootStackParamList, 'StripeSuccess'>;
+  const { params } = useRoute<SuccessRoute>();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const theme = useTheme();
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const profileStore = useUserProfileStore();
+
+  useEffect(() => {
+    async function verify() {
+      const success =
+        (params as any)?.success === true || (params as any)?.success === 'true';
+      if (!success) {
+        console.log('⚠️ Missing success param', params);
+        setFailed(true);
+        setLoading(false);
+        return;
+      }
+      console.log('✅ Stripe payment success redirect');
+      console.log('🔄 Reloading user profile...');
+      try {
+        await profileStore.refreshUserProfile();
+        const profile = profileStore.profile;
+        console.log('📦 Refetched profile:', profile);
+        console.log('🔥 Subscription active:', profile?.isSubscribed);
+        if (profile?.isSubscribed) {
+          setLoading(false);
+          setTimeout(() => {
+            navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+          }, 1000);
+          return;
+        }
+      } catch (err) {
+        console.log('❌ Verification error', err);
+      }
+      setFailed(true);
+      setLoading(false);
+    }
+    verify();
+  }, [params]);
+
+  const retry = () => {
+    setLoading(true);
+    setFailed(false);
+    // Re-run verification
+    (async () => {
+      const success =
+        (params as any)?.success === true || (params as any)?.success === 'true';
+      if (!success) {
+        setFailed(true);
+        setLoading(false);
+        return;
+      }
+      console.log('🔄 Reloading user profile...');
+      try {
+        await profileStore.refreshUserProfile();
+        const profile = profileStore.profile;
+        console.log('📦 Refetched profile:', profile);
+        console.log('🔥 Subscription active:', profile?.isSubscribed);
+        if (profile?.isSubscribed) {
+          setLoading(false);
+          setTimeout(() => {
+            navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+          }, 1000);
+          return;
+        }
+      } catch (err) {
+        console.log('❌ Verification error', err);
+      }
+      setFailed(true);
+      setLoading(false);
+    })();
+  };
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        center: { alignItems: 'center', marginTop: theme.spacing.xl },
+        msg: {
+          marginVertical: theme.spacing.md,
+          fontSize: 18,
+          textAlign: 'center',
+          color: theme.colors.text,
+        },
+        retryBtn: { marginTop: theme.spacing.md },
+      }),
+    [theme],
+  );
+
+  if (loading) {
+    return (
+      <ScreenContainer>
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <CustomText style={styles.msg}>Verifying purchase...</CustomText>
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  if (failed) {
+    return (
+      <ScreenContainer>
+        <View style={styles.center}>
+          <CustomText style={styles.msg}>
+            We couldn&apos;t verify your subscription.
+          </CustomText>
+          <Button title="Retry" onPress={retry} style={styles.retryBtn as any} />
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  return (
+    <ScreenContainer>
+      <View style={styles.center}>
+        <CustomText style={styles.msg}>Subscription activated!</CustomText>
+      </View>
+    </ScreenContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add `StripeSuccessScreen` to verify subscription after payment
- wire new screen into navigation types and stack
- expose screen name in screens constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68866d3274788330a4f3a8e8df5d37bc