### PR TITLE
Refactor Firestore queries for pagination

### DIFF
--- a/App/screens/auth/ForgotUsernameScreen.tsx
+++ b/App/screens/auth/ForgotUsernameScreen.tsx
@@ -53,8 +53,11 @@ export default function ForgotUsernameScreen() {
   useEffect(() => {
     const load = async () => {
       try {
-        const list = await queryCollection('regions');
-        list.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+        const list = await queryCollection('regions', {
+          orderByField: 'sortOrder',
+          direction: 'ASCENDING',
+          limit: 50,
+        });
         setRegions(list);
         if (!region && list.length) setRegion(list[0].name);
       } catch (err) {

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -879,10 +879,22 @@ export const generateDailyChallenge = functions
       timestamp: admin.firestore.FieldValue.serverTimestamp(),
     });
 
-    const allSnap = await historyRef.orderBy("timestamp", "desc").get();
-    const docs = allSnap.docs;
-    for (let i = 3; i < docs.length; i++) {
-      await docs[i].ref.delete();
+    let last = histSnap.docs[histSnap.docs.length - 1];
+    let snap = await historyRef
+      .orderBy("timestamp", "desc")
+      .startAfter(last)
+      .limit(20)
+      .get();
+    while (!snap.empty) {
+      const batch = db.batch();
+      snap.docs.forEach((d) => batch.delete(d.ref));
+      await batch.commit();
+      last = snap.docs[snap.docs.length - 1];
+      snap = await historyRef
+        .orderBy("timestamp", "desc")
+        .startAfter(last)
+        .limit(20)
+        .get();
     }
 
     await userRef.set(
@@ -1002,10 +1014,22 @@ export const skipDailyChallenge = functions
       timestamp: admin.firestore.FieldValue.serverTimestamp(),
     });
 
-    const allSnap = await historyRef.orderBy("timestamp", "desc").get();
-    const docs = allSnap.docs;
-    for (let i = 3; i < docs.length; i++) {
-      await docs[i].ref.delete();
+    let last = histSnap.docs[histSnap.docs.length - 1];
+    let snap = await historyRef
+      .orderBy("timestamp", "desc")
+      .startAfter(last)
+      .limit(20)
+      .get();
+    while (!snap.empty) {
+      const batch = db.batch();
+      snap.docs.forEach((d) => batch.delete(d.ref));
+      await batch.commit();
+      last = snap.docs[snap.docs.length - 1];
+      snap = await historyRef
+        .orderBy("timestamp", "desc")
+        .startAfter(last)
+        .limit(20)
+        .get();
     }
 
     await userRef.set(


### PR DESCRIPTION
## Summary
- paginate organization lookup and region list to avoid unbounded reads
- page journal entry history and add client load-more
- batch prune challenge history and seed scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892d84bf42c8330a3b73cf0b0915a68