### PR TITLE
refactor: add stripe ctor shim and type imports

### DIFF
--- a/functions/src/stripe/paymentSheetSubs.ts
+++ b/functions/src/stripe/paymentSheetSubs.ts
@@ -12,7 +12,7 @@ import {
 } from '@stripe/shared';
 import { logTokenVerificationError } from '@utils/index';
 import * as admin from 'firebase-admin';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 
 export const createStripeSubscriptionIntent = functions.https.onRequest(
     withCors(async (req: Request, res: Response) => {

--- a/functions/src/stripe/setupIntent.ts
+++ b/functions/src/stripe/setupIntent.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import * as logger from 'firebase-functions/logger';
 import { withCors } from '@core/http';
 import { verifyAuth, extractAuthToken } from '@core/helpers';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 import {
   stripe,
   ensureStripeCustomer,

--- a/functions/src/stripe/shared.ts
+++ b/functions/src/stripe/shared.ts
@@ -1,5 +1,4 @@
 import * as functions from 'firebase-functions/v1';
-import Stripe from 'stripe';
 import * as admin from 'firebase-admin';
 import { auth, db } from '@core/firebase';
 import {
@@ -56,8 +55,10 @@ export function getTokensFromPriceId(
   return baseGetTokensFromPriceId(priceId, ids) as 20 | 50 | 100 | null;
 }
 
-export const stripe = new Stripe(STRIPE_SECRET, {
-  apiVersion: '2023-10-16' as any,
+const stripeModule = require('stripe');
+const StripeCtor = stripeModule?.Stripe ?? stripeModule?.default ?? stripeModule;
+export const stripe = new StripeCtor(getStripeSecret(), {
+  apiVersion: '2023-10-16',
   typescript: true,
 });
 

--- a/functions/src/stripe/webhooks.ts
+++ b/functions/src/stripe/webhooks.ts
@@ -1,6 +1,6 @@
 import * as functions from 'firebase-functions/v1';
 import * as admin from 'firebase-admin';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 import { env } from '@core/env';
 import { stripe } from '@stripe/shared';
 


### PR DESCRIPTION
## Summary
- shim stripe initialization via dynamic require to handle varying module exports
- use type-only Stripe imports across handlers

## Testing
- `npm ls stripe`
- `npm run build` *(fails: Namespace '"/workspace/wwjd-app/functions/node_modules/minimatch/dist/commonjs/index"' has no exported member 'IOptions'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a152e5a4608330836596b3c03d3cdb