### PR TITLE
Fix Firestore rules for leaderboard and challenge

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,12 +8,23 @@ service cloud.firestore {
 
     // 🔐 User profile document
     match /users/{userId} {
-      allow read, create, update: if isSignedIn() && request.auth.uid == userId;
-    }
+      // Users can always read and modify their own profile data
+      allow get, create, update: if isSignedIn() && request.auth.uid == userId;
 
-    // ✅ Active challenge document
-    match /activeChallenge/{docId} {
-      allow read, write: if isSignedIn() && request.auth.uid == docId;
+      /*
+       * Allow authenticated users to query the users collection for leaderboard
+       * purposes. Only simple ordering by individualPoints with a small limit
+       * is permitted to reduce exposure of profile data. This enables queries
+       * such as `.orderBy('individualPoints').limit(10)`.
+       */
+      allow list: if isSignedIn() &&
+                  request.query.orderBy.field == 'individualPoints' &&
+                  request.query.limit <= 50;
+
+      // Subcollection storing each user's active challenge session
+      match /activeChallenge/{docId} {
+        allow read, write: if isSignedIn() && request.auth.uid == userId;
+      }
     }
 
     // 📊 Subcollections used for tracking


### PR DESCRIPTION
## Summary
- allow listing users for leaderboard queries
- restrict listing to points-based queries
- secure active challenge subcollection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688684a290008330b48f47bb4d3ef337