### PR TITLE
feat: add session chat buffer and save conversation option

### DIFF
--- a/App/hooks/useSessionContext.ts
+++ b/App/hooks/useSessionContext.ts
@@ -1,0 +1,15 @@
+import { useRef } from 'react';
+
+export type SessionMessage = { role: 'user'|'assistant'|'system'; content: string; ts: number };
+
+export function useSessionContext() {
+  const messagesRef = useRef<SessionMessage[]>([]);
+  return {
+    append(msg: { role: 'user'|'assistant'|'system'; content: string }) {
+      messagesRef.current.push({ ...msg, ts: Date.now() });
+    },
+    clear() { messagesRef.current = []; },
+    all() { return messagesRef.current.slice(); },
+    toPlainText() { return messagesRef.current.map(m => `${m.role.toUpperCase()}: ${m.content}`).join('\n'); }
+  };
+}


### PR DESCRIPTION
## Summary
- add hook to track chat session messages
- add SaveConversationButton component for subscribers
- log ReligionAI chats under `users/{uid}/religionChats/messages`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74ddbb1c08330b859084e8284a528