### PR TITLE
fix: return subscription client secret

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1333,8 +1333,13 @@ export const createStripeSubscriptionIntent = functions
         metadata: { uid, tier },
       });
 
-      const clientSecret = (subscription.latest_invoice as any)?.payment_intent?.client_secret as string | undefined;
+      const latestInvoice = subscription.latest_invoice as Stripe.Invoice | null;
+      const clientSecret = latestInvoice?.payment_intent?.client_secret as string | undefined;
       if (!clientSecret) {
+        logger.error('Failed to obtain client secret', {
+          subscriptionId: subscription.id,
+          latestInvoice,
+        });
         res.status(500).json({ error: 'Failed to obtain client secret' });
         return;
       }


### PR DESCRIPTION
## Summary
- capture latest invoice client secret when creating Stripe subscriptions
- log and fail if payment intent data is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b9896cc483308b710fbd0fc5845f