### PR TITLE
Lazily load Stripe env vars with Firebase Secrets

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "firebase-admin": "^11.10.1",
-        "firebase-functions": "^3.22.0",
+        "firebase-functions": "^4.9.0",
         "stripe": "^18.3.0"
       },
       "devDependencies": {
@@ -3791,26 +3791,25 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
-      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.9.0.tgz",
+      "integrity": "sha512-IqxOEsVAWGcRv9KRGzWQR5mOFuNsil3vsfkRPPiaV1U/ATC27/jbahh4z8I4rW8Xqa6cQE5xqnw0ueyMH7i7Ag==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "lodash": "^4.17.14",
-        "node-fetch": "^2.6.7"
+        "protobufjs": "^7.2.2"
       },
       "bin": {
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
       }
     },
     "node_modules/firebase-functions/node_modules/@types/express": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,20 +18,20 @@
   "dependencies": {
     "@google-cloud/secret-manager": "^4.0.0",
     "@google/generative-ai": "^0.24.1",
+    "axios": "^1.9.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "firebase-admin": "^11.10.1",
-    "firebase-functions": "^3.22.0",
-    "stripe": "^18.3.0",
-    "axios": "^1.9.0"
+    "firebase-functions": "^4.9.0",
+    "stripe": "^18.3.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.4",
-    "rimraf": "^6.0.1",
-    "typescript": "^5.8.3",
+    "concurrently": "^8",
     "jest": "^30.0.4",
+    "rimraf": "^6.0.1",
     "tsc-alias": "^1.8.8",
-    "concurrently": "^8"
+    "typescript": "^5.8.3"
   },
   "private": true
 }

--- a/functions/src/core/env.ts
+++ b/functions/src/core/env.ts
@@ -1,53 +1,26 @@
 /**
- * Central environment variable accessor. Provides required/optional vars with
- * defaults and a consistent getter used throughout the codebase.
+ * Lightweight environment accessor that defers validation until runtime.
+ * Use `env.get` for optional vars and `env.require` inside handlers when a
+ * variable must be present.
  */
 
-function required(name: string): string {
-  const val = process.env[name];
-  if (!val) {
-    throw new Error(`Missing env var ${name}`);
+function get(name: string, fallback?: string): string {
+  const v = process.env[name];
+  return v === undefined || v === null || v === '' ? (fallback ?? '') : v;
+}
+
+function requireVar(name: string): string {
+  const v = get(name);
+  if (!v) {
+    throw new Error(`Missing required env: ${name}`);
   }
-  return val;
+  return v;
 }
 
-const APP_BASE_URL =
-  process.env.APP_BASE_URL ||
-  process.env.FRONTEND_URL ||
-  'https://onevine.app';
-
-interface EnvVars {
-  APP_BASE_URL: string;
-  FRONTEND_URL?: string;
-  STRIPE_SECRET_KEY: string;
-  STRIPE_PUBLISHABLE_KEY: string;
-  STRIPE_SUB_PRICE_ID: string;
-  STRIPE_SUCCESS_URL: string;
-  STRIPE_CANCEL_URL: string;
-  STRIPE_20_TOKEN_PRICE_ID?: string;
-  STRIPE_50_TOKEN_PRICE_ID?: string;
-  STRIPE_100_TOKEN_PRICE_ID?: string;
-}
-
-export const env: EnvVars = {
-  APP_BASE_URL,
-  FRONTEND_URL: process.env.FRONTEND_URL,
-  STRIPE_SECRET_KEY: required('STRIPE_SECRET_KEY'),
-  STRIPE_PUBLISHABLE_KEY: required('STRIPE_PUBLISHABLE_KEY'),
-  STRIPE_SUB_PRICE_ID: required('STRIPE_SUB_PRICE_ID'),
-  STRIPE_SUCCESS_URL:
-    process.env.STRIPE_SUCCESS_URL ||
-    `${APP_BASE_URL}/stripe-success?session_id={CHECKOUT_SESSION_ID}`,
-  STRIPE_CANCEL_URL: process.env.STRIPE_CANCEL_URL || 'https://example.com/cancel',
-  STRIPE_20_TOKEN_PRICE_ID: process.env.STRIPE_20_TOKEN_PRICE_ID,
-  STRIPE_50_TOKEN_PRICE_ID: process.env.STRIPE_50_TOKEN_PRICE_ID,
-  STRIPE_100_TOKEN_PRICE_ID: process.env.STRIPE_100_TOKEN_PRICE_ID,
+export const env = {
+  get,
+  require: requireVar,
 };
 
-export function get(name: keyof EnvVars): string {
-  const val = env[name];
-  if (!val) throw new Error(`Missing env var ${name}`);
-  return val;
-}
-
 export const projectId = process.env.GCLOUD_PROJECT || '';
+

--- a/functions/src/core/secrets.ts
+++ b/functions/src/core/secrets.ts
@@ -1,0 +1,9 @@
+import { defineSecret } from 'firebase-functions/params';
+
+export const STRIPE_SECRET_KEY = defineSecret('STRIPE_SECRET_KEY');
+export const STRIPE_PUBLISHABLE_KEY = defineSecret('STRIPE_PUBLISHABLE_KEY');
+export const STRIPE_SUB_PRICE_ID = defineSecret('STRIPE_SUB_PRICE_ID');
+export const STRIPE_20_TOKEN_PRICE_ID = defineSecret('STRIPE_20_TOKEN_PRICE_ID');
+export const STRIPE_50_TOKEN_PRICE_ID = defineSecret('STRIPE_50_TOKEN_PRICE_ID');
+export const STRIPE_100_TOKEN_PRICE_ID = defineSecret('STRIPE_100_TOKEN_PRICE_ID');
+


### PR DESCRIPTION
## Summary
- defer env var validation with runtime `env.get`/`env.require`
- define Stripe-related Firebase Secrets and wrap billing/webhook handlers with `runWith`
- initialize Stripe inside handlers to avoid import-time crashes

## Testing
- `npm --prefix functions run build`
- `npx --yes firebase-tools deploy --only functions` *(fails: No currently active project)*

------
https://chatgpt.com/codex/tasks/task_e_68a01847a32883309519658a83d75e43