### PR TITLE
refactor: migrate stripe webhook to firebase functions 1st gen

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -10,27 +10,26 @@ if (!admin.apps.length) {
 }
 const db = admin.firestore();
 const auth = admin.auth();
-// Create a new subscription after PaymentSheet setup
-export const createSubscription = functions.https.onRequest(async (req, res) => {
-  try {
-    const { customerId, paymentMethodId, uid } = req.body;
-    if (!customerId || !paymentMethodId || !uid) {
-      res.status(400).json({ error: 'Missing required fields' });
-      return;
-    }
-    const priceId = 'price_1RFjFaGLKcFWSqCIrIiOVfwM';
-    const subscription = await stripe.subscriptions.create({
-      customer: customerId,
-      default_payment_method: paymentMethodId,
-      items: [{ price: priceId }],
-      metadata: { uid },
-    });
-    res.status(200).json({ subscriptionId: subscription.id });
-  } catch (err: any) {
-    logger.error('createSubscription failed', err);
-    res.status(500).json({ error: err?.message || 'Failed to create subscription' });
-  }
-});
+// export const createSubscription = functions.https.onRequest(async (req, res) => {
+//   try {
+//    const { customerId, paymentMethodId, uid } = req.body;
+//    if (!customerId || !paymentMethodId || !uid) {
+//      res.status(400).json({ error: 'Missing required fields' });
+//      return;
+//    }
+//    const priceId = 'price_1RFjFaGLKcFWSqCIrIiOVfwM';
+//    const subscription = await stripe.subscriptions.create({
+//      customer: customerId,
+//      default_payment_method: paymentMethodId,
+//      items: [{ price: priceId }],
+//      metadata: { uid },
+//    });
+//    res.status(200).json({ subscriptionId: subscription.id });
+//  } catch (err: any) {
+//    logger.error('createSubscription failed', err);
+//    res.status(500).json({ error: err?.message || 'Failed to create subscription' });
+//  }
+//});
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { createGeminiModel, fetchReligionContext } from './geminiUtils';
 import {

--- a/functions/stripeWebhooks.ts
+++ b/functions/stripeWebhooks.ts
@@ -1,4 +1,4 @@
-import { onRequest } from 'firebase-functions/v2/https';
+import * as functions from 'firebase-functions/v1';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
 
@@ -11,7 +11,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
 } as any);
 
-export const handleStripeWebhookV2 = onRequest(async (req, res) => {
+export const handleStripeWebhookV2 = functions.https.onRequest(async (req, res) => {
   const sig = req.headers['stripe-signature'];
   if (typeof sig !== 'string') {
     res.status(400).send('Missing stripe-signature header');
@@ -70,6 +70,7 @@ export const handleStripeWebhookV2 = onRequest(async (req, res) => {
     console.warn(`⚠️ Unrecognized metadata.type: ${type}`);
   }
 
+  console.log('✅ Webhook handled successfully');
   res.status(200).send('Webhook handled');
 });
 


### PR DESCRIPTION
## Summary
- switch handleStripeWebhookV2 to Firebase Functions 1st Gen and log success on completion
- comment out outdated createSubscription function to avoid conflicts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688feb4a357c83309aa6c9858504eb9a