### PR TITLE
feat: support deep link checkout and idempotent Stripe webhooks

### DIFF
--- a/App/hooks/usePaymentFlow.ts
+++ b/App/hooks/usePaymentFlow.ts
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Alert, Linking } from 'react-native';
 import { useStripe } from '@stripe/stripe-react-native';
+import { useNavigation } from '@react-navigation/native';
 import { useUserProfileStore } from '@/state/userProfile';
 import { logTransaction } from '@/utils/transactionLogger';
 import { getIdToken, getCurrentUserId } from '@/utils/authUtils';
@@ -15,11 +16,20 @@ export type PaymentFlowParams = {
 
 export function usePaymentFlow() {
   const { initPaymentSheet, presentPaymentSheet, handleURLCallback } = useStripe();
+  const navigation = useNavigation<any>();
 
   useEffect(() => {
-    const sub = Linking.addEventListener('url', (e) => handleURLCallback(e.url));
+    const sub = Linking.addEventListener('url', ({ url }) => {
+      handleURLCallback(url);
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol === 'onevine:' && parsed.hostname === 'home') {
+          navigation.reset({ index: 0, routes: [{ name: 'HomeScreen' }] });
+        }
+      } catch {}
+    });
     return () => sub.remove();
-  }, [handleURLCallback]);
+  }, [handleURLCallback, navigation]);
 
 
   // ...existing code...

--- a/App/screens/BuyTokensScreen.tsx
+++ b/App/screens/BuyTokensScreen.tsx
@@ -89,29 +89,18 @@ export default function BuyTokensScreen({ navigation }: Props) {
         return;
       }
 
-      const prevTokens =
-        useUserProfileStore.getState().profile?.tokens ?? 0;
-
       const { error } = await presentPaymentSheet();
-      if (error) {
+      if (!error) {
+        ToastAndroid.show(
+          'Tokens added to your account!',
+          ToastAndroid.SHORT,
+        );
+        await refreshProfile();
+      } else {
         if (error.code !== 'Canceled') {
           Alert.alert('Payment Error', error.message);
         }
         return;
-      }
-
-      for (let i = 0; i < 5; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        await refreshProfile();
-        const currentTokens =
-          useUserProfileStore.getState().profile?.tokens ?? prevTokens;
-        if (currentTokens > prevTokens) {
-          ToastAndroid.show(
-            `✅ Purchase successful! ${tokenAmount} tokens have been added to your wallet.`,
-            ToastAndroid.LONG,
-          );
-          break;
-        }
       }
     } catch (err: any) {
       Alert.alert('Checkout Error', err?.message || 'Unable to start checkout');

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,5 +38,5 @@ export {
 } from './stripeHandlers';
 
 export { onCompletedChallengeCreate } from './firestoreArchitecture';
-export { handleStripeWebhookV2 } from './stripeWebhooks';
+export { stripeWebhooks } from './stripeWebhooks';
 export { cleanLegacySubscriptionFields } from './cleanLegacySubscriptionFields';


### PR DESCRIPTION
## Summary
- add webhook handler with idempotency and subscription syncing
- ensure subscription checkout uses deep-link success URL and logs pending transactions
- handle `onevine://home` deep links and toast token purchase success in client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2687f92108330adfb813e243749cf