### PR TITLE
Refactor subscription gating to central hook

### DIFF
--- a/App/hooks/useSubscriptionStatus.ts
+++ b/App/hooks/useSubscriptionStatus.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getDocument } from '@/services/firestoreService';
+
+export function useSubscriptionStatus(uid: string | null): {
+  isPlus: boolean;
+  loading: boolean;
+  refresh: () => Promise<void>;
+} {
+  const [isPlus, setIsPlus] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!uid) return;
+    setLoading(true);
+    try {
+      const userDoc = await getDocument(`users/${uid}`);
+      const usersIsSubscribed = userDoc?.isSubscribed;
+      console.log('SUBS ▶ REST users.isSubscribed', usersIsSubscribed, 'fallback used?', usersIsSubscribed === undefined);
+      if (typeof usersIsSubscribed === 'boolean') {
+        setIsPlus(usersIsSubscribed);
+      } else {
+        const subDoc = await getDocument(`subscriptions/${uid}`);
+        const status = subDoc?.status;
+        const active = status === 'active' || status === 'trialing';
+        setIsPlus(active);
+      }
+    } catch (err) {
+      console.warn('Failed to fetch subscription status', err);
+      setIsPlus(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [uid]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  if (!uid) {
+    return { isPlus: false, loading: false, refresh: async () => {} };
+  }
+
+  return { isPlus, loading, refresh };
+}
+

--- a/App/screens/dashboard/HomeScreen.tsx
+++ b/App/screens/dashboard/HomeScreen.tsx
@@ -5,29 +5,28 @@ import Button from '@/components/common/Button';
 import * as SecureStore from 'expo-secure-store';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
-import { getTokenCount, syncSubscriptionStatus } from "@/utils/TokenManager";
+import { getTokenCount } from "@/utils/TokenManager";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import AuthGate from '@/components/AuthGate';
 import { useAuth } from '@/hooks/useAuth';
+import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'HomeScreen'>;
 
 export default function HomeScreen({ navigation }: Props) {
   const [tokens, setTokens] = useState<number>(0);
-  const [subscribed, setSubscribed] = useState<boolean>(false);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [isOrgManager, setIsOrgManager] = useState<boolean>(false);
 
   const theme = useTheme();
   const { authReady, uid } = useAuth();
+  const { isPlus } = useSubscriptionStatus(uid);
   useEffect(() => {
     if (!authReady || !uid) return;
     const loadData = async () => {
       const t = await getTokenCount();
-      await syncSubscriptionStatus(); // updates Firestore token state
       setTokens(t);
-      setSubscribed(t >= 9999); // 9999 token cap implies OneVine+ sub
       const adminFlag = await SecureStore.getItemAsync('isAdmin');
       const managerFlag = await SecureStore.getItemAsync('isOrgManager');
       setIsAdmin(adminFlag === 'true');
@@ -89,7 +88,7 @@ export default function HomeScreen({ navigation }: Props) {
         <CustomText style={styles.subtitle}>Grow in Faith Daily</CustomText>
 
         <View style={styles.statusBox}>
-          {subscribed ? (
+          {isPlus ? (
             <CustomText style={styles.subscribed}>🌟 OneVine+ Active</CustomText>
           ) : (
             <CustomText style={styles.tokenInfo}>🎟️ Tokens: {tokens}</CustomText>

--- a/App/screens/dashboard/StripeSuccessScreen.tsx
+++ b/App/screens/dashboard/StripeSuccessScreen.tsx
@@ -10,6 +10,7 @@ import { getIdToken } from '@/utils/authUtils';
 import { useUser } from '@/hooks/useUser';
 import { SCREENS } from '@/navigation/screens';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
+import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
 
 /**
  * Screen shown after returning from Stripe's success_url.
@@ -22,11 +23,13 @@ export default function StripeSuccessScreen() {
   const { user } = useUser();
   const refreshProfile = useUserProfileStore((s) => s.refreshUserProfile);
   const [loading, setLoading] = useState(true);
+  const { refresh } = useSubscriptionStatus(user?.uid ?? null);
 
   useFocusEffect(
     React.useCallback(() => {
       refreshProfile();
-    }, [refreshProfile]),
+      refresh();
+    }, [refreshProfile, refresh]),
   );
 
   useEffect(() => {
@@ -36,6 +39,7 @@ export default function StripeSuccessScreen() {
       try {
         await getIdToken(true);
         const profile = await handlePostSubscription(user.uid);
+        await refresh();
         if (!mounted) return;
         if (profile) {
           if (profile.isSubscribed === true) {

--- a/App/screens/dashboard/SubmitProofScreen.tsx
+++ b/App/screens/dashboard/SubmitProofScreen.tsx
@@ -16,10 +16,11 @@ import { getAuthHeaders } from '@/utils/TokenManager';
 import ScreenContainer from "@/components/theme/ScreenContainer";
 import { useTheme } from "@/components/theme/theme";
 import { ensureAuth } from '@/utils/authGuard';
-import * as SecureStore from 'expo-secure-store';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
+import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function SubmitProofScreen() {
   const theme = useTheme();
@@ -54,17 +55,15 @@ export default function SubmitProofScreen() {
   const [image, setImage] = useState<any>(null);
   const [uploading, setUploading] = useState(false);
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { uid } = useAuth();
+  const { isPlus, loading } = useSubscriptionStatus(uid);
 
   useEffect(() => {
-    const checkAccess = async () => {
-      const sub = await SecureStore.getItemAsync('isSubscribed');
-      if (sub !== 'true') {
-        Alert.alert('Access Denied', 'This feature is for OneVine+ or Org Managers only.');
-        navigation.goBack();
-      }
-    };
-    checkAccess();
-  }, []);
+    if (!loading && !isPlus) {
+      Alert.alert('Access Denied', 'This feature is for OneVine+ or Org Managers only.');
+      navigation.goBack();
+    }
+  }, [loading, isPlus, navigation]);
 
   const pickImage = async () => {
     const result = await ImagePicker.launchImageLibraryAsync({

--- a/App/screens/profile/OrganizationManagementScreen.tsx
+++ b/App/screens/profile/OrganizationManagementScreen.tsx
@@ -20,6 +20,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/RootStackParamList';
 import AuthGate from '@/components/AuthGate';
 import { useAuth } from '@/hooks/useAuth';
+import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
 
 export default function OrganizationManagementScreen() {
   const theme = useTheme();
@@ -71,18 +72,18 @@ export default function OrganizationManagementScreen() {
   const [org, setOrg] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-
+  const { isPlus, loading: subLoading } = useSubscriptionStatus(uid);
   useEffect(() => {
     const checkAccess = async () => {
       const admin = await SecureStore.getItemAsync('isAdmin');
       const manager = await SecureStore.getItemAsync('isOrgManager');
-      if (admin !== 'true' && manager !== 'true') {
+      if (!subLoading && !isPlus && admin !== 'true' && manager !== 'true') {
         Alert.alert('Access Denied', 'This feature is for OneVine+ or Org Managers only.');
         navigation.goBack();
       }
     };
     checkAccess();
-  }, []);
+  }, [isPlus, subLoading, navigation]);
 
   useEffect(() => {
     if (!authReady || !uid) return;

--- a/App/services/chatHistoryService.ts
+++ b/App/services/chatHistoryService.ts
@@ -16,8 +16,18 @@ export interface ChatMessage {
 export async function isSubscribed(uid: string): Promise<boolean> {
   const storedUid = await ensureAuth(uid);
   if (!storedUid) return false;
+  const userDoc = await getDocument(`users/${storedUid}`);
+  const usersIsSubscribed = userDoc?.isSubscribed;
+  console.log(
+    'SUBS ▶ REST users.isSubscribed',
+    usersIsSubscribed,
+    'fallback used?',
+    usersIsSubscribed === undefined,
+  );
+  if (typeof usersIsSubscribed === 'boolean') return usersIsSubscribed;
   const subDoc = await getDocument(`subscriptions/${storedUid}`);
-  return subDoc?.active === true;
+  const status = subDoc?.status;
+  return status === 'active' || status === 'trialing';
 }
 
 // Alias used by various screens

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -56,11 +56,29 @@ export const useFreeAsk = async () => {
 export const syncSubscriptionStatus = async () => {
   const uid = await ensureAuth();
   if (!uid) return;
-  const sub = await getDocument(`subscriptions/${uid}`);
-  const isSubscribed = !!sub && sub.active === true;
-  console.log('💎 OneVine+ Status:', isSubscribed);
-  if (isSubscribed) {
-    await updateUserProfile({ tokens: 9999 }, uid);
+  try {
+    const userDoc = await getDocument(`users/${uid}`);
+    const usersIsSubscribed = userDoc?.isSubscribed;
+    console.log(
+      'SUBS ▶ REST users.isSubscribed',
+      usersIsSubscribed,
+      'fallback used?',
+      usersIsSubscribed === undefined,
+    );
+    let isSubscribed: boolean;
+    if (typeof usersIsSubscribed === 'boolean') {
+      isSubscribed = usersIsSubscribed;
+    } else {
+      const subDoc = await getDocument(`subscriptions/${uid}`);
+      const status = subDoc?.status;
+      isSubscribed = status === 'active' || status === 'trialing';
+    }
+    console.log('💎 OneVine+ Status:', isSubscribed);
+    if (isSubscribed) {
+      await updateUserProfile({ tokens: 9999 }, uid);
+    }
+  } catch (err) {
+    console.error('❌ Subscription sync failed:', err);
   }
 };
 

--- a/App/utils/userProfile.ts
+++ b/App/utils/userProfile.ts
@@ -92,28 +92,11 @@ export async function loadUserProfile(
       religionData = await getReligionProfile(user.religion);
     }
 
-    // Fetch subscription status separately. Missing docs should not throw.
-    let isSubscribed = false;
-    try {
-      const subUrl = `${FIRESTORE_BASE}/subscriptions/${userId}`;
-      const subRes = await apiClient.get(subUrl, requestOptions as any);
-      const subDoc = fromFirestore(subRes.data);
-      isSubscribed = subDoc?.active === true;
-    } catch (subErr: any) {
-      if (subErr?.response?.status === 404) {
-        console.warn(
-          `\u26A0\uFE0F Subscription document missing for uid: ${userId}, defaulting to isSubscribed: false`,
-        );
-      } else {
-        logFirestoreError('GET', `subscriptions/${userId}`, subErr);
-      }
-    }
-
     cachedProfile = {
       uid: userId,
       ...user,
       religionData,
-      isSubscribed,
+      isSubscribed: user?.isSubscribed ?? false,
     } as CachedProfile;
     if (user.profileSchemaVersion && user.profileSchemaVersion !== CURRENT_PROFILE_SCHEMA) {
       console.warn(
@@ -160,6 +143,8 @@ export async function fetchProfileWithCounts(uid?: string): Promise<(UserProfile
     return { ...profile, counts: {} };
   }
 }
+
+export const isUserPlus = (profile?: UserProfile | null) => !!profile?.isSubscribed;
 
 export async function updateUserProfile(
   fields: Record<string, any>,


### PR DESCRIPTION
## Summary
- add `useSubscriptionStatus` hook to read subscription status via REST
- replace old subscription checks with hook usage across app
- update services to fall back from `users/{uid}.isSubscribed` to `subscriptions/{uid}.status`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c704f9e48330b85ece7cefd4efbf