### PR TITLE
Refactor Firestore queries and update religion chat paths

### DIFF
--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -16,7 +16,7 @@ import { Screen } from "@/components/ui/Screen";
 import { useTheme } from "@/components/theme/theme";
 import { showGracefulError } from '@/utils/gracefulError';
 import * as LocalAuthentication from 'expo-local-authentication';
-import { querySubcollection, addDocument, getDocument, setDocument } from '@/services/firestoreService';
+import { runSubcollectionQuery, addDocument, getDocument, setDocument } from '@/services/firestoreService';
 
 import { loadUserProfile, incrementUserPoints, getUserAIPrompt } from '@/utils/userProfile';
 import type { UserProfile } from '../../types/profile';
@@ -187,13 +187,15 @@ export default function JournalScreen() {
     }
     if (!hasMore && !reset) return;
     setLoadingMore(true);
-    const page = await querySubcollection(
+    const page = await runSubcollectionQuery(
       `journalEntries/${storedUid}`,
       'entries',
-      'timestamp',
-      'DESCENDING',
-      20,
-      reset ? undefined : lastTimestamp || undefined,
+      {
+        orderByField: 'timestamp',
+        direction: 'DESCENDING',
+        limit: 20,
+        startAfter: reset ? undefined : lastTimestamp || undefined,
+      },
     );
     const newEntries = reset ? page : [...entries, ...page];
     setEntries(newEntries);

--- a/App/screens/ManageMemories.tsx
+++ b/App/screens/ManageMemories.tsx
@@ -5,7 +5,7 @@ import { Screen } from '@/components/ui/Screen';
 import { useTheme } from '@/components/theme/theme';
 import { ensureAuth } from '@/utils/authGuard';
 import { getCurrentUserId } from '@/utils/authUtils';
-import { querySubcollection } from '@/services/firestoreService';
+import { runSubcollectionQuery } from '@/services/firestoreService';
 import { Button } from '@/components/ui/Button';
 import { endpoints } from '@/services/endpoints';
 import { getAuthHeaders } from '@/utils/authUtils';
@@ -32,7 +32,10 @@ export default function ManageMemories() {
     (async () => {
       const uid = await ensureAuth(await getCurrentUserId());
       if (!uid) return;
-      const docs = await querySubcollection(`users/${uid}`, 'memories', 'updatedAt', 'DESCENDING');
+      const docs = await runSubcollectionQuery(`users/${uid}`, 'memories', {
+        orderByField: 'updatedAt',
+        direction: 'DESCENDING',
+      });
       setItems(docs as Memory[]);
     })();
   }, []);

--- a/App/screens/ReligionAIScreen.tsx
+++ b/App/screens/ReligionAIScreen.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Button } from '@/components/ui/Button';
-import { Screen } from "@/components/ui/Screen";
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from "@/components/theme/theme";
 import { getTokenCount, setTokenCount } from "@/utils/TokenManager";
 import { showGracefulError } from '@/utils/gracefulError';
@@ -128,9 +128,9 @@ export default function ReligionAIScreen() {
 
   async function logMessage(role: 'user' | 'assistant', content: string) {
     sessionCtx.append({ role, content });
-    const payload = { role, content, ts: Date.now() };
     if (!uid) return;
-    await createDoc(`users/${uid}/religionChats/messages`, payload);
+    const payload = { role, content, timestamp: Date.now() };
+    await createDoc(`users/${uid}/religionChats`, payload);
     try {
       await createDoc(`religionChats/${uid}/messages`, payload);
     } catch {}
@@ -342,7 +342,7 @@ export default function ReligionAIScreen() {
 
   return (
     <AuthGate>
-    <Screen>
+    <SafeAreaView style={{ flex: 1 }}>
       <KeyboardAvoidingView
         style={styles.container}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
@@ -424,7 +424,7 @@ export default function ReligionAIScreen() {
           </CustomText>
         )}
       </KeyboardAvoidingView>
-    </Screen>
+    </SafeAreaView>
     </AuthGate>
   );
 }

--- a/App/services/confessionalChatService.ts
+++ b/App/services/confessionalChatService.ts
@@ -1,4 +1,4 @@
-import { addDocument, querySubcollection } from '@/services/firestoreService';
+import { addDocument, runSubcollectionQuery } from '@/services/firestoreService';
 import { ensureAuth } from '@/utils/authGuard';
 
 export interface ConfessionalMessage {
@@ -36,11 +36,10 @@ export async function fetchConfessionalHistory(uid: string): Promise<Confessiona
   console.warn('🔥 Attempting Firestore access:', `confessionalChats/${storedUid}/messages`);
   console.warn('👤 Using UID:', storedUid);
   try {
-    return await querySubcollection(
+    return await runSubcollectionQuery(
       `confessionalChats/${storedUid}`,
       'messages',
-      'createdAt',
-      'ASCENDING',
+      { orderByField: 'createdAt', direction: 'ASCENDING' },
     );
   } catch (error: any) {
     console.warn('💬 Confessional Error', error.response?.status, error.message);

--- a/App/services/confessionalSessionService.ts
+++ b/App/services/confessionalSessionService.ts
@@ -1,6 +1,6 @@
 import {
   addDocument,
-  querySubcollection,
+  runSubcollectionQuery,
   deleteDocument,
 } from '@/services/firestoreService';
 import { ensureAuth } from '@/utils/authGuard';
@@ -40,11 +40,10 @@ export async function fetchTempSession(uid: string): Promise<TempMessage[]> {
   console.warn('🔥 Attempting Firestore access:', `tempConfessionalSessions/${storedUid}/messages`);
   console.warn('👤 Using UID:', storedUid);
   try {
-    return await querySubcollection(
+    return await runSubcollectionQuery(
       `tempConfessionalSessions/${storedUid}`,
       'messages',
-      'timestamp',
-      'ASCENDING',
+      { orderByField: 'timestamp', direction: 'ASCENDING' },
     );
   } catch (error: any) {
     console.warn('💬 Confessional Error', error.response?.status, error.message);
@@ -58,7 +57,7 @@ export async function clearConfessionalSession(uid: string): Promise<void> {
   console.warn('🔥 Attempting Firestore access:', `tempConfessionalSessions/${storedUid}/messages`);
   console.warn('👤 Using UID:', storedUid);
   try {
-    const docs = await querySubcollection(`tempConfessionalSessions/${storedUid}`, 'messages');
+    const docs = await runSubcollectionQuery(`tempConfessionalSessions/${storedUid}`, 'messages');
     for (const msg of docs) {
       await deleteDocument(`tempConfessionalSessions/${storedUid}/messages/${msg.id}`);
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -56,6 +56,11 @@ service cloud.firestore {
       match /preferences/{prefId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      // ✅ New: religion chat messages directly under the user
+      match /religionChats/{msgId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // 📊 Subcollections used for tracking


### PR DESCRIPTION
## Summary
- fix Firestore runQuery bodies by sending parent and structuredQuery separately
- store religion chat messages under `users/{uid}/religionChats` and keep legacy path
- update chat services and rules, and remove nested ScrollView warning on Religion AI screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7905e4e28833087bb8460a42c2544