### PR TITLE
Fix daily challenge Firestore handling

### DIFF
--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -183,6 +183,16 @@ export default function ChallengeScreen() {
       } else {
         console.log('🌟 New Challenge:', newChallenge);
         setChallenge(newChallenge);
+        await updateActiveChallenge(uid, {
+          challengeText: newChallenge,
+          totalDays: 1,
+          currentDay: 1,
+          isComplete: false,
+          isMultiDay: false,
+          startDate: new Date().toISOString(),
+          lastCompleted: null,
+          completedDays: [],
+        });
       }
 
       await updateUserProfile({
@@ -236,11 +246,8 @@ export default function ChallengeScreen() {
         uid,
       );
       await updateActiveChallenge(uid, {
-        day: (active?.day || 0) + 1,
-        startTimestamp: new Date().toISOString(),
-        completed: false,
-        isMultiDay: false,
-        totalDays: 1,
+        isComplete: true,
+        lastCompleted: new Date().toISOString(),
       });
       setCanSkip(true);
       fetchChallenge(true);
@@ -363,14 +370,8 @@ export default function ChallengeScreen() {
       Alert.alert('Great job!', 'Challenge completed.');
     }
     await updateActiveChallenge(uid, {
-      completed: true,
-    });
-    await updateActiveChallenge(uid, {
-      day: (active?.day || 0) + 1,
-      startTimestamp: new Date().toISOString(),
-      completed: false,
-      isMultiDay: false,
-      totalDays: 1,
+      isComplete: true,
+      lastCompleted: new Date().toISOString(),
     });
     const shouldGenerateNew = useToken || history.completed < limit;
     fetchChallenge(shouldGenerateNew);

--- a/App/utils/userProfile.ts
+++ b/App/utils/userProfile.ts
@@ -158,7 +158,7 @@ export async function updateUserProfile(
   }
   const sanitized: Record<string, any> = {};
   for (const [key, value] of Object.entries(fields)) {
-    if (value !== undefined) sanitized[key] = value;
+    if (value !== undefined && value !== null) sanitized[key] = value;
   }
   if (Object.keys(sanitized).length === 0) {
     return;


### PR DESCRIPTION
## Summary
- sanitize Firestore writes to drop undefined/null values
- store new daily challenges under `users/{uid}/activeChallenge/current`
- mark challenges complete/skipped correctly
- initialize activeChallenge documents with expected fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68869653659c83309aa9eb4a1361e6b0