### PR TITLE
Fix subscription initialization and token purchase logging

### DIFF
--- a/App/services/firestoreService.ts
+++ b/App/services/firestoreService.ts
@@ -115,6 +115,20 @@ export async function getDocument(path: string): Promise<any | null> {
     }
     if (status === 404) {
       // Document missing is not an auth issue
+      if (path.startsWith('subscriptions/')) {
+        const defaultSub = {
+          active: false,
+          tier: 'free',
+          subscribedAt: new Date(),
+          createdVia: 'autoInit',
+        };
+        try {
+          await setDocument(path, defaultSub);
+        } catch (createErr) {
+          console.error('Failed to auto-create subscription document', createErr);
+        }
+        return defaultSub;
+      }
       return null;
     }
     throw err;


### PR DESCRIPTION
## Summary
- auto-create missing subscription docs
- update subscriptions and user docs on Stripe webhooks
- increment user tokens and log purchases with transaction IDs

## Testing
- `npm test`
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_689019dbe58c8330ad656c251fa1bf8c