### PR TITLE
refactor: use client Firestore REST helper in app

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -25,7 +25,7 @@ import { ASK_GEMINI_SIMPLE } from '@/utils/constants';
 import { ensureAuth } from '@/utils/authGuard';
 import { getToken, getCurrentUserId } from '@/utils/TokenManager';
 import { sendGeminiPrompt } from '@/services/geminiService';
-import { getReligionById } from '../../functions/lib/firestoreRest';
+import { getReligionById } from '@/lib/firestoreRest';
 import { useAuth } from '@/hooks/useAuth';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -43,7 +43,7 @@ import {
 } from '@/services/chatHistoryService';
 import { useSubscriptionStatus } from '@/hooks/useSubscriptionStatus';
 import { showInterstitialAd } from '@/services/adService';
-import { getReligionById } from '../../functions/lib/firestoreRest';
+import { getReligionById } from '@/lib/firestoreRest';
 
 export default function ReligionAIScreen() {
   const theme = useTheme();

--- a/App/screens/auth/ProfileCompletionScreen.tsx
+++ b/App/screens/auth/ProfileCompletionScreen.tsx
@@ -14,7 +14,7 @@ import { Picker } from '@react-native-picker/picker';
 import { useLookupLists } from '@/hooks/useLookupLists';
 import { getDocument, updateDocument } from '@/services/firestoreService';
 import { updateUserProfile, loadUserProfile } from '@/utils/userProfile';
-import { listReligions, Religion } from '../../../functions/lib/firestoreRest';
+import { listReligions, Religion } from '@/lib/firestoreRest';
 import { useUserProfileStore } from '@/state/userProfile';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -16,7 +16,7 @@ import { loadUserProfile, updateUserProfile } from '@/utils/userProfile';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { ensureAuth } from '@/utils/authGuard';
-import { listReligions, Religion } from '../../../functions/lib/firestoreRest';
+import { listReligions, Religion } from '@/lib/firestoreRest';
 
 const FALLBACK_RELIGIONS: Religion[] = [{ id: 'spiritual', name: 'Spiritual' }];
 

--- a/App/screens/dashboard/ChallengeScreen.tsx
+++ b/App/screens/dashboard/ChallengeScreen.tsx
@@ -26,7 +26,7 @@ import { createMultiDayChallenge, completeChallengeDay } from '@/services/functi
 import { ensureAuth } from '@/utils/authGuard';
 import { getCurrentUserId, getTokenCount, getToken, setTokenCount } from '@/utils/TokenManager';
 import { useAuth } from '@/hooks/useAuth';
-import { getReligionById } from '../../../functions/lib/firestoreRest';
+import { getReligionById } from '@/lib/firestoreRest';
 import { sendGeminiPrompt } from '@/services/geminiService';
 import AuthGate from '@/components/AuthGate';
 import { UserProfile } from '../../../types';

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -14,7 +14,7 @@ import {
   updateUserProfile,
   setCachedUserProfile,
 } from '@/utils/userProfile';
-import { listReligions, Religion } from '../../../functions/lib/firestoreRest';
+import { listReligions, Religion } from '@/lib/firestoreRest';
 import type { UserProfile } from '../../../types';
 import { getDocument } from '@/services/firestoreService';
 import { useTheme } from '@/components/theme/theme';

--- a/App/utils/userProfile.ts
+++ b/App/utils/userProfile.ts
@@ -4,7 +4,7 @@ import { getAuthHeaders, getCurrentUserId } from '@/utils/authUtils';
 // API_URL no longer needed for direct Firestore PATCH
 import { logFirestoreError } from '@/lib/logging';
 import type { CachedProfile, ReligionDocument, UserProfile } from '../../types/profile';
-import { getReligionById } from '../../functions/lib/firestoreRest';
+import { getReligionById } from '@/lib/firestoreRest';
 
 export const CURRENT_PROFILE_SCHEMA = 1;
 


### PR DESCRIPTION
## Summary
- use client Firestore REST helper via `@/lib/firestoreRest`
- keep Firestore REST helper exports for listing and fetching religions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d467b15bc8330ae568370dfb7391c