### PR TITLE
Add transaction support and REST usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,26 @@ The app communicates with Firebase using the following REST endpoints:
 * `https://firestore.googleapis.com/v1/projects/{projectId}/databases/(default)/documents/...` – Firestore reads and writes
 * `https://us-central1-{projectId}.cloudfunctions.net/getUserProfile` – secure profile fetch
 
+Example REST call to read a user document:
+
+```ts
+const res = await fetch(
+  `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/users/${uid}`,
+  { headers: { Authorization: `Bearer ${idToken}` } },
+);
+const userData = await res.json();
+```
+
+To list past transactions:
+
+```ts
+const res = await fetch(
+  `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/users/${uid}/transactions?pageSize=20`,
+  { headers: { Authorization: `Bearer ${idToken}` } },
+);
+const txDocs = await res.json();
+```
+
 ## 📚 Codex Prompt Library
 
 Prompts used for Codex and Copilot live in the `codexPrompts` Firestore collection.

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,6 +25,11 @@ service cloud.firestore {
       match /activeChallenge/{docId} {
         allow read, write: if isSignedIn() && request.auth.uid == userId;
       }
+
+      // 💵 Payment transactions
+      match /transactions/{transactionId} {
+        allow read, write: if isSignedIn() && request.auth.uid == userId;
+      }
     }
 
     // 📊 Subcollections used for tracking

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1611,6 +1611,7 @@ export const onUserCreate = functions
         onboardingComplete: false,
         religion: "SpiritGuide",
         tokens: 0,
+        tokenCount: 0,
         skipTokensUsed: 0,
         individualPoints: 0,
         isSubscribed: false,
@@ -1632,7 +1633,7 @@ export const onUserCreate = functions
 
       logger.info("onUserCreate profile", profile);
 
-      await docRef.set(profile, { merge: false });
+      await docRef.set(profile, { merge: true });
       const subscriptionRef = admin.firestore().doc(`subscriptions/${uid}`);
       await subscriptionRef.set({
         isSubscribed: false,
@@ -2039,6 +2040,18 @@ export const finalizePaymentIntent = functions.https.onRequest(
           status: 'completed',
           created: admin.firestore.FieldValue.serverTimestamp(),
           amount: intent.amount,
+        },
+        { merge: true }
+      );
+
+      await db.doc(`users/${uid}/transactions/${paymentIntentId}`).set(
+        {
+          amount: intent.amount,
+          currency: intent.currency,
+          stripePaymentIntentId: paymentIntentId,
+          paymentMethod: intent.payment_method_types?.[0] || 'unknown',
+          status: intent.status,
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
         },
         { merge: true }
       );


### PR DESCRIPTION
## Summary
- secure transactions via Firestore rules
- create user doc on signup with merge semantics
- log Stripe payments in a transactions subcollection
- document REST calls for reading user and transaction data

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688859809a0483308df033a9b4262a69