### PR TITLE
Add Stripe token and subscription hooks

### DIFF
--- a/App/hooks/useStripeCheckout.ts
+++ b/App/hooks/useStripeCheckout.ts
@@ -1,0 +1,79 @@
+import { useStripe } from '@stripe/stripe-react-native';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { Alert } from 'react-native';
+import { useUserProfileStore } from '@/state/userProfile';
+
+export function useStripeCheckout() {
+  const { initPaymentSheet, presentPaymentSheet } = useStripe();
+  const refreshProfile = useUserProfileStore((s) => s.refreshUserProfile);
+
+  async function purchaseTokens(uid: string, amount: number) {
+    try {
+      const callable = httpsCallable(
+        getFunctions(),
+        'createTokenPurchaseSheet',
+      );
+      const res = await callable({ amount, uid });
+      const data = res.data as any;
+      if (!data?.paymentIntent || !data.ephemeralKey || !data.customer) {
+        throw new Error('Missing payment sheet parameters');
+      }
+
+      const { error: initError } = await initPaymentSheet({
+        customerId: data.customer,
+        customerEphemeralKeySecret: data.ephemeralKey,
+        paymentIntentClientSecret: data.paymentIntent,
+        merchantDisplayName: 'OneVine',
+        returnURL: 'onevine://payment-return',
+      });
+
+      if (initError) {
+        Alert.alert('Payment Error', initError.message);
+        return false;
+      }
+
+      const { error } = await presentPaymentSheet();
+      if (error) {
+        if (error.code !== 'Canceled') {
+          Alert.alert('Payment Error', error.message);
+        }
+        return false;
+      }
+
+      await refreshProfile();
+      return true;
+    } catch (err: any) {
+      Alert.alert('Checkout Error', err?.message || 'Unable to start checkout');
+      return false;
+    }
+  }
+
+  async function startSubscription(uid: string, priceId: string) {
+    try {
+      const callable = httpsCallable(getFunctions(), 'createCheckoutSession');
+      const res = await callable({ priceId, uid });
+      const data = res.data as any;
+      const url = data?.url || data?.checkoutUrl;
+      if (!url) {
+        throw new Error('Missing checkout URL');
+      }
+
+      await presentStripeCheckout(url);
+      await refreshProfile();
+      return true;
+    } catch (err: any) {
+      Alert.alert('Subscription Error', err?.message || 'Unable to start checkout');
+      return false;
+    }
+  }
+
+  async function presentStripeCheckout(url: string) {
+    // Use WebBrowser.openBrowserAsync or Linking.openURL to open Stripe Checkout
+    const webBrowser = await import('expo-web-browser');
+    await webBrowser.openBrowserAsync(url);
+  }
+
+  return { purchaseTokens, startSubscription };
+}
+
+export default useStripeCheckout;

--- a/App/utils/index.ts
+++ b/App/utils/index.ts
@@ -1,5 +1,6 @@
 // Utilities entrypoint intentionally left minimal.
 export * from './userProfile';
 export * from '../hooks/usePaymentFlow';
+export * from '../hooks/useStripeCheckout';
 export * from './transactionLogger';
 


### PR DESCRIPTION
## Summary
- add `useStripeCheckout` hook to handle token purchases via `createTokenPurchaseSheet` and subscriptions via `createCheckoutSession`
- export new hook from utils index

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be1e1b8a88330ba14a349b4b0fa29