### PR TITLE
Fix Firestore REST runQuery 403s and simplify client headers

### DIFF
--- a/App/screens/ConfessionalScreen.tsx
+++ b/App/screens/ConfessionalScreen.tsx
@@ -25,7 +25,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { saveTempMessage, fetchTempSession } from '@/services/confessionalSessionService';
 import { useConfessionalSession } from '@/hooks/useConfessionalSession';
 import AuthGate from '@/components/AuthGate';
-import { runQueryREST, parentForUserDoc, parentFor } from '@/lib/firestoreRest';
+import { runQueryREST, parentFor } from '@/lib/firestoreRest';
 
 export default function ConfessionalScreen() {
   const theme = useTheme();
@@ -83,27 +83,23 @@ export default function ConfessionalScreen() {
   const [loading, setLoading] = useState(false);
   const { messages, setMessages, endSession } = useConfessionalSession();
 
-  // Smoke Firestore REST queries to surface 403 diagnostics
+  // Smoke Firestore REST query to surface 403 diagnostics
   React.useEffect(() => {
     if (!uid) return;
     (async () => {
+      const parent = parentFor(`tempConfessionalSessions/${uid}`);
       try {
         const rows = await runQueryREST({
-          parent: parentForUserDoc(uid),
-          structuredQuery: { from: [{ collectionId: 'religionChats' }], limit: 1 },
+          parent,
+          structuredQuery: {
+            from: [{ collectionId: 'messages' }],
+            orderBy: [{ field: { fieldPath: 'timestamp' }, direction: 'ASCENDING' }],
+            limit: 50,
+          },
         });
-        console.log('[Smoke] religionChats rows:', Array.isArray(rows) ? rows.length : 'n/a');
+        console.log('[Smoke] confessional messages rows:', Array.isArray(rows) ? rows.length : 'n/a');
       } catch (e: any) {
-        console.warn('[Smoke] religionChats error:', e?.response?.status, e?.response?.data || e?.message);
-      }
-      try {
-        const rows = await runQueryREST({
-          parent: parentFor(`journalEntries/${uid}`),
-          structuredQuery: { from: [{ collectionId: 'entries' }], limit: 1 },
-        });
-        console.log('[Smoke] journal entries rows:', Array.isArray(rows) ? rows.length : 'n/a');
-      } catch (e: any) {
-        console.warn('[Smoke] journal entries error:', e?.response?.status, e?.response?.data || e?.message);
+        console.warn('[Smoke] confessional messages error:', e?.response?.status, e?.response?.data || e?.message);
       }
     })();
   }, [uid]);

--- a/App/screens/JournalScreen.tsx
+++ b/App/screens/JournalScreen.tsx
@@ -35,28 +35,24 @@ import AuthGate from '@/components/AuthGate';
 import { Picker } from '@react-native-picker/picker';
 import { JOURNAL_STAGES, JOURNAL_PROMPTS } from '@/utils/journalStages';
 import type { JournalStage } from '@/types';
-import { runQueryREST, parentForUserDoc, parentFor } from '@/lib/firestoreRest';
+import { runQueryREST, parentFor } from '@/lib/firestoreRest';
 
 export default function JournalScreen() {
   const theme = useTheme();
   const { authReady, uid } = useAuth();
-  // Smoke Firestore REST queries to surface 403 diagnostics
+  // Smoke Firestore REST query to surface 403 diagnostics
   useEffect(() => {
     if (!uid) return;
     (async () => {
+      const parent = parentFor(`journalEntries/${uid}`);
       try {
         const rows = await runQueryREST({
-          parent: parentForUserDoc(uid),
-          structuredQuery: { from: [{ collectionId: 'religionChats' }], limit: 1 },
-        });
-        console.log('[Smoke] religionChats rows:', Array.isArray(rows) ? rows.length : 'n/a');
-      } catch (e: any) {
-        console.warn('[Smoke] religionChats error:', e?.response?.status, e?.response?.data || e?.message);
-      }
-      try {
-        const rows = await runQueryREST({
-          parent: parentFor(`journalEntries/${uid}`),
-          structuredQuery: { from: [{ collectionId: 'entries' }], limit: 1 },
+          parent,
+          structuredQuery: {
+            from: [{ collectionId: 'entries' }],
+            orderBy: [{ field: { fieldPath: 'timestamp' }, direction: 'DESCENDING' }],
+            limit: 20,
+          },
         });
         console.log('[Smoke] journal entries rows:', Array.isArray(rows) ? rows.length : 'n/a');
       } catch (e: any) {


### PR DESCRIPTION
## Summary
- replace Firestore REST client with RN-safe Axios implementation that validates ID token project, normalizes parent paths, and adds rich diagnostics
- switch ReligionAI, Journal, and Confessional screens to use helper parents with runQueryREST

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbd029041c8330a2cfcb0cf2c32dde