### PR TITLE
feat: improve religion helper and screens

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -20,7 +20,7 @@ import { showGracefulError } from '@/utils/gracefulError';
 import axios from 'axios';
 import type { GeminiMessage } from '@/services/geminiService';
 import { CONFESSIONAL_AI_URL } from '@/utils/constants';
-import { getReligionById } from '../lib/firestoreRest';
+import { getReligionById } from '@/lib/firestoreRest';
 import { useAuth } from '@/hooks/useAuth';
 import { saveTempMessage, fetchTempSession } from '@/services/confessionalSessionService';
 import { useConfessionalSession } from '@/hooks/useConfessionalSession';

--- a/App/screens/auth/SelectReligionScreen.tsx
+++ b/App/screens/auth/SelectReligionScreen.tsx
@@ -16,7 +16,8 @@ import { loadUserProfile, updateUserProfile } from '@/utils/userProfile';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/navigation/RootStackParamList";
 import { ensureAuth } from '@/utils/authGuard';
-import { listReligions, Religion } from '@/lib/firestoreRest';
+import { listReligions, Religion, __debugReligions } from '@/lib/firestoreRest';
+import { getIdToken } from '@/utils/authUtils';
 
 const FALLBACK_RELIGIONS: Religion[] = [{ id: 'spiritual', name: 'Spiritual' }];
 
@@ -63,10 +64,12 @@ export default function SelectReligionScreen({ navigation }: Props) {
     let cancelled = false;
     (async () => {
       try {
-        const rows = await listReligions();
+        const token = await (getIdToken?.() ?? Promise.resolve(null));
+        const idToken = token || undefined;
+        if (__DEV__) await __debugReligions(idToken);
+        const rows = await listReligions(idToken ? { idToken } : undefined);
         if (!cancelled) {
           setOptions(rows.length ? rows : FALLBACK_RELIGIONS);
-          if (__DEV__) console.debug('[religion] loaded', rows.length);
         }
       } catch {
         if (!cancelled) {

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -14,7 +14,8 @@ import {
   updateUserProfile,
   setCachedUserProfile,
 } from '@/utils/userProfile';
-import { listReligions, Religion } from '@/lib/firestoreRest';
+import { listReligions, Religion, __debugReligions } from '@/lib/firestoreRest';
+import { getIdToken } from '@/utils/authUtils';
 import type { UserProfile } from '../../../types';
 import { getDocument } from '@/services/firestoreService';
 import { useTheme } from '@/components/theme/theme';
@@ -106,7 +107,10 @@ export default function ProfileScreen() {
     let cancelled = false;
     (async () => {
       try {
-        const rows = await listReligions();
+        const token = await (getIdToken?.() ?? Promise.resolve(null));
+        const idToken = token || undefined;
+        if (__DEV__) await __debugReligions(idToken);
+        const rows = await listReligions(idToken ? { idToken } : undefined);
         if (!cancelled) {
           setReligions(rows.length ? rows : [{ id: 'spiritual', name: 'Spiritual' }]);
         }


### PR DESCRIPTION
## Summary
- sort religions client-side and support optional id token
- pass id token + debug dropdown fetch in onboarding/profile screens
- clean up Firestore helper imports

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689db8af15a8833086aa1c33cc2d9587