### PR TITLE
Handle Stripe success deep link

### DIFF
--- a/App/navigation/AuthGate.tsx
+++ b/App/navigation/AuthGate.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 // Prevent multiple auth listeners on re-renders
 let authInitialized = false;
 
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, type LinkingOptions } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { navigationRef } from './navigationRef';
 import { RootStackParamList } from './RootStackParamList';
@@ -47,6 +47,15 @@ import GiveBackScreen from '@/screens/GiveBackScreen';
 import AppInfoScreen from '@/screens/AppInfoScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const linking: LinkingOptions<RootStackParamList> = {
+  prefixes: ['onevine://', 'https://onevine.app'],
+  config: {
+    screens: {
+      StripeSuccess: 'payment-success',
+    },
+  },
+};
 
 export default function AuthGate() {
   const theme = useTheme();
@@ -136,6 +145,7 @@ export default function AuthGate() {
 
   return (
     <NavigationContainer
+      linking={linking}
       ref={navigationRef}
       onStateChange={() => {
         if (uid) refreshLastActive(uid);

--- a/App/screens/dashboard/StripeSuccessScreen.tsx
+++ b/App/screens/dashboard/StripeSuccessScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, ActivityIndicator, StyleSheet, Text } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
@@ -20,7 +20,14 @@ export default function StripeSuccessScreen() {
   const theme = useTheme();
   const { user } = useUser();
   const setProfile = useUserProfileStore((s) => s.setUserProfile);
+  const refreshProfile = useUserProfileStore((s) => s.refreshUserProfile);
   const [loading, setLoading] = useState(true);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      refreshProfile();
+    }, [refreshProfile]),
+  );
 
   useEffect(() => {
     let mounted = true;

--- a/app.config.js
+++ b/app.config.js
@@ -4,6 +4,7 @@ export default ({ config }) => ({
   ...config,
   name: "OneVine",
   slug: "onevine-app",
+  scheme: "onevine",
   version: "1.0.0",
   // Use the shared logo for both platforms
   icon: "./assets/icon.png",


### PR DESCRIPTION
## Summary
- configure deep linking in the navigation container
- register URL scheme
- refresh profile when `StripeSuccessScreen` is focused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886fd521fbc8330b2e7e10c6fdf4f2d