### PR TITLE
feat: add token purchase metadata and toast feedback

### DIFF
--- a/App/hooks/useStripeCheckout.ts
+++ b/App/hooks/useStripeCheckout.ts
@@ -1,9 +1,9 @@
 import { useStripe } from '@stripe/stripe-react-native';
-import { Alert } from 'react-native';
+import { Alert, ToastAndroid } from 'react-native';
 import { useUserProfileStore } from '@/state/userProfile';
 import { getIdToken } from '@/utils/authUtils';
 import { ONEVINE_PLUS_PRICE_ID } from '@/config/stripeConfig';
-import { createCheckoutSession, finalizePaymentIntent } from '@/services/apiService';
+import { createCheckoutSession } from '@/services/apiService';
 import { endpoints } from '@/services/endpoints';
 
 export function useStripeCheckout() {
@@ -30,6 +30,8 @@ export function useStripeCheckout() {
         return false;
       }
 
+      const prevTokens = useUserProfileStore.getState().profile?.tokens ?? 0;
+
       const { error } = await presentPaymentSheet();
       if (error) {
         if (error.code !== 'Canceled') {
@@ -37,9 +39,20 @@ export function useStripeCheckout() {
         }
         return false;
       }
-      const paymentIntentId = clientSecret.split('_secret')[0];
-      await finalizePaymentIntent(paymentIntentId, 'payment', tokenAmount);
-      await refreshProfile();
+
+      for (let i = 0; i < 5; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await refreshProfile();
+        const currentTokens =
+          useUserProfileStore.getState().profile?.tokens ?? prevTokens;
+        if (currentTokens > prevTokens) {
+          ToastAndroid.show(
+            `✅ Purchase successful! ${tokenAmount} tokens have been added to your wallet.`,
+            ToastAndroid.LONG,
+          );
+          break;
+        }
+      }
       return true;
     } catch (err: any) {
       Alert.alert('Checkout Error', err?.message || 'Unable to start checkout');

--- a/functions/src/stripeHandlers.ts
+++ b/functions/src/stripeHandlers.ts
@@ -301,8 +301,8 @@ export const createCheckoutSession = functions
         customer: customerId,
         metadata: {
           uid,
-          purchaseType: 'token',
-          tokenAmount: String(tokenAmount),
+          purchaseType: 'tokens',
+          tokens: String(tokenAmount),
         },
         automatic_payment_methods: { enabled: true },
       });
@@ -1005,8 +1005,8 @@ export const createTokenPurchaseSheet = functions
       customer: customerId,
       metadata: {
         uid,
-        tokens: amount,
-        type: 'token',
+        purchaseType: 'tokens',
+        tokens: String(amount),
       },
       automatic_payment_methods: { enabled: true },
     });


### PR DESCRIPTION
## Summary
- include purchase metadata in token PaymentIntents
- poll Firestore after payment and toast token additions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20a98a5b48330b3aaf45690f318e9