### PR TITLE
feat: persist and hydrate religion chat

### DIFF
--- a/App/components/SaveConversationButton.tsx
+++ b/App/components/SaveConversationButton.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, ActivityIndicator } from 'react-native';
 import { createDoc } from '@/lib/firestoreService';
 import { getAuth } from 'firebase/auth';
 import type { SessionMessage } from '@/hooks/useSessionContext';
+import { toast } from '@/utils/toast';
 
 type Props = { disabled?: boolean; getBuffer: () => SessionMessage[]; onSaved?: (id: string) => void };
 
@@ -25,7 +26,7 @@ export default function SaveConversationButton({ disabled, getBuffer, onSaved }:
       for (let i = 0; i < msgs.length; i++) {
         await createDoc(`users/${uid}/conversations/${convoId}/messages`, msgs[i]);
       }
-
+      toast('Conversation saved ✅');
       onSaved?.(convoId);
     } finally {
       setBusy(false);

--- a/App/utils/toast.ts
+++ b/App/utils/toast.ts
@@ -11,3 +11,13 @@ export function showToast(title: string, message?: string) {
   }
 }
 
+// Tiny convenience helper used across the app
+// Shows a short toast on Android and an alert on iOS
+export function toast(msg: string) {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(msg, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('', msg);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add cross-platform toast helper
- show toast on conversation save and clearing
- pull user religion chats and hydrate session context
- tweak ReligionAI screen layout with save/clear buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b79ca5c2b48330941587c6a9221615