### PR TITLE
fix: support REST path join and religion dropdown

### DIFF
--- a/App/hooks/useSubscriptionStatus.ts
+++ b/App/hooks/useSubscriptionStatus.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getDocument } from '@/services/firestoreService';
+import { getDocumentByPath } from '@/services/firestoreService';
 
 export function useSubscriptionStatus(uid: string | null): {
   isPlus: boolean;
@@ -13,13 +13,13 @@ export function useSubscriptionStatus(uid: string | null): {
     if (!uid) return;
     setLoading(true);
     try {
-      const userDoc = await getDocument(`users/${uid}`);
+      const userDoc = await getDocumentByPath(`users/${uid}`);
       const usersIsSubscribed = userDoc?.isSubscribed;
       console.log('SUBS ▶ REST users.isSubscribed', usersIsSubscribed, 'fallback used?', usersIsSubscribed === undefined);
       if (typeof usersIsSubscribed === 'boolean') {
         setIsPlus(usersIsSubscribed);
       } else {
-        const subDoc = await getDocument(`subscriptions/${uid}`);
+        const subDoc = await getDocumentByPath(`subscriptions/${uid}`);
         const status = subDoc?.status;
         const active = status === 'active' || status === 'trialing';
         setIsPlus(active);

--- a/App/screens/profile/JoinOrganizationScreen.tsx
+++ b/App/screens/profile/JoinOrganizationScreen.tsx
@@ -11,7 +11,7 @@ import Button from '@/components/common/Button';
 import { useUser } from '@/hooks/useUser';
 import ScreenContainer from '@/components/theme/ScreenContainer';
 import { useTheme } from '@/components/theme/theme';
-import { queryCollection, setDocument, getDocument } from '@/services/firestoreService';
+import { queryCollection, setDocument, getDocumentByPath } from '@/services/firestoreService';
 import { loadUserProfile, updateUserProfile } from '@/utils/userProfile';
 import type { UserProfile } from '../../../types';
 import { getAuthHeaders } from '@/utils/TokenManager';
@@ -131,7 +131,7 @@ export default function JoinOrganizationScreen() {
 
       setProfile(user ? { ...user, organizationId: undefined } as any : undefined as any);
 
-      const orgData = await getDocument(`organizations/${orgId}`);
+      const orgData = await getDocumentByPath(`organizations/${orgId}`);
       const members = (orgData?.members || []).filter((m: string) => m !== uid);
       await setDocument(`organizations/${orgId}`, { members });
     } catch (err: any) {
@@ -182,7 +182,7 @@ export default function JoinOrganizationScreen() {
 
       setProfile(user ? { ...user, organizationId: org.id } as any : undefined as any);
 
-      const orgData = await getDocument(`organizations/${org.id}`);
+      const orgData = await getDocumentByPath(`organizations/${org.id}`);
       const members = orgData?.members || [];
       await setDocument(`organizations/${org.id}`, {
         members: [...members, user.uid],

--- a/App/screens/profile/OrganizationManagementScreen.tsx
+++ b/App/screens/profile/OrganizationManagementScreen.tsx
@@ -7,7 +7,7 @@ import {
   Alert,
   ActivityIndicator} from 'react-native';
 import Button from '@/components/common/Button';
-import { getDocument, setDocument } from '@/services/firestoreService';
+import { getDocumentByPath, setDocument } from '@/services/firestoreService';
 import { loadUserProfile } from '@/utils/userProfile';
 import { useUser } from '@/hooks/useUser';
 import { getAuthHeaders } from '@/utils/TokenManager';
@@ -106,7 +106,7 @@ export default function OrganizationManagementScreen() {
       const orgId = userSnap?.organizationId;
       if (!orgId) throw new Error('No organization found');
 
-      const orgSnap = await getDocument(`organizations/${orgId}`);
+      const orgSnap = await getDocumentByPath(`organizations/${orgId}`);
       setOrg({ id: orgId, ...orgSnap });
     } catch (err: any) {
       console.error('🔥 API Error:', err?.response?.data || err.message);
@@ -128,7 +128,7 @@ export default function OrganizationManagementScreen() {
     if (!authUid) return;
 
     try {
-      const orgData = await getDocument(`organizations/${org.id}`);
+      const orgData = await getDocumentByPath(`organizations/${org.id}`);
       const members = (orgData?.members || []).filter((m: string) => m !== uid);
       await setDocument(`organizations/${org.id}`, { members });
 

--- a/App/screens/profile/ProfileScreen.tsx
+++ b/App/screens/profile/ProfileScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { listReligions, Religion, __debugReligions } from '@/lib/firestoreRest';
 import { getIdToken } from '@/utils/authUtils';
 import type { UserProfile } from '../../../types';
-import { getDocument } from '@/services/firestoreService';
+import { getDocumentByPath } from '@/services/firestoreService';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
 import { useNavigation } from '@react-navigation/native';
@@ -90,7 +90,7 @@ export default function ProfileScreen() {
         if (profile.organizationName) {
           setOrganization(profile.organizationName);
         } else if (profile.organizationId) {
-          const org = await getDocument(`organizations/${profile.organizationId}`);
+          const org = await getDocumentByPath(`organizations/${profile.organizationId}`);
           setOrganization(org?.name || '');
         }
       }

--- a/App/services/chatHistoryService.ts
+++ b/App/services/chatHistoryService.ts
@@ -1,7 +1,7 @@
 import {
   addDocument,
   querySubcollection,
-  getDocument,
+  getDocumentByPath,
   deleteDocument,
 } from '@/services/firestoreService';
 import { ensureAuth } from '@/utils/authGuard';
@@ -16,7 +16,7 @@ export interface ChatMessage {
 export async function isSubscribed(uid: string): Promise<boolean> {
   const storedUid = await ensureAuth(uid);
   if (!storedUid) return false;
-  const userDoc = await getDocument(`users/${storedUid}`);
+  const userDoc = await getDocumentByPath(`users/${storedUid}`);
   const usersIsSubscribed = userDoc?.isSubscribed;
   console.log(
     'SUBS ▶ REST users.isSubscribed',
@@ -25,7 +25,7 @@ export async function isSubscribed(uid: string): Promise<boolean> {
     usersIsSubscribed === undefined,
   );
   if (typeof usersIsSubscribed === 'boolean') return usersIsSubscribed;
-  const subDoc = await getDocument(`subscriptions/${storedUid}`);
+  const subDoc = await getDocumentByPath(`subscriptions/${storedUid}`);
   const status = subDoc?.status;
   return status === 'active' || status === 'trialing';
 }

--- a/App/services/lookupService.ts
+++ b/App/services/lookupService.ts
@@ -1,23 +1,10 @@
-import { queryCollection } from '@/services/firestoreService';
+import { listCollection } from '@/services/firestoreService';
 
-export type Religion = { id: string; name: string; order?: number };
+export type Religion = { id: string; name: string };
 
 export async function fetchReligions(): Promise<Religion[]> {
-  try {
-    const docs = await queryCollection<Religion>('religions', {
-      orderByField: 'order',
-      direction: 'ASCENDING',
-      limit: 500,
-    });
-    const list = Array.isArray(docs) ? docs : [];
-    return list.sort((a, b) => {
-      const ao = a.order ?? 999999;
-      const bo = b.order ?? 999999;
-      if (ao !== bo) return ao - bo;
-      return (a.name ?? '').localeCompare(b.name ?? '');
-    });
-  } catch (err) {
-    console.warn('Failed to fetch religions', err);
-    return [];
-  }
+  const docs = await listCollection<Religion>('religions', 500);
+  return docs
+    .filter((r) => !!r?.id && !!r?.name)
+    .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
 }

--- a/App/utils/TokenManager.ts
+++ b/App/utils/TokenManager.ts
@@ -1,4 +1,4 @@
-import { getDocument, setDocument } from '@/services/firestoreService';
+import { getDocumentByPath, setDocument } from '@/services/firestoreService';
 import { updateUserProfile } from './userProfile';
 import { ensureAuth } from '@/utils/authGuard';
 
@@ -6,7 +6,7 @@ export const getTokenCount = async () => {
   const uid = await ensureAuth();
   if (!uid) return 0;
   try {
-    const snapshot = await getDocument(`users/${uid}`);
+    const snapshot = await getDocumentByPath(`users/${uid}`);
     const count = snapshot?.tokens ?? 0;
     console.log('🪙 Token count:', count);
     return count;
@@ -35,7 +35,7 @@ export const canUseFreeAsk = async () => {
   const uid = await ensureAuth();
   if (!uid) return false;
 
-  const snapshot = await getDocument(`freeAsk/${uid}`);
+  const snapshot = await getDocumentByPath(`freeAsk/${uid}`);
   if (!snapshot) return true;
   const lastUsed = snapshot.date ? new Date(snapshot.date) : null;
   if (!lastUsed) return true;
@@ -57,7 +57,7 @@ export const syncSubscriptionStatus = async () => {
   const uid = await ensureAuth();
   if (!uid) return;
   try {
-    const userDoc = await getDocument(`users/${uid}`);
+    const userDoc = await getDocumentByPath(`users/${uid}`);
     const usersIsSubscribed = userDoc?.isSubscribed;
     console.log(
       'SUBS ▶ REST users.isSubscribed',
@@ -69,7 +69,7 @@ export const syncSubscriptionStatus = async () => {
     if (typeof usersIsSubscribed === 'boolean') {
       isSubscribed = usersIsSubscribed;
     } else {
-      const subDoc = await getDocument(`subscriptions/${uid}`);
+      const subDoc = await getDocumentByPath(`subscriptions/${uid}`);
       const status = subDoc?.status;
       isSubscribed = status === 'active' || status === 'trialing';
     }

--- a/regionRest.ts
+++ b/regionRest.ts
@@ -1,4 +1,4 @@
-import { getDocument } from '@/services/firestoreService';
+import { getDocumentByPath } from '@/services/firestoreService';
 import { logFirestoreError } from './App/lib/logging';
 
 export interface RegionItem {
@@ -32,7 +32,7 @@ export async function fetchRegionList(): Promise<RegionItem[]> {
 
   try {
     const snaps = await Promise.all(
-      REGION_IDS.map((id) => getDocument(`regions/${id}`)),
+      REGION_IDS.map((id) => getDocumentByPath(`regions/${id}`)),
     );
     regionCache = snaps
       .map((data, idx) => ({ id: REGION_IDS[idx], name: data?.name || 'Unnamed' }))


### PR DESCRIPTION
## Summary
- fix Firestore REST helpers with safe path joining and auth logging
- fetch religions via REST and expose in profile completion dropdown
- log before/after counts when user profile changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e9775ffe88330bf16930b81bdc6a5