### PR TITLE
refactor: wrap religion fetch with firestore rest helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 
 # Node modules and build artifacts
 node_modules/
+
+# Keep helper source in version control
+!functions/lib/
+!functions/lib/**/*.ts
 .expo/
 dist/
 build/

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-lib/
 *.local


### PR DESCRIPTION
## Summary
- add backwards-compatible religion wrapper that delegates to new Firestore REST helper
- ensure functions/lib TypeScript helpers are tracked by updating ignore rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d04f5f3848330b02ff1b66e71dc4b