### PR TITLE
Update build properties for SDK 35

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -12,8 +12,8 @@ export default ({ config }) => ({
   plugins: [
     ["expo-build-properties", {
       android: {
-        compileSdkVersion: 34,
-        targetSdkVersion: 34,
+        compileSdkVersion: 35,
+        targetSdkVersion: 35,
         minSdkVersion: 24
       }
     }]

--- a/eas.json
+++ b/eas.json
@@ -37,7 +37,7 @@
       "channel": "production",
       "android": {
         "buildType": "apk",
-        "gradleCommand": ":app:assembleRelease",
+        "gradleCommand": ":app:assembleRelease --warning-mode all",
         "env": {
           "SENTRY_AUTH_TOKEN": "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"
         }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
     "ios": "expo run:ios",
     "test": "jest"
   },
+  "expo": {
+    "doctor": {
+      "reactNativeDirectoryCheck": {
+        "listUnknownPackages": false
+      }
+    }
+  },
   "dependencies": {
     "@expo-google-fonts/merriweather": "^0.4.1",
     "@expo-google-fonts/poppins": "^0.4.0",


### PR DESCRIPTION
## Summary
- bump compileSdkVersion and targetSdkVersion to 35
- disable Expo doctor warning about unknown packages
- show Gradle deprecation warnings in EAS build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888168a2c248330b8f268aa6428434b