### PR TITLE
feat: add subscription PaymentSheet setup

### DIFF
--- a/functions/__tests__/prepareSubscriptionPaymentSheet.test.ts
+++ b/functions/__tests__/prepareSubscriptionPaymentSheet.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="jest" />
+
+process.env.STRIPE_SECRET_KEY = 'sk_test';
+process.env.STRIPE_PUBLISHABLE_KEY = 'pk_test';
+
+const mockStripe = {
+  ephemeralKeys: { create: jest.fn().mockResolvedValue({ secret: 'ephkey' }) },
+  setupIntents: { create: jest.fn().mockResolvedValue({ client_secret: 'seti_secret' }) },
+  customers: { create: jest.fn().mockResolvedValue({ id: 'cus_123' }) },
+};
+
+jest.mock('stripe', () => {
+  return jest.fn(() => mockStripe);
+});
+
+jest.mock('firebase-admin', () => {
+  return {
+    firestore: () => ({
+      collection: () => ({
+        doc: () => ({
+          get: jest.fn().mockResolvedValue({ exists: false }),
+          set: jest.fn(),
+        }),
+      }),
+    }),
+    auth: () => ({}),
+    apps: [],
+    initializeApp: jest.fn(),
+  } as any;
+});
+
+import { prepareSubscriptionPaymentSheetHandler } from '../index';
+
+describe('prepareSubscriptionPaymentSheet', () => {
+  it('returns all required keys', async () => {
+    const req: any = { method: 'POST', headers: { uid: 'user123', origin: 'http://localhost' } };
+    const res: any = {
+      statusCode: 0,
+      body: undefined,
+      headers: {} as Record<string, string>,
+      setHeader(key: string, value: string) {
+        this.headers[key] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(obj: any) {
+        this.body = obj;
+      },
+    };
+
+    await prepareSubscriptionPaymentSheetHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.customer).toBe('cus_123');
+    expect(res.body.ephemeralKey).toBe('ephkey');
+    expect(res.body.setupIntent).toBe('seti_secret');
+    expect(res.body.publishableKey).toBe('pk_test');
+  });
+});

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -13,5 +13,5 @@
     "types": ["node"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["lib", "dist", "node_modules"]
+  "exclude": ["lib", "dist", "node_modules", "__tests__"]
 }


### PR DESCRIPTION
## Summary
- add getOrCreateStripeCustomer helper
- implement prepareSubscriptionPaymentSheet endpoint and tests
- wire Upgrade flow to new setup intent API

## Testing
- `npm --prefix functions run build`
- `npx jest -c functions/jest.config.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6fc953388330a221031369f83224