### PR TITLE
Allow users to manage their own transactions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -28,7 +28,9 @@ service cloud.firestore {
 
       // 💵 Payment transactions
       match /transactions/{transactionId} {
-        allow create, read: if request.auth != null && request.auth.uid == userId;
+        // Only the authenticated user can read and write their own
+        // transactions subcollection
+        allow read, write: if isSignedIn() && request.auth.uid == userId;
       }
     }
 


### PR DESCRIPTION
## Summary
- let users read and write to their own `transactions` subcollection
- keep existing permissions for other collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68895eb4c22c8330ac44ea1ecad48e31