### PR TITLE
feat: ensure subscription doc creation

### DIFF
--- a/functions/stripeWebhooks.ts
+++ b/functions/stripeWebhooks.ts
@@ -120,9 +120,12 @@ async function processSubscription(
     }
   }
 
+  const subscriptionType = object.metadata?.tier || 'premium';
   const subData = {
     active: true,
-    tier: object.metadata?.tier || 'premium',
+    tier: subscriptionType,
+    isSubscribed: true,
+    subscriptionType,
     subscribedAt: admin.firestore.FieldValue.serverTimestamp(),
     expiresAt: expiresAt || null,
     updatedVia: 'stripeWebhook',


### PR DESCRIPTION
## Summary
- ensure `subscriptions/{uid}` is created/updated with subscription info on successful Stripe purchase

## Testing
- `npm test`
- `npm test` (functions) *(fails: Missing script: "test")*
- `npm run build` (functions)


------
https://chatgpt.com/codex/tasks/task_e_68902e71f7ec83309191e3cc4a664f50