### PR TITLE
feat: allow unauthenticated signup via optional auth middleware

### DIFF
--- a/functions/helpers.ts
+++ b/functions/helpers.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 import { Request, Response } from 'express';
 import { auth, db } from './firebase';
 
-const corsHandler = cors({ origin: true });
+const corsHandler = cors({ origin: true, credentials: true });
 
 export function withCors(handler: (req: Request, res: Response) => void): (req: Request, res: Response) => void {
   return (req, res) => corsHandler(req, res, () => handler(req, res));

--- a/functions/middleware/optionalAuth.ts
+++ b/functions/middleware/optionalAuth.ts
@@ -1,0 +1,15 @@
+import * as admin from 'firebase-admin';
+import { Request, Response, NextFunction } from 'express';
+
+export async function optionalAuth(req: Request & { user?: admin.auth.DecodedIdToken }, res: Response, next: NextFunction) {
+  try {
+    const hdr = req.headers.authorization || '';
+    const m = hdr.match(/^Bearer (.+)$/i);
+    if (m) {
+      req.user = await admin.auth().verifyIdToken(m[1]);
+    }
+  } catch {
+    // ignore decode errors, proceed unauthenticated
+  }
+  next();
+}


### PR DESCRIPTION
## Summary
- add optionalAuth middleware for decoding ID token when present
- expose RESTful `postSignup` endpoint with optional auth and safe user defaults
- replace callable profile update with HTTP `updateUserProfile`
- relax CORS to allow credentials and update README examples

## Testing
- `npm --prefix functions run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a85a9f19c8330927229ceb8000b69