### PR TITLE
refactor(stripe): drop v2 secret injection from v1 functions

### DIFF
--- a/functions/src/stripe/checkoutHosted.ts
+++ b/functions/src/stripe/checkoutHosted.ts
@@ -5,7 +5,6 @@ import { withCors } from '@core/http';
 import { verifyAuth } from '@core/helpers';
 import {
   stripe,
-  stripeSecrets,
   cleanPriceId,
   getTokenPriceIds,
   getTokensFromPriceId,
@@ -20,9 +19,7 @@ import {
 // Subscription checkout (hosted checkout for subs)
 // -----------------------------------------------------------------------------
 
-export const startSubscriptionCheckout = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const startSubscriptionCheckout = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('📦 startSubscriptionCheckout payload', req.body);
       const { uid, priceId } = req.body || {};
@@ -68,9 +65,7 @@ export const startSubscriptionCheckout = functions
 // Token checkout (hosted)
 // -----------------------------------------------------------------------------
 
-export const startTokenCheckout = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const startTokenCheckout = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('🪙 startTokenCheckout payload', req.body);
       const { uid, priceId } = req.body || {};
@@ -122,9 +117,7 @@ export const startTokenCheckout = functions
 // Donations via Checkout
 // -----------------------------------------------------------------------------
 
-export const startDonationCheckout = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const startDonationCheckout = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('💖 startDonationCheckout payload', req.body);
       const { userId, amount } = req.body || {};
@@ -186,9 +179,7 @@ export const startDonationCheckout = functions
 // Generic startCheckoutSession (supports tokens or arbitrary price)
 // -----------------------------------------------------------------------------
 
-export const startCheckoutSession = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const startCheckoutSession = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('📦 startCheckoutSession payload', req.body);
       logger.debug('startCheckoutSession headers', req.headers);

--- a/functions/src/stripe/finalize.ts
+++ b/functions/src/stripe/finalize.ts
@@ -4,12 +4,10 @@ import * as logger from 'firebase-functions/logger';
 import { withCors } from '@core/http';
 import { verifyAuth, extractAuthToken } from '@core/helpers';
 import { db } from '@core/firebase';
-import { stripe, stripeSecrets, serverTS } from '@stripe/shared';
+import { stripe, serverTS } from '@stripe/shared';
 import { addTokens, logTokenVerificationError } from '@utils/index';
 
-export const finalizePaymentIntent = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const finalizePaymentIntent = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('finalizePaymentIntent called', { body: req.body });
 

--- a/functions/src/stripe/paymentSheetSubs.ts
+++ b/functions/src/stripe/paymentSheetSubs.ts
@@ -6,7 +6,6 @@ import { verifyAuth } from '@core/helpers';
 import { db } from '@core/firebase';
 import {
   stripe,
-  stripeSecrets,
   cleanPriceId,
   ensureStripeCustomer,
   createEphemeralKey,
@@ -15,9 +14,7 @@ import { logTokenVerificationError } from '@utils/index';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
 
-export const createStripeSubscriptionIntent = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const createStripeSubscriptionIntent = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('createStripeSubscriptionIntent payload', req.body);
       const { uid, priceId, tier = 'premium' } = req.body || {};

--- a/functions/src/stripe/paymentSheetTokens.ts
+++ b/functions/src/stripe/paymentSheetTokens.ts
@@ -6,7 +6,6 @@ import { verifyAuth } from '@core/helpers';
 import { db } from '@core/firebase';
 import {
   stripe,
-  stripeSecrets,
   cleanPriceId,
   ensureStripeCustomer,
   createEphemeralKey,
@@ -14,9 +13,7 @@ import {
 import { logTokenVerificationError } from '@utils/index';
 import * as admin from 'firebase-admin';
 
-export const createCheckoutSession = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const createCheckoutSession = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('createCheckoutSession payload', req.body);
       const { uid, priceId, tokenAmount } = req.body || {};

--- a/functions/src/stripe/setupIntent.ts
+++ b/functions/src/stripe/setupIntent.ts
@@ -6,15 +6,12 @@ import { verifyAuth, extractAuthToken } from '@core/helpers';
 import Stripe from 'stripe';
 import {
   stripe,
-  stripeSecrets,
   ensureStripeCustomer,
   createEphemeralKey,
 } from '@stripe/shared';
 import { logTokenVerificationError } from '@utils/index';
 
-export const createStripeSetupIntent = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(
+export const createStripeSetupIntent = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {
       logger.info('createStripeSetupIntent called', { body: req.body });
 

--- a/functions/src/stripe/webhooks.ts
+++ b/functions/src/stripe/webhooks.ts
@@ -2,7 +2,7 @@ import * as functions from 'firebase-functions/v1';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
 import { env } from '@core/env';
-import { stripe, stripeSecrets } from '@stripe/shared';
+import { stripe } from '@stripe/shared';
 
 const firestore = admin.firestore();
 
@@ -95,9 +95,7 @@ async function handleTokenPurchase(intent: Stripe.PaymentIntent) {
   console.log('Token handler: credited tokens', { uid, tokenAmount });
 }
 
-export const handleStripeWebhookV2 = functions
-  .runWith({ secrets: stripeSecrets })
-  .https.onRequest(async (req, res) => {
+export const handleStripeWebhookV2 = functions.https.onRequest(async (req, res) => {
     const sig = req.headers['stripe-signature'];
     if (typeof sig !== 'string') {
       console.error('Missing stripe-signature header');


### PR DESCRIPTION
## Summary
- remove `stripeSecrets` import and `.runWith({ secrets })` from Stripe HTTP handlers
- rely on existing config/env in `shared.ts`

## Testing
- `npm run build`
- `rg "runWith" -n lib/stripe`


------
https://chatgpt.com/codex/tasks/task_e_68a14fac18ec8330876159dbedb584a5