### PR TITLE
feat: refresh profile after subscription

### DIFF
--- a/App/screens/auth/LoginScreen.tsx
+++ b/App/screens/auth/LoginScreen.tsx
@@ -6,7 +6,7 @@ import ScreenContainer from "@/components/theme/ScreenContainer";
 import TextField from "@/components/TextField";
 import Button from "@/components/common/Button";
 import { login, resetPassword } from "@/services/authService";
-import { loadUserProfile } from "@/utils";
+import { loadFreshUserProfile } from "@/utils";
 import { useUserProfileStore } from "@/state/userProfile";
 import type { UserProfile } from "../../../types";
 import { checkIfUserIsNewAndRoute } from "@/services/onboardingService";
@@ -33,7 +33,7 @@ export default function LoginScreen() {
       const result = await login(email, password);
       if (result.localId) {
         setUid(result.localId);
-        const profile: UserProfile | null = await loadUserProfile(result.localId);
+        const profile: UserProfile | null = await loadFreshUserProfile(result.localId);
         if (profile) {
           useUserProfileStore.getState().setUserProfile(profile as any);
         }

--- a/App/screens/dashboard/StripeSuccessScreen.tsx
+++ b/App/screens/dashboard/StripeSuccessScreen.tsx
@@ -5,7 +5,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
 import { useUserProfileStore } from '@/state/userProfile';
-import { loadUserProfile } from '@/utils/userProfile';
+import { handlePostSubscription } from '@/utils/profileRefresh';
 import { getIdToken } from '@/utils/authUtils';
 import { useUser } from '@/hooks/useUser';
 import { SCREENS } from '@/navigation/screens';
@@ -20,7 +20,6 @@ export default function StripeSuccessScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const theme = useTheme();
   const { user } = useUser();
-  const setProfile = useUserProfileStore((s) => s.setUserProfile);
   const refreshProfile = useUserProfileStore((s) => s.refreshUserProfile);
   const [loading, setLoading] = useState(true);
 
@@ -36,10 +35,9 @@ export default function StripeSuccessScreen() {
       if (!user?.uid) return;
       try {
         await getIdToken(true);
-        const profile = await loadUserProfile(user.uid);
+        const profile = await handlePostSubscription(user.uid);
         if (!mounted) return;
         if (profile) {
-          setProfile(profile as any);
           if (profile.isSubscribed === true) {
             Alert.alert('Upgrade Complete', 'Welcome to OneVine+!');
             navigation.replace('MainTabs', { screen: SCREENS.MAIN.CHALLENGE });
@@ -58,7 +56,7 @@ export default function StripeSuccessScreen() {
     return () => {
       mounted = false;
     };
-  }, [user?.uid, navigation, setProfile]);
+  }, [user?.uid, navigation]);
 
   const styles = React.useMemo(
     () =>

--- a/App/utils/profileRefresh.ts
+++ b/App/utils/profileRefresh.ts
@@ -1,0 +1,13 @@
+import { loadFreshUserProfile } from './userProfile';
+import { useUserProfileStore } from '@/state/userProfile';
+import type { UserProfile } from '../../types';
+
+export async function handlePostSubscription(uid: string): Promise<UserProfile | null> {
+  console.log('🌱 Starting post-subscription refresh flow...');
+  const updatedProfile = await loadFreshUserProfile(uid);
+  if (updatedProfile) {
+    useUserProfileStore.getState().setUserProfile(updatedProfile as any);
+    console.log('✅ Updated user profile with post-subscription status');
+  }
+  return updatedProfile;
+}

--- a/functions/cleanLegacySubscriptionFields.ts
+++ b/functions/cleanLegacySubscriptionFields.ts
@@ -1,0 +1,33 @@
+import * as functions from 'firebase-functions/v1';
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const firestore = admin.firestore();
+
+export const cleanLegacySubscriptionFields = functions.https.onCall(async (data, context) => {
+  const uid = data.uid;
+  if (!uid) {
+    throw new functions.https.HttpsError('invalid-argument', 'UID is required');
+  }
+
+  const subRef = firestore.doc(`subscriptions/${uid}`);
+  const subSnap = await subRef.get();
+
+  if (!subSnap.exists) {
+    console.warn(`No subscription document found for UID: ${uid}`);
+    return { cleaned: false };
+  }
+
+  const subData = subSnap.data();
+  if (subData && 'tier' in subData) {
+    await subRef.update({ tier: admin.firestore.FieldValue.delete() });
+    console.log(`🧹 Cleaned up legacy 'tier' field for UID: ${uid}`);
+    return { cleaned: true };
+  }
+
+  console.log(`✅ No legacy 'tier' field to clean for UID: ${uid}`);
+  return { cleaned: false };
+});

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -2466,3 +2466,4 @@ export const createSubscriptionSession = functions.https.onCall(
 
 export { onCompletedChallengeCreate } from './firestoreArchitecture';
 export { handleStripeWebhookV2 } from './stripeWebhooks';
+export { cleanLegacySubscriptionFields } from './cleanLegacySubscriptionFields';


### PR DESCRIPTION
## Summary
- force server-side reads for profiles
- expose helper to refresh profile after purchase
- add callable function to clear legacy subscription tier

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689419bf48b483308ffcea5838b55733