### PR TITLE
chore: add firebase key fallback and bump version

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,12 @@ import Constants from 'expo-constants';
 import { useTheme } from './App/components/theme/theme';
 import { FIREBASE_WEB_API_KEY } from './App/config/env';
 
-console.log('[env] FIREBASE_WEB_API_KEY present:', Boolean(FIREBASE_WEB_API_KEY));
+console.log(
+  '[env] key present?',
+  Boolean(FIREBASE_WEB_API_KEY),
+  '| head:',
+  (FIREBASE_WEB_API_KEY || '').slice(0, 6),
+);
 
 const dsn = process.env.SENTRY_DSN || process.env.EXPO_PUBLIC_SENTRY_DSN;
 if (!dsn || dsn.includes('your-key')) {

--- a/App/config/env.ts
+++ b/App/config/env.ts
@@ -1,12 +1,16 @@
 import Constants from 'expo-constants';
 
-export const FIREBASE_WEB_API_KEY =
-  process.env.EXPO_PUBLIC_FIREBASE_WEB_API_KEY ?? '';
+const webFromSecret = process.env.EXPO_PUBLIC_FIREBASE_WEB_API_KEY ?? '';
+const webFromPlain  = process.env.EXPO_PUBLIC_FIREBASE_API_KEY ?? '';
+
+export const FIREBASE_WEB_API_KEY = (webFromSecret || webFromPlain).trim();
+
 export const FIREBASE_PROJECT_ID =
-  process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID ?? '';
+  (process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID ?? '').trim();
+
 if (!FIREBASE_WEB_API_KEY) {
   console.warn(
-    '[env] Missing EXPO_PUBLIC_FIREBASE_WEB_API_KEY; Firebase Auth REST calls will fail',
+    '[env] Missing EXPO_PUBLIC_FIREBASE_WEB_API_KEY/EXPO_PUBLIC_FIREBASE_API_KEY',
   );
 }
 

--- a/app.config.js
+++ b/app.config.js
@@ -5,7 +5,7 @@ export default ({ config }) => ({
   name: 'OneVine',
   slug: 'onevine-app',
   scheme: 'onevine',
-  version: '1.0.0',
+  version: '1.0.1',
   icon: './assets/icon.png',
   runtimeVersion: '1.0.0',
   plugins: [
@@ -25,6 +25,7 @@ export default ({ config }) => ({
   android: {
     package: 'com.whippybuckle.onevineapp',
     permissions: ['INTERNET'],
+    versionCode: 2,
   },
   extra: {
     eas: {


### PR DESCRIPTION
## Summary
- support fallback firebase web api key from public env vars and log head on startup
- use firebase web api key for auth REST requests
- bump app version and android version code for new binary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1634f1008330a54371815e126a62