### PR TITLE
feat: add Firestore REST helper for religions

### DIFF
--- a/App/hooks/useLookupLists.ts
+++ b/App/hooks/useLookupLists.ts
@@ -1,20 +1,13 @@
 import { useEffect, useState } from 'react';
 import { fetchRegionList, RegionItem } from '../../regionRest';
-import { getReligions, ReligionItem } from '../../firebase/religion';
+import { listReligions, Religion } from '../../functions/lib/firestoreRest';
 
 const FALLBACK_REGION: RegionItem = { id: 'unknown', name: 'Unknown' };
-const FALLBACK_RELIGION: ReligionItem = {
-  id: 'spiritual',
-  name: 'Spiritual Guide',
-  aiVoice: '',
-  defaultChallenges: [],
-  totalPoints: 0,
-  language: '',
-};
+const FALLBACK_RELIGION: Religion = { id: 'spiritual', name: 'Spiritual' };
 
 export function useLookupLists() {
   const [regions, setRegions] = useState<RegionItem[]>([]);
-  const [religions, setReligions] = useState<ReligionItem[]>([]);
+  const [religions, setReligions] = useState<Religion[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -24,7 +17,7 @@ export function useLookupLists() {
       try {
         const [rgns, rels] = await Promise.all([
           fetchRegionList(),
-          getReligions(),
+          listReligions(),
         ]);
         if (!isMounted) return;
         console.log('📖 Fetched regions', rgns);

--- a/config/env.ts
+++ b/config/env.ts
@@ -1,0 +1,6 @@
+export const ENV = {
+  FIREBASE_PROJECT_ID: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID!,
+  FIREBASE_WEB_API_KEY: process.env.EXPO_PUBLIC_FIREBASE_WEB_API_KEY!,
+} as const;
+
+export default ENV;

--- a/firebase/religion.ts
+++ b/firebase/religion.ts
@@ -1,5 +1,5 @@
 // firebase/religion.ts
-// Backwards-compatible wrapper over the unified Firestore REST helper.
+// Backwards-compatible wrapper over unified Firestore REST helper.
 // Keeps existing imports working while routing through listReligions().
 
 import { listReligions } from '../functions/lib/firestoreRest';
@@ -16,19 +16,11 @@ export interface ReligionItem {
 
 let religionsCache: ReligionItem[] = [];
 
-/**
- * getReligions(forceRefresh?)
- * - Preserves the previous API so existing screens/components don't break.
- * - Delegates to listReligions() under the hood.
- * - Provides the same fallback behavior you relied on before.
- */
 export async function getReligions(forceRefresh = false): Promise<ReligionItem[]> {
   if (!forceRefresh && religionsCache.length) return religionsCache;
 
   try {
     const rows = await listReligions();
-
-    // Map to the legacy shape
     const mapped: ReligionItem[] = rows.map(r => ({
       id: r.id,
       name: r.name,
@@ -45,7 +37,7 @@ export async function getReligions(forceRefresh = false): Promise<ReligionItem[]
 
     if (__DEV__) console.debug('[religion] wrapper loaded', religionsCache.length);
     return religionsCache;
-  } catch (e) {
+  } catch {
     console.warn('[religion] wrapper failed, using fallback');
     return [{ id: 'spiritual', name: 'Spiritual', defaultChallenges: [] }];
   }

--- a/functions/lib/firestoreRest.ts
+++ b/functions/lib/firestoreRest.ts
@@ -1,0 +1,107 @@
+import { ENV } from '../../config/env';
+
+const BASE_URL = `https://firestore.googleapis.com/v1/projects/${ENV.FIREBASE_PROJECT_ID}/databases/(default)/documents`;
+
+function parseValue(value: any): any {
+  if (!value) return undefined;
+  if ('stringValue' in value) return value.stringValue;
+  if ('integerValue' in value) return Number(value.integerValue);
+  if ('doubleValue' in value) return Number(value.doubleValue);
+  if ('booleanValue' in value) return value.booleanValue;
+  if ('timestampValue' in value) return new Date(value.timestampValue).toISOString();
+  if ('nullValue' in value) return null;
+  if ('arrayValue' in value) {
+    const vals = value.arrayValue?.values || [];
+    return vals.map((v: any) => parseValue(v));
+  }
+  if ('mapValue' in value) {
+    const obj: any = {};
+    const fields = value.mapValue?.fields || {};
+    for (const [k, v] of Object.entries(fields)) {
+      obj[k] = parseValue(v);
+    }
+    return obj;
+  }
+  return undefined;
+}
+
+export function mapFirestoreDocToPlain<T = any>(doc: any): { id: string } & T {
+  const out: any = { id: doc.name?.split('/').pop() || '' };
+  const fields = doc.fields || {};
+  for (const [k, v] of Object.entries(fields)) {
+    const parsed = parseValue(v);
+    if (parsed !== undefined) out[k] = parsed;
+  }
+  return out as { id: string } & T;
+}
+
+export async function getDocuments<T = any>(
+  collectionPath: string,
+  opts?: {
+    pageSize?: number;
+    orderBy?: string[];
+    idToken?: string;
+  }
+): Promise<Array<{ id: string } & T>> {
+  const { pageSize, orderBy = [], idToken } = opts || {};
+  const url = new URL(`${BASE_URL}/${collectionPath}`);
+  if (pageSize) url.searchParams.set('pageSize', String(pageSize));
+  orderBy.forEach((o) => url.searchParams.append('orderBy', o));
+  if (idToken) {
+    // no API key when authenticated
+  } else {
+    url.searchParams.set('key', ENV.FIREBASE_WEB_API_KEY);
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: idToken ? { Authorization: `Bearer ${idToken}` } : undefined,
+  });
+  if (!res.ok) {
+    const error: any = new Error(`Request failed with status ${res.status}`);
+    error.status = res.status;
+    try {
+      const body = await res.json();
+      error.code = body.error?.status;
+    } catch {}
+    throw error;
+  }
+  const data = await res.json();
+  const docs = Array.isArray(data.documents) ? data.documents : [];
+  return docs.map((d: any) => mapFirestoreDocToPlain<T>(d));
+}
+
+export type Religion = {
+  id: string;
+  name: string;
+  prompt?: string;
+  aiVoice?: string;
+  defaultChallenges?: string[];
+  language?: string;
+  totalPoints?: number;
+  userCount?: number;
+  active?: boolean;
+  order?: number;
+};
+
+export async function listReligions(params?: {
+  includeInactive?: boolean;
+  idToken?: string;
+}): Promise<Religion[]> {
+  const { includeInactive = false, idToken } = params || {};
+  try {
+    const docs = await getDocuments<Omit<Religion, 'id'>>('religion', {
+      orderBy: ['order', 'name'],
+      idToken,
+    });
+    const rows = docs
+      .filter((r) => typeof r.name === 'string' && r.name.trim())
+      .filter((r) => includeInactive || r.active !== false) as Religion[];
+    if (__DEV__) console.debug('[religion] loaded', rows.length);
+    return rows;
+  } catch (err: any) {
+    const status = err?.status;
+    const code = err?.code;
+    console.warn('[religion] fetch failed', { status, code });
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add generic Firestore REST helper and typed `listReligions`
- wrap legacy `firebase/religion.ts` around new helper
- load religions dynamically in onboarding and lookup lists with fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2b9949088330897673a63d406d81